### PR TITLE
Added presentation formats (JSON and YAML) with some small modifications.

### DIFF
--- a/cmd/harbor/root/cmd.go
+++ b/cmd/harbor/root/cmd.go
@@ -16,7 +16,6 @@ import (
 )
 
 var (
-	output  string
 	cfgFile string
 	verbose bool
 )
@@ -92,11 +91,8 @@ harbor help
 
 	cobra.OnInitialize(initConfig)
 
-	root.PersistentFlags().StringVarP(&output, "output-format", "o", "", "Output format. One of: json|yaml")
 	root.PersistentFlags().StringVar(&cfgFile, "config", utils.DefaultConfigPath, "config file (default is $HOME/.harbor/config.yaml)")
 	root.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
-
-	viper.BindPFlag("output-format", root.PersistentFlags().Lookup("output-format"))
 
 	root.AddCommand(
 		versionCommand(),

--- a/cmd/harbor/root/registry/list.go
+++ b/cmd/harbor/root/registry/list.go
@@ -6,28 +6,33 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/views/registry/list"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // NewListRegistryCommand creates a new `harbor list registry` command
 func ListRegistryCommand() *cobra.Command {
 	var opts api.ListFlags
+	var formatFlag string
 
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "list registry",
 		Run: func(cmd *cobra.Command, args []string) {
-			registry, err := api.ListRegistries(opts)
-
+			response, err := api.ListRegistries(opts)
 			if err != nil {
 				log.Fatalf("failed to get projects list: %v", err)
 			}
-			FormatFlag := viper.GetString("output-format")
-			if FormatFlag != "" {
-				utils.PrintPayloadInJSONFormat(registry)
-				return
+
+			if formatFlag != "" {
+				if formatFlag == "json" {
+					utils.PrintPayloadInJSONFormat(response)
+				} else if formatFlag == "yaml" {
+					utils.PrintPayloadInYAMLFormat(response)
+				} else {
+					log.Errorf("invalid output format: %s", formatFlag)
+				}
+			} else {
+				list.ListRegistries(response.Payload)
 			}
-			list.ListRegistry(registry.Payload)
 		},
 	}
 
@@ -36,6 +41,7 @@ func ListRegistryCommand() *cobra.Command {
 	flags.Int64VarP(&opts.PageSize, "page-size", "", 10, "Size of per page")
 	flags.StringVarP(&opts.Q, "query", "q", "", "Query string to query resources")
 	flags.StringVarP(&opts.Sort, "sort", "", "", "Sort the resource list in ascending or descending order")
+	flags.StringVarP(&formatFlag, "output-format", "o", "", "Output format. One of: json|yaml")
 
 	return cmd
 }

--- a/cmd/harbor/root/repository/list.go
+++ b/cmd/harbor/root/repository/list.go
@@ -4,35 +4,49 @@ import (
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/repository"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
+	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/repository/list"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 func ListRepositoryCommand() *cobra.Command {
+	var formatFlag string
+
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "list repositories within a project",
+		Short: "list [PROJECT]",
 		Args:  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			var err error
-			var resp repository.ListRepositoriesOK
+			var response repository.ListRepositoriesOK
 
 			if len(args) > 0 {
-				resp, err = api.ListRepository(args[0])
+				response, err = api.ListRepository(args[0])
 			} else {
 				projectName := prompt.GetProjectNameFromUser()
-				resp, err = api.ListRepository(projectName)
+				response, err = api.ListRepository(projectName)
 			}
-
 			if err != nil {
 				log.Errorf("failed to list repositories: %v", err)
 			}
 
-			list.ListRepositories(resp.Payload)
-
+			if formatFlag != "" {
+				if formatFlag == "json" {
+					utils.PrintPayloadInJSONFormat(response)
+				} else if formatFlag == "yaml" {
+					utils.PrintPayloadInYAMLFormat(response)
+				} else {
+					log.Errorf("invalid output format: %s", formatFlag)
+				}
+			} else {
+				list.ListRepositories(response.Payload)
+			}
 		},
 	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&formatFlag, "output-format", "o", "", "Output format. One of: json|yaml")
 
 	return cmd
 }

--- a/cmd/harbor/root/user/list.go
+++ b/cmd/harbor/root/user/list.go
@@ -6,10 +6,11 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/views/user/list"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 func UserListCmd() *cobra.Command {
+	var formatFlag string
+
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "list users",
@@ -21,15 +22,22 @@ func UserListCmd() *cobra.Command {
 				log.Errorf("failed to list users: %v", err)
 				return
 			}
-			FormatFlag := viper.GetString("output-format")
-			if FormatFlag != "" {
-				utils.PrintPayloadInJSONFormat(response.Payload)
+			if formatFlag != "" {
+				if formatFlag == "json" {
+					utils.PrintPayloadInJSONFormat(response)
+				} else if formatFlag == "yaml" {
+					utils.PrintPayloadInYAMLFormat(response)
+				} else {
+					log.Errorf("invalid output format: %s", formatFlag)
+				}
 			} else {
 				list.ListUsers(response.Payload)
 			}
 		},
 	}
 
-	return cmd
+	flags := cmd.Flags()
+	flags.StringVarP(&formatFlag, "output-format", "o", "", "Output format. One of: json|yaml")
 
+	return cmd
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -3,12 +3,11 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
+	"gopkg.in/yaml.v3"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
 )
-
-// Returns Harbor v2 client for given clientConfig
 
 func PrintPayloadInJSONFormat(payload any) {
 	if payload == nil {
@@ -21,6 +20,19 @@ func PrintPayloadInJSONFormat(payload any) {
 	}
 
 	fmt.Println(string(jsonStr))
+}
+
+func PrintPayloadInYAMLFormat(payload any) {
+	if payload == nil {
+		return
+	}
+
+	yamlStr, err := yaml.Marshal(payload)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(string(yamlStr))
 }
 
 func ParseProjectRepo(projectRepo string) (string, string) {

--- a/pkg/views/registry/list/view.go
+++ b/pkg/views/registry/list/view.go
@@ -22,9 +22,9 @@ var columns = []table.Column{
 	// {Title: "Description", Width: 12},
 }
 
-func ListRegistry(registry []*models.Registry) {
+func ListRegistries(registries []*models.Registry) {
 	var rows []table.Row
-	for _, regis := range registry {
+	for _, regis := range registries {
 		createdTime, _ := utils.FormatCreatedTime(regis.CreationTime.String())
 		rows = append(rows, table.Row{
 			fmt.Sprintf("%d", regis.ID),


### PR DESCRIPTION
Fixes part of: #11 

It seems not all commands should have this option. In Kubectl, the `get` command has this output format option. `get` returns the resources, mainly it returns some information. In Kubectl the option is not set as a global option. It is added where it is necessary or can have this feature. So in harbor CLI, the option should be available for some specific commands. In this PR I have added it for the `list` command. In the current code, the `-o` option is given as a global option. So I think it should be moved to the specific commands. So I moved the option to the `list` commands.

The default return format of the lists from the go client is table, so the output format `table` is not added as an option. It is the default return format for the list command. The user can only specify JSON or YAML.

Refactored the `list.go` files of the commands to make them similar and symmetric. 

Renamed the `ListRegistry` to `ListRegistries`, converted to plural to make things symmetric.