### PR TITLE
bug: `harbor project create` command fails due to unhandled error. 

### DIFF
--- a/pkg/views/project/create/view.go
+++ b/pkg/views/project/create/view.go
@@ -36,7 +36,10 @@ func getRegistryList() (*registry.ListRegistriesOK, error) {
 func CreateProjectView(createView *CreateView) {
 	theme := huh.ThemeCharm()
 	// I want it to be a map of registry ID to registry name
-	registries, _ := getRegistryList()
+	registries, err := getRegistryList()
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	registryOptions := map[string]string{}
 	for _, registry := range registries.Payload {
@@ -49,7 +52,7 @@ func CreateProjectView(createView *CreateView) {
 		registrySelectOptions = append(registrySelectOptions, huh.NewOption(name, id))
 	}
 
-	err := huh.NewForm(
+	err = huh.NewForm(
 		huh.NewGroup(
 			huh.NewInput().
 				Title("Project Name").

--- a/pkg/views/project/create/view.go
+++ b/pkg/views/project/create/view.go
@@ -81,7 +81,8 @@ func CreateProjectView(createView *CreateView) {
 				Value(&createView.ProxyCache).
 				Affirmative("yes").
 				Negative("no"),
-
+		),
+		huh.NewGroup(
 			huh.NewSelect[string]().
 				Validate(func(str string) error {
 					if createView.ProxyCache && str == "" {
@@ -93,7 +94,9 @@ func CreateProjectView(createView *CreateView) {
 				Title("Registry ID").
 				Value(&createView.RegistryID).
 				Options(registrySelectOptions...),
-		),
+		).WithHideFunc(func() bool {
+			return !createView.ProxyCache || len(registryOptions) == 0
+		}),
 	).WithTheme(theme).Run()
 
 	if err != nil {


### PR DESCRIPTION
- `harbor project create` commands due to unhandled error in the `getRegistryList`.

https://github.com/goharbor/harbor-cli/blob/381ec2dd7305dc515f290e9236d0f387e6a4470b/pkg/views/project/create/view.go#L39


```
./harbor project create
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x9b1cbd]

goroutine 1 [running]:
github.com/goharbor/harbor-cli/pkg/views/project/create.CreateProjectView(0xc000392d00)
        /home/mehul/lfx/harbor-cli/pkg/views/project/create/view.go:45 +0x9d
github.com/goharbor/harbor-cli/cmd/harbor/root/project.createProjectView(0x0?)
        /home/mehul/lfx/harbor-cli/cmd/harbor/root/project/create.go:67 +0x58
github.com/goharbor/harbor-cli/cmd/harbor/root/project.CreateProjectCommand.func1(0xc0001c8d00?, {0x10c6680?, 0x4?, 0xaf28a6?})
        /home/mehul/lfx/harbor-cli/cmd/harbor/root/project/create.go:37 +0xec
github.com/spf13/cobra.(*Command).execute(0xc0002f6f00, {0x10c6680, 0x0, 0x0})
        /home/mehul/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:987 +0xaa3
github.com/spf13/cobra.(*Command).ExecuteC(0xc0002f6300)
        /home/mehul/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x3ff
github.com/spf13/cobra.(*Command).Execute(0xc0000061a0?)
        /home/mehul/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039 +0x13
main.main()
        /home/mehul/lfx/harbor-cli/cmd/harbor/main.go:10 +0x18
```