### PR TITLE
added the credential-name flag to the registry command

### DIFF
--- a/cmd/harbor/root/registry/cmd.go
+++ b/cmd/harbor/root/registry/cmd.go
@@ -11,6 +11,8 @@ func Registry() *cobra.Command {
 		Long:    `Manage registries in Harbor`,
 		Example: `  harbor registry list`,
 	}
+
+	cmd.PersistentFlags().StringP("credential-name", "c", "", "Credential to use of authorization")
 	cmd.AddCommand(
 		CreateRegistryCommand(),
 		DeleteRegistryCommand(),


### PR DESCRIPTION
Fixes #44 

- Added the `credential-name` flag as a persistent flag under the registry command. 
