### PR TITLE
feat: add insecure flag

### DIFF
--- a/cmd/harbor/root/login.go
+++ b/cmd/harbor/root/login.go
@@ -15,6 +15,7 @@ type loginOptions struct {
 	serverAddress string
 	username      string
 	password      string
+	insecure      bool
 }
 
 // LoginCommand creates a new `harbor login` command
@@ -33,8 +34,8 @@ func LoginCommand() *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.StringVarP(&opts.name, "name", "", "", "name for the set of credentials")
 
+	flags.StringVarP(&opts.name, "name", "n", "", "name for the set of credentials")
 	flags.StringVarP(&opts.username, "username", "u", "", "Username")
 	if err := cmd.MarkFlagRequired("username"); err != nil {
 		panic(err)
@@ -43,6 +44,7 @@ func LoginCommand() *cobra.Command {
 	if err := cmd.MarkFlagRequired("password"); err != nil {
 		panic(err)
 	}
+	flags.BoolVarP(&opts.insecure, "insecure", "i", false, "Allow insecure server connections when using SSL")
 
 	return cmd
 }
@@ -52,6 +54,7 @@ func runLogin(opts loginOptions) error {
 		URL:      opts.serverAddress,
 		Username: opts.username,
 		Password: opts.password,
+		Insecure: opts.insecure,
 	}
 	client := utils.GetClientByConfig(clientConfig)
 
@@ -69,7 +72,7 @@ func runLogin(opts loginOptions) error {
 	}
 
 	if err = utils.StoreCredential(cred, true); err != nil {
-		return fmt.Errorf("Failed to store the credential: %s", err)
+		return fmt.Errorf("failed to store the credential: %s", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description
Add `--insecure` flag to `login` command.

- Fixes: #9 

Note the issue mentioned an awkward login flow when URL is given without `https` the client defaults to pretending the URL with `localhost` which causes the `cli` to err.

## To consider
Other things to consider opening an issue for:
- Encrypting the password when store in `~/.harbor/config`
- Removing password as flag from `login` command and take it as input discreetly.
- Currently flag `--name` isn't doing much, use to store multiple users and then use this config to easily login for different users, fix `--name` flag iverwritting the previously stored creds.

## Current behaviour
```bash
 ./harbor login https://demo.goharbor.io -n jaeaeich -u admin -p Harbor12345 -i
```

![image](https://github.com/goharbor/harbor-cli/assets/100477031/a7e2f0cd-e74d-4c60-9c82-387cf0e00646)
![image](https://github.com/goharbor/harbor-cli/assets/100477031/847b837e-01cb-4337-92dc-c8d31be2b811)

@Vad1mo If the above mentioned issues seem reasonable maybe its worth opening issues for, do tell me so I can write further details.