### PR TITLE
feat: added unit tests for `utils` and `login`

### DIFF
--- a/cmd/harbor/root/login_test.go
+++ b/cmd/harbor/root/login_test.go
@@ -50,13 +50,13 @@ func TestLoginCommand(t *testing.T) {
 	flags.Set("username", "testuser")
 	flags.Set("password", "testpass")
 
-	assert.NotEmpty(t, cmd.Args, "serverAddress cmd argument has set")
+	assert.NotEmpty(t, cmd.Args, "serverAddress cmd argument has already set")
 	usernameFlag, err := flags.GetString("username")
 	assert.NoError(t, err, "Expected no error getting username flag")
 	assert.NotEmpty(t, usernameFlag, "Expected username flag has already set")
 	passwordFlag, err := flags.GetString("password")
 	assert.NoError(t, err, "Expected no error getting password flag")
-	assert.NotEmpty(t, passwordFlag, "Expected password flag to be set")
+	assert.NotEmpty(t, passwordFlag, "Expected password flag has already set")
 
 	// Test case 2: required flags value should not be set
 	flags.Set("username", "")

--- a/cmd/harbor/root/login_test.go
+++ b/cmd/harbor/root/login_test.go
@@ -1,0 +1,72 @@
+package root
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/goharbor/harbor-cli/pkg/views/login"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunLogin_Successful(t *testing.T) {
+	// Mock Harbor server
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v2.0/users/current", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockServer.Close()
+	opts := login.LoginView{
+		Server:   mockServer.URL,
+		Username: "testuser",
+		Password: "testpassword",
+	}
+	err := runLogin(opts)
+	assert.NoError(t, err)
+}
+
+func TestRunLogin_Failed(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v2.0/users/current", r.URL.Path)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer mockServer.Close()
+	opts := login.LoginView{
+		Server:   mockServer.URL,
+		Username: "testuser",
+		Password: "testpassword",
+	}
+	err := runLogin(opts)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "login failed")
+}
+
+func TestLoginCommand(t *testing.T) {
+	cmd := LoginCommand()
+	flags := cmd.Flags()
+
+	// Test case 1: required flags value should be set
+	cmd.SetArgs([]string{"http://testgoharbor.io"})
+	flags.Set("username", "testuser")
+	flags.Set("password", "testpass")
+
+	assert.NotEmpty(t, cmd.Args, "serverAddress cmd argument has set")
+	usernameFlag, err := flags.GetString("username")
+	assert.NoError(t, err, "Expected no error getting username flag")
+	assert.NotEmpty(t, usernameFlag, "Expected username flag has already set")
+	passwordFlag, err := flags.GetString("password")
+	assert.NoError(t, err, "Expected no error getting password flag")
+	assert.NotEmpty(t, passwordFlag, "Expected password flag to be set")
+
+	// Test case 2: required flags value should not be set
+	flags.Set("username", "")
+	flags.Set("password", "")
+	usernameFlag, _ = flags.GetString("username")
+	if usernameFlag == "" {
+		assert.Empty(t, usernameFlag, "Expected username flag has to be set")
+	}
+	passwordFlag, _ = flags.GetString("password")
+	if passwordFlag == "" {
+		assert.Empty(t, passwordFlag, "Expected password flag has to be set")
+	}
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,35 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/goharbor/go-client/pkg/harbor"
+)
+
+func TestGetClientByConfig(t *testing.T) {
+	clientConfig := &harbor.ClientSetConfig{
+		URL:      "testURL",
+		Username: "testUsername",
+		Password: "testPassword",
+	}
+	client := GetClientByConfig(clientConfig)
+	if client == nil {
+		t.Errorf("Expected client not to be nil")
+	}
+}
+
+func TestGetClientByCredentialName(t *testing.T) {
+	client := GetClientByCredentialName("127.0.0.1-testuser")
+	if client == nil {
+		t.Errorf("Expected client not to be nil")
+	}
+}
+
+func TestPrintPayloadInJSONFormat(t *testing.T) {
+	PrintPayloadInJSONFormat(nil)
+	
+	payload := map[string]interface{}{
+		"testkey": "test-value",
+	}
+	PrintPayloadInJSONFormat(payload)
+}


### PR DESCRIPTION
### Fixes parts of https://github.com/goharbor/harbor-cli/issues/23
- Added the test files for `utils.go` (78.9%) and `login.go` (60%) test coverage
- used mock server for testing purpose with `stretchr/testify` package