### PR TITLE
bump: fix the goreleaser release cycle & Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: daily

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -11,16 +11,16 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Setup go env
         uses: actions/setup-go@master
         with:
-          go-version: "1.20"
+          go-version: "1.21"
       - name: goreleaser with tag
         uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -23,4 +23,4 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,10 +1,14 @@
 project_name: harbor
 
+before:
+  hooks:
+    - go mod tidy
+
 builds:
-- main: ./cmd/harbor
-  binary: ./harbor
+- main: ./cmd/harbor/main.go
+
   env:
-    - CGO_ENABLED=0
+    - CGO_ENABLED=0 
   ldflags:
     - -w -s -X github.com/goharbor/harbor-cli/cmd/harbor/internal/version.GitCommit={{.FullCommit}}
   goos:
@@ -14,20 +18,28 @@ builds:
   goarch:
     - amd64
     - arm64
-    - arm
+    - arm  
   ignore: 
     - goos: windows
       goarch: arm
     - goos: windows
       goarch: arm64
 archives:
-- format: tar.gz
-  format_overrides:
-    - goos: windows
-      format: zip
+  - format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot: 
+  name_template: "{{ .Tag }}-next"
+
 release:
-  draft: true
-  prerelease: auto
+  name_template: "HarborCLI {{.Tag}}"
+  # draft: true
+  # prerelease: auto
 
 changelog:
   sort: asc

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/goharbor/harbor-cli
 
-go 1.20
+go 1.21
 
 require github.com/spf13/cobra v1.7.0
 


### PR DESCRIPTION
This PR fixes the [failing workflow](https://github.com/goharbor/harbor-cli/actions/runs/7905056008)

This PR suggests tagging `v0.1.0-beta.1` and proceeding with the release.

Updated goreleaser configuration, @Vad1mo . Add **GH_TOKEN** secret with `repo scope, write:packages`.
Also I included a dependabot, to automate dependency updates.

After merging, let's release the packages on Homebrew, Winget, Nix, and Snap.


