### PR TITLE
feat: Fix Creating Project Flow

### DIFF
--- a/cmd/harbor/root/project/create.go
+++ b/cmd/harbor/root/project/create.go
@@ -12,9 +12,11 @@ func CreateProjectCommand() *cobra.Command {
 	var opts create.CreateView
 
 	cmd := &cobra.Command{
-		Use:   "create",
+		Use:   "create [project name]",
 		Short: "create project",
+		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			opts.ProjectName = args[0]
 			var err error
 			createView := &create.CreateView{
 				ProjectName:  opts.ProjectName,
@@ -40,8 +42,7 @@ func CreateProjectCommand() *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.StringVarP(&opts.ProjectName, "name", "", "", "Name of the project")
-	flags.BoolVarP(&opts.Public, "public", "", false, "Project is public or private. Private by default")
+	flags.BoolVarP(&opts.Public, "public", "", false, "Project is public or private")
 	flags.StringVarP(&opts.RegistryID, "registry-id", "", "", "ID of referenced registry when creating the proxy cache project")
 	flags.StringVarP(&opts.StorageLimit, "storage-limit", "", "-1", "Storage quota of the project")
 	flags.BoolVarP(&opts.ProxyCache, "proxy-cache", "", false, "Whether the project is a proxy cache project")


### PR DESCRIPTION
## Fixes #12 

### Description:
- Allow project name to be specified as a positional argument in the `project create` command.
- Change the default value of the `--public` flag to `false`, making projects private by default.
- Remove the `--name` flag and update the command to handle the project name from the positional argument.

### Examples:
- Create a private project by default:
  `./harbor project create bupd-test` will work

- Create a public project:
  `./harbor create project bupd-test --public` 

These changes improve user experience by simplifying command usage and enhance security by setting a private default for projects.