### PR TITLE
feat: fix the create schema of project, update the project table to take Type into action

### DIFF
--- a/pkg/views/project/create/view.go
+++ b/pkg/views/project/create/view.go
@@ -1,10 +1,15 @@
 package create
 
 import (
+	"context"
 	"errors"
+	"fmt"
 
 	"github.com/charmbracelet/huh"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/registry"
+	"github.com/goharbor/harbor-cli/pkg/utils"
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 )
 
 type CreateView struct {
@@ -12,10 +17,38 @@ type CreateView struct {
 	Public       bool
 	RegistryID   string
 	StorageLimit string
+	ProxyCache   bool
+}
+
+func getRegistryList() (*registry.ListRegistriesOK, error) {
+	credentialName := viper.GetString("current-credential-name")
+	client := utils.GetClientByCredentialName(credentialName)
+	ctx := context.Background()
+	response, err := client.Registry.ListRegistries(ctx, &registry.ListRegistriesParams{})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
 }
 
 func CreateProjectView(createView *CreateView) {
 	theme := huh.ThemeCharm()
+	// I want it to be a map of registry ID to registry name
+	registries, _ := getRegistryList()
+
+	registryOptions := map[string]string{}
+	for _, registry := range registries.Payload {
+		regiId := fmt.Sprintf("%d", registry.ID)
+		registryOptions[regiId] = fmt.Sprintf("%s (%s)", registry.Name, registry.URL)
+	}
+
+	var registrySelectOptions []huh.Option[string]
+	for id, name := range registryOptions {
+		registrySelectOptions = append(registrySelectOptions, huh.NewOption(name, id))
+	}
+
 	err := huh.NewForm(
 		huh.NewGroup(
 			huh.NewInput().
@@ -33,19 +66,30 @@ func CreateProjectView(createView *CreateView) {
 				Affirmative("yes").
 				Negative("no"),
 			huh.NewInput().
-				Title("Registry ID").
-				Value(&createView.RegistryID).
-				Validate(func(str string) error {
-					// Assuming RegistryID is an int64
-					return nil
-				}),
-			huh.NewInput().
 				Title("Storage Limit").
 				Value(&createView.StorageLimit).
 				Validate(func(str string) error {
 					// Assuming StorageLimit is an int64
 					return nil
 				}),
+
+			huh.NewConfirm().
+				Title("Proxy Cache").
+				Value(&createView.ProxyCache).
+				Affirmative("yes").
+				Negative("no"),
+
+			huh.NewSelect[string]().
+				Validate(func(str string) error {
+					if createView.ProxyCache && str == "" {
+						return errors.New("registry ID cannot be empty")
+					}
+					return nil
+				}).
+				Description("Select a registry to reference when creating the proxy cache project").
+				Title("Registry ID").
+				Value(&createView.RegistryID).
+				Options(registrySelectOptions...),
 		),
 	).WithTheme(theme).Run()
 

--- a/pkg/views/project/list/view.go
+++ b/pkg/views/project/list/view.go
@@ -20,8 +20,7 @@ type model struct {
 var columns = []table.Column{
 	{Title: "Project Name", Width: 12},
 	{Title: "Access Level", Width: 12},
-	// {Title: "Role", Width: 12},
-	// {Title: "Type", Width: 12},
+	{Title: "Type", Width: 12},
 	{Title: "Repo Count", Width: 12},
 	{Title: "Creation Time", Width: 30},
 }
@@ -48,10 +47,17 @@ func ListProjects(projects []*models.Project) {
 		if project.Metadata.Public != "true" {
 			accessLevel = "private"
 		}
+
+		projectType := "project"
+
+		if project.RegistryID != 0 {
+			projectType = "proxy cache"
+		}
 		createdTime, _ := utils.FormatCreatedTime(project.CreationTime.String())
 		rows = append(rows, table.Row{
 			project.Name, // Project Name
 			accessLevel,  // Access Level
+			projectType,  // Type
 			strconv.FormatInt(project.RepoCount, 10),
 			createdTime, // Creation Time
 		})


### PR DESCRIPTION
Refine the project creation schema and update the project table to incorporate the 'Type' field.

We have integrated the proxy cache into this project schema.

![image](https://github.com/goharbor/harbor-cli/assets/136564604/feb00f16-eac3-48c7-aed3-34d96875b3a0)

![image](https://github.com/goharbor/harbor-cli/assets/136564604/18b543eb-5567-4c60-8169-6c161320ad16)
