### PR TITLE
fix: empty config panic

### DIFF
--- a/pkg/utils/credential_store.go
+++ b/pkg/utils/credential_store.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/url"
 	"os"
@@ -39,11 +38,10 @@ func checkAndUpdateCredentialName(credential *Credential) {
 
 	credential.Name = parsedUrl.Hostname() + "-" + credential.Username
 	log.Println("credential name not specified, storing the credential with the name as:", credential.Name)
-	return
 }
 
 func readCredentialStore() (CredentialStore, error) {
-	configInfo, err := ioutil.ReadFile(configFile)
+	configInfo, err := os.ReadFile(configFile)
 	if err != nil {
 		return CredentialStore{}, err
 	}
@@ -100,7 +98,7 @@ func StoreCredential(credential Credential, setAsCurrentCredential bool) error {
 	if err != nil {
 		return err
 	}
-	if err = ioutil.WriteFile(configFile, bytes, 0600); err != nil {
+	if err = os.WriteFile(configFile, bytes, 0600); err != nil {
 		return err
 	}
 	log.Println("Saving credentials to:", configFile)
@@ -114,7 +112,7 @@ func StoreCredential(credential Credential, setAsCurrentCredential bool) error {
 func resolveCredential(credentialName string) (Credential, error) {
 	credentialStore, err := readCredentialStore()
 	if err != nil {
-		panic(fmt.Sprintf("failed to read credential store: %s", err))
+		return Credential{}, fmt.Errorf("failed to read credential store: %s", err)
 	}
 
 	// If credentialName is not specified, check environment variable

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/goharbor/go-client/pkg/harbor"
 	v2client "github.com/goharbor/go-client/pkg/sdk/v2.0/client"
@@ -21,7 +22,8 @@ func GetClientByConfig(clientConfig *harbor.ClientSetConfig) *v2client.HarborAPI
 func GetClientByCredentialName(credentialName string) *v2client.HarborAPI {
 	credential, err := resolveCredential(credentialName)
 	if err != nil {
-		panic(err)
+		fmt.Print(err)
+		os.Exit(1)
 	}
 	clientConfig := &harbor.ClientSetConfig{
 		URL:      credential.ServerAddress,


### PR DESCRIPTION
## Description
While login if the config read fails or the config is not found, it makes more sense to not panic but rather print a user-friendly message and exit out.

This PR also removes the deprecated use of [ioutils](https://github.com/grpc/grpc-go/pull/5906).

Fixes - #8 