### PR TITLE
Added the missing options in some commands and refactored some commands.

### DIFF
--- a/cmd/harbor/root/project/logs.go
+++ b/cmd/harbor/root/project/logs.go
@@ -12,15 +12,8 @@ import (
 	"github.com/spf13/viper"
 )
 
-type logsProjectOptions struct {
-	page     int64
-	pageSize int64
-	q        string
-	sort     string
-}
-
 func LogsProjectCommmand() *cobra.Command {
-	var opts logsProjectOptions
+	var opts api.ListFlags
 
 	cmd := &cobra.Command{
 		Use:   "logs",
@@ -54,10 +47,10 @@ func LogsProjectCommmand() *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.Int64VarP(&opts.page, "page", "", 1, "Page number")
-	flags.Int64VarP(&opts.pageSize, "page-size", "", 10, "Size of per page")
-	flags.StringVarP(&opts.q, "query", "q", "", "Query string to query resources")
-	flags.StringVarP(&opts.sort, "sort", "", "", "Sort the resource list in ascending or descending order")
+	flags.Int64VarP(&opts.Page, "page", "", 1, "Page number")
+	flags.Int64VarP(&opts.PageSize, "page-size", "", 10, "Size of per page")
+	flags.StringVarP(&opts.Q, "query", "q", "", "Query string to query resources")
+	flags.StringVarP(&opts.Sort, "sort", "", "", "Sort the resource list in ascending or descending order")
 
 	return cmd
 }

--- a/cmd/harbor/root/project/logs.go
+++ b/cmd/harbor/root/project/logs.go
@@ -1,7 +1,7 @@
 package project
 
 import (
-	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/project"
+	proj "github.com/goharbor/go-client/pkg/sdk/v2.0/client/project"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
@@ -12,14 +12,23 @@ import (
 	"github.com/spf13/viper"
 )
 
+type logsProjectOptions struct {
+	page     int64
+	pageSize int64
+	q        string
+	sort     string
+}
+
 func LogsProjectCommmand() *cobra.Command {
+	var opts logsProjectOptions
+
 	cmd := &cobra.Command{
 		Use:   "logs",
 		Short: "get project logs",
 		Args:  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			var err error
-			var resp *project.GetLogsOK
+			var resp *proj.GetLogsOK
 			if len(args) > 0 {
 				resp, err = api.LogsProject(args[0])
 			} else {
@@ -41,9 +50,14 @@ func LogsProjectCommmand() *cobra.Command {
 			} else {
 				auditLog.LogsProject(resp.Payload)
 			}
-
 		},
 	}
+
+	flags := cmd.Flags()
+	flags.Int64VarP(&opts.page, "page", "", 1, "Page number")
+	flags.Int64VarP(&opts.pageSize, "page-size", "", 10, "Size of per page")
+	flags.StringVarP(&opts.q, "query", "q", "", "Query string to query resources")
+	flags.StringVarP(&opts.sort, "sort", "", "", "Sort the resource list in ascending or descending order")
 
 	return cmd
 }

--- a/cmd/harbor/root/project/view.go
+++ b/cmd/harbor/root/project/view.go
@@ -11,9 +11,8 @@ import (
 	"github.com/spf13/viper"
 )
 
-// GetProjectCommand creates a new `harbor get project` command
 func ViewCommand() *cobra.Command {
-
+	var isID bool
 	cmd := &cobra.Command{
 		Use:   "view [NAME|ID]",
 		Short: "get project by name or id",
@@ -30,7 +29,6 @@ func ViewCommand() *cobra.Command {
 			}
 
 			project, err = api.GetProject(projectName)
-
 			if err != nil {
 				log.Errorf("failed to get project: %v", err)
 				return
@@ -46,9 +44,11 @@ func ViewCommand() *cobra.Command {
 			} else {
 				view.ViewProjects(project.Payload)
 			}
-
 		},
 	}
+
+	flags := cmd.Flags()
+	flags.BoolVar(&isID, "id", false, "Get project by id")
 
 	return cmd
 }

--- a/cmd/harbor/root/registry/view.go
+++ b/cmd/harbor/root/registry/view.go
@@ -33,7 +33,6 @@ func ViewRegistryCommand() *cobra.Command {
 			}
 
 			registry, err = api.ViewRegistry(registryId)
-
 			if err != nil {
 				log.Errorf("failed to get registry info: %v", err)
 				return
@@ -48,7 +47,6 @@ func ViewRegistryCommand() *cobra.Command {
 			} else {
 				view.ViewRegistry(registry.Payload)
 			}
-
 		},
 	}
 

--- a/cmd/harbor/root/repository/list.go
+++ b/cmd/harbor/root/repository/list.go
@@ -11,15 +11,8 @@ import (
 	"github.com/spf13/viper"
 )
 
-type listRepositoryOptions struct {
-	page     int64
-	pageSize int64
-	q        string
-	sort     string
-}
-
 func ListRepositoryCommand() *cobra.Command {
-	var opts listRepositoryOptions
+	var opts api.ListFlags
 
 	cmd := &cobra.Command{
 		Use:     "list",
@@ -58,10 +51,10 @@ func ListRepositoryCommand() *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.Int64VarP(&opts.page, "page", "", 1, "Page number")
-	flags.Int64VarP(&opts.pageSize, "page-size", "", 10, "Size of per page")
-	flags.StringVarP(&opts.q, "query", "q", "", "Query string to query resources")
-	flags.StringVarP(&opts.sort, "sort", "", "", "Sort the resource list in ascending or descending order")
+	flags.Int64VarP(&opts.Page, "page", "", 1, "Page number")
+	flags.Int64VarP(&opts.PageSize, "page-size", "", 10, "Size of per page")
+	flags.StringVarP(&opts.Q, "query", "q", "", "Query string to query resources")
+	flags.StringVarP(&opts.Sort, "sort", "", "", "Sort the resource list in ascending or descending order")
 
 	return cmd
 }

--- a/cmd/harbor/root/repository/list.go
+++ b/cmd/harbor/root/repository/list.go
@@ -11,7 +11,16 @@ import (
 	"github.com/spf13/viper"
 )
 
+type listRepositoryOptions struct {
+	page     int64
+	pageSize int64
+	q        string
+	sort     string
+}
+
 func ListRepositoryCommand() *cobra.Command {
+	var opts listRepositoryOptions
+
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "list repositories within a project",
@@ -30,7 +39,6 @@ func ListRepositoryCommand() *cobra.Command {
 			}
 
 			repos, err = api.ListRepository(projectName)
-
 			if err != nil {
 				log.Errorf("failed to list repositories: %v", err)
 				return
@@ -45,8 +53,15 @@ func ListRepositoryCommand() *cobra.Command {
 			} else {
 				list.ListRepositories(repos.Payload)
 			}
+			list.ListRepositories(repos.Payload)
 		},
 	}
+
+	flags := cmd.Flags()
+	flags.Int64VarP(&opts.page, "page", "", 1, "Page number")
+	flags.Int64VarP(&opts.pageSize, "page-size", "", 10, "Size of per page")
+	flags.StringVarP(&opts.q, "query", "q", "", "Query string to query resources")
+	flags.StringVarP(&opts.sort, "sort", "", "", "Sort the resource list in ascending or descending order")
 
 	return cmd
 }

--- a/cmd/harbor/root/user/list.go
+++ b/cmd/harbor/root/user/list.go
@@ -42,5 +42,4 @@ func UserListCmd() *cobra.Command {
 	flags.StringVarP(&opts.Sort, "sort", "s", "", "Sort the resource list in ascending or descending order")
 
 	return cmd
-
 }


### PR DESCRIPTION
Fixes: #76 

Added missing parameters in the 
(1) go client `list` function of the `repo` and `user` commands 
(2) go client `getLogs` function of the `logs.go` file in the `project` command using options.

Added the `XIsResourceName` parameter for the `GetProjectParams` function. This parameter specifies whether the input is name or ID. 

Refactored the `view.go` file of the `project` command. 
Refactored the `view.go` file of the `registry` command: accessing the `credentialName`.