### PR TITLE
feat: added summary, candidate, and scanner command under project command.

### DIFF
--- a/cmd/harbor/root/project/candidate.go
+++ b/cmd/harbor/root/project/candidate.go
@@ -1,0 +1,67 @@
+package project
+
+import (
+	"context"
+
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/project"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+type candidateScannerOptions struct {
+	projectNameOrId string
+	pageSize        int64
+	page            int64
+	q               string
+	sort            string
+}
+
+func GetCandidateScanner() *cobra.Command {
+	var opts candidateScannerOptions
+
+	cmd := &cobra.Command{
+		Use:   "candidate [Name|ID]",
+		Short: "Get scanner registration candidates for configuring project level scanner",
+		Long:  "Retrieve the system configured scanner registrations as candidates of setting project level scanner.",
+		Args:  cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) > 0 {
+				opts.projectNameOrId = args[0]
+			} else {
+				projectName := utils.GetProjectNameFromUser()
+				opts.projectNameOrId = projectName
+			}
+
+			response, err := runGetCandidateScanner(opts)
+			if err != nil {
+				log.Fatalf("failed to get candidate scanner: %v", err)
+			}
+			utils.PrintPayloadInJSONFormat(response)
+		},
+	}
+
+	flags := cmd.Flags()
+
+	flags.Int64VarP(&opts.pageSize, "page-size", "", 10, "Size of per page")
+	flags.Int64VarP(&opts.page, "page", "", 1, "Page number")
+	flags.StringVarP(&opts.q, "query", "q", "", "Query string to query resources")
+	flags.StringVarP(&opts.sort, "sort", "", "", "Sort the resource list in ascending or descending order. e.g. sort by field1 in ascending order and field2 in descending order with 'sort=field1,-field2'")
+
+	return cmd
+
+}
+
+func runGetCandidateScanner(opts candidateScannerOptions) (*project.ListScannerCandidatesOfProjectOK, error) {
+
+	credentialName := viper.GetString("current-credential-name")
+	client := utils.GetClientByCredentialName(credentialName)
+	ctx := context.Background()
+	response, err := client.Project.ListScannerCandidatesOfProject(ctx, &project.ListScannerCandidatesOfProjectParams{ProjectNameOrID: opts.projectNameOrId, PageSize: &opts.pageSize, Page: &opts.page, Q: &opts.q, Sort: &opts.sort})
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}

--- a/cmd/harbor/root/project/cmd.go
+++ b/cmd/harbor/root/project/cmd.go
@@ -16,7 +16,10 @@ func Project() *cobra.Command {
 		DeleteProjectCommand(),
 		ListProjectCommand(),
 		ViewCommand(),
-		LogsProjectCommmand(),
+		LogsProjectCommand(),
+		SummaryCommand(),
+		ScannerCommand(),
+		GetCandidateScanner(),
 	)
 
 	return cmd

--- a/cmd/harbor/root/project/logs.go
+++ b/cmd/harbor/root/project/logs.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-func LogsProjectCommmand() *cobra.Command {
+func LogsProjectCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "logs",
 		Short: "get project logs",

--- a/cmd/harbor/root/project/scanner.go
+++ b/cmd/harbor/root/project/scanner.go
@@ -1,0 +1,55 @@
+package project
+
+import (
+	"context"
+
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/project"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+type projectLevelScannerOptions struct {
+	projectNameOrID string
+}
+
+func ScannerCommand() *cobra.Command {
+	var opts projectLevelScannerOptions
+
+	cmd := &cobra.Command{
+		Use:   "scanner [NAME|ID]",
+		Short: "Get the scanner registration of a project.",
+		Long:  "Get the scanner registration of a project by name or id. If no scanner registration is configured for the specified project, the system default scanner registration will be returned",
+		Args:  cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) > 0 {
+				opts.projectNameOrID = args[0]
+			} else {
+				projectName := utils.GetProjectNameFromUser()
+				opts.projectNameOrID = projectName
+			}
+
+			response, err := runGetProjectScanner(opts)
+			if err != nil {
+				log.Fatalf("failed to get project scanner: %v", err)
+			}
+			utils.PrintPayloadInJSONFormat(response.GetPayload())
+
+		},
+	}
+	return cmd
+}
+
+func runGetProjectScanner(opts projectLevelScannerOptions) (*project.GetScannerOfProjectOK, error) {
+	credentialName := viper.GetString("current-credential-name")
+	client := utils.GetClientByCredentialName(credentialName)
+	ctx := context.Background()
+	response, err := client.Project.GetScannerOfProject(ctx, &project.GetScannerOfProjectParams{ProjectNameOrID: opts.projectNameOrID})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}

--- a/cmd/harbor/root/project/summary.go
+++ b/cmd/harbor/root/project/summary.go
@@ -1,0 +1,57 @@
+package project
+
+import (
+	"context"
+
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/project"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+type getProjectSummaryOptions struct {
+	projectNameOrID string
+}
+
+func SummaryCommand() *cobra.Command {
+	var opts getProjectSummaryOptions
+
+	cmd := &cobra.Command{
+		Use:   "summary [NAME|ID]",
+		Short: "Get project summary by name or id",
+		Long:  "Get project summary by name or id. If the project name or id is not provided, the command will prompt the user to enter the project name.",
+		Args:  cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+
+			if len(args) > 0 {
+				opts.projectNameOrID = args[0]
+			} else {
+				projectName := utils.GetProjectNameFromUser()
+				opts.projectNameOrID = projectName
+			}
+
+			response, err := runGetProjectSummary(opts)
+			if err != nil {
+				log.Fatalf("failed to get project summary: %v", err)
+			}
+			utils.PrintPayloadInJSONFormat(response.GetPayload())
+
+		},
+	}
+
+	return cmd
+}
+
+func runGetProjectSummary(opts getProjectSummaryOptions) (*project.GetProjectSummaryOK, error) {
+	credentialName := viper.GetString("current-credential-name")
+	client := utils.GetClientByCredentialName(credentialName)
+	ctx := context.Background()
+	response, err := client.Project.GetProjectSummary(ctx, &project.GetProjectSummaryParams{ProjectNameOrID: opts.projectNameOrID})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}


### PR DESCRIPTION
This pull request enhances the project command by introducing new commands for better project management.
@Vad1mo Sir, it would be great if you could review it.

- `summary` command helps the user to get the summary of a project using the project name or the project ID. 
```
./harbor project summary testproject1
{
  "project_admin_count": 1,
  "quota": {
    "hard": {
      "storage": -1
    },
    "used": {
      "storage": 0
    }
  },
  "repo_count": 0
}
```
- `candidate` command helps to retrieve the system configured scanner registrations as candidates of setting project level scanner.

```
./harbor project candidate testproject1
{
  "Link": "",
  "XTotalCount": 1,
  "Payload": [
    {
      "access_credential": "",
      "auth": "",
      "create_time": "2024-05-15T05:00:20.222Z",
      "description": "The Trivy scanner adapter",
      "disabled": false,
      "is_default": true,
      "name": "Trivy",
      "skip_certVerify": false,
      "update_time": "2024-05-15T05:00:20.222Z",
      "url": "http://trivy-adapter:8080",
      "use_internal_addr": true,
      "uuid": "07748217-1278-11ef-98f2-0242c0a8a009"
    }
  ]
}
```
- `scanner` command helps to get the scanner registration of the specified project.

```
./harbor project scanner testproject1
{
  "access_credential": "",
  "adapter": "Trivy",
  "auth": "",
  "create_time": "2024-05-15T05:00:20.222Z",
  "description": "The Trivy scanner adapter",
  "disabled": false,
  "health": "healthy",
  "is_default": true,
  "name": "Trivy",
  "skip_certVerify": false,
  "update_time": "2024-05-15T05:00:20.222Z",
  "url": "http://trivy-adapter:8080",
  "use_internal_addr": true,
  "uuid": "07748217-1278-11ef-98f2-0242c0a8a009",
  "vendor": "Aqua Security",
  "version": "v0.47.0"
}
```