### PR TITLE
feat: Adding docker image support with docker publish Github_action

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -2,7 +2,7 @@ name: Publishing Docker image
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "docker" ]
     paths-ignore:
       - 'README.md'
       - '**/*_test.go'
@@ -35,3 +35,4 @@ jobs:
           tags: demo.goharbor.io/library/harbor-cli:1.2.3
           push: true
           labels: ${{ steps.meta.outputs.labels }}
+

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -31,18 +31,22 @@ jobs:
         uses: sigstore/cosign-installer@v3.1.1
         
       - name: Build and push Docker image
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: ./Dockerfile
-          tags: demo.goharbor.io/library/harbor-cli:1.2.4
+          tags: demo.goharbor.io/library/harbor-cli:1.2.5
           push: true
           labels: ${{ steps.meta.outputs.labels }}
 
+      - name: Get the image digest
+        id: image_digest
+        run: |
+          echo "IMAGE_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' demo.goharbor.io/library/harbor-cli:1.2.5)" >> $GITHUB_ENV
+
       - name: Sign image with a key
         run: |
-          cosign sign --yes --key env://COSIGN_PRIVATE_KEY  demo.goharbor.io/library/harbor-cli:1.2.5
+          cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${{ env.IMAGE_DIGEST }}
         env:
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
-

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -20,23 +20,18 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
       
-      - name: Log in to Docker Hub
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+      - name: Log in to Harbor
+        uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
-        with:
-          images: goharbor/harbor-cli
+          registry: demo.goharbor.io
+          username: ${{ secrets.REGISTRY_GOHARBOR_USERNAME }}
+          password: ${{ secrets.REGISTRY_GOHARBOR_PASSWORD }}
       
       - name: Build and push Docker image
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
           context: .
           file: ./Dockerfile
-          tags: goharbor/harbor-cli:latest
+          tags: demo.goharbor.io/library/harbor-cli:1.2.3
           push: true
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -26,7 +26,10 @@ jobs:
           registry: demo.goharbor.io
           username: ${{ secrets.REGISTRY_GOHARBOR_USERNAME }}
           password: ${{ secrets.REGISTRY_GOHARBOR_PASSWORD }}
-      
+          
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.1.1
+        
       - name: Build and push Docker image
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
@@ -35,4 +38,11 @@ jobs:
           tags: demo.goharbor.io/library/harbor-cli:1.2.4
           push: true
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Sign image with a key
+        run: |
+          cosign sign --yes --key env://COSIGN_PRIVATE_KEY  demo.goharbor.io/library/harbor-cli:1.2.5
+        env:
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Log in to Harbor
         uses: docker/login-action@v3
         with:
-          registry: demo.goharbor.io
+          registry: demo.goharbor.io/library
           username: ${{ secrets.REGISTRY_GOHARBOR_USERNAME }}
           password: ${{ secrets.REGISTRY_GOHARBOR_PASSWORD }}
       
@@ -32,7 +32,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          tags: demo.goharbor.io/library/harbor-cli:1.2.3
+          tags: harbor-cli:1.2.4
           push: true
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          tags: library/harbor-cli:1.2.4
+          tags: demo.goharbor.io/library/harbor-cli:1.2.4
           push: true
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Log in to Harbor
         uses: docker/login-action@v3
         with:
-          registry: demo.goharbor.io/library
+          registry: demo.goharbor.io
           username: ${{ secrets.REGISTRY_GOHARBOR_USERNAME }}
           password: ${{ secrets.REGISTRY_GOHARBOR_PASSWORD }}
       
@@ -32,7 +32,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          tags: harbor-cli:1.2.4
+          tags: library/harbor-cli:1.2.4
           push: true
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -2,7 +2,7 @@ name: Publishing Docker image
 
 on:
   push:
-    branches: [ "docker" ]
+    branches: [ "main" ]
     paths-ignore:
       - 'README.md'
       - '**/*_test.go'
@@ -35,7 +35,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          tags: demo.goharbor.io/library/harbor-cli:1.2.5
+          tags: demo.goharbor.io/library/harbor-cli:0.0.1
           push: true
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -1,0 +1,42 @@
+name: Publishing Docker image
+
+on:
+  push:
+    branches: [ "main" ]
+    paths-ignore:
+      - 'README.md'
+      - '**/*_test.go'
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore:
+      - 'README.md'
+      - '**/*_test.go'
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+      
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: goharbor/harbor-cli
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: .
+          file: ./Dockerfile
+          tags: goharbor/harbor-cli:latest
+          push: true
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Stage 1: Build the Go binary
+FROM golang:1.21-alpine AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+
+# Download all dependencies. Dependencies will be cached if the go.mod and go.sum files are not changed
+RUN go mod download
+
+COPY . .
+
+RUN go build -o harbor ./cmd/harbor
+
+# Stage 2: Create a small image for the Go binary
+FROM alpine:latest
+
+WORKDIR /root/
+
+# Copy the Pre-built binary file from the previous stage
+COPY --from=builder /app/harbor .
+
+CMD ["./harbor"]


### PR DESCRIPTION
# Fixes ⇾ part of #7

## Previous State
- Docker building image was missing and also auto publish Docker image through GitHub_action

## Current Behavior
- [x] Added Dockerfile to build the harbor-cli image
- [x] Integrated GitHub Action to auto publish the current version of harbor image to Docker hub 

## Needs to be set

- Set the `secrets` in the repository scope using below naming convention
  - DOCKER_USERNAME
  - DOCKER_PASSWORD
- Create a separate repository in Docker Hub repository named `harbor-cli` and Docker hub account name `goharbor` (can be changed if already existing any account)
  - like this → `goharbor/harbor-cli`

To trigger the github action, just need to push any changes in main branch or any pull request 

//cc @Vad1mo @amands98