### PR TITLE
feat: add ID to `list` table.

### DIFF
--- a/pkg/views/project/list/view.go
+++ b/pkg/views/project/list/view.go
@@ -13,6 +13,7 @@ import (
 )
 
 var columns = []table.Column{
+ 	{Title: "ID", Width: 6},
 	{Title: "Project Name", Width: 12},
 	{Title: "Access Level", Width: 12},
 	{Title: "Type", Width: 12},
@@ -35,6 +36,7 @@ func ListProjects(projects []*models.Project) {
 		}
 		createdTime, _ := utils.FormatCreatedTime(project.CreationTime.String())
 		rows = append(rows, table.Row{
+      strconv.FormatInt(int64(project.ProjectID), 10), // ProjectID
 			project.Name, // Project Name
 			accessLevel,  // Access Level
 			projectType,  // Type

--- a/pkg/views/user/list/view.go
+++ b/pkg/views/user/list/view.go
@@ -3,6 +3,7 @@ package list
 import (
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
@@ -12,6 +13,7 @@ import (
 )
 
 var columns = []table.Column{
+	{Title: "ID", Width: 6},
 	{Title: "Name", Width: 16},
 	{Title: "Administrator", Width: 16},
 	{Title: "Email", Width: 20},
@@ -27,6 +29,7 @@ func ListUsers(users []*models.UserResp) {
 		}
 		createdTime, _ := utils.FormatCreatedTime(user.CreationTime.String())
 		rows = append(rows, table.Row{
+			strconv.FormatInt(int64(user.UserID), 10), // UserID
 			user.Username,
 			isAdmin,
 			user.Email,


### PR DESCRIPTION
## Fixes: #84 

The `project list` and `user list` table has a missing ID column, it will be easier for the user to see the table, identify the IDs.

Adding this column will enhance the user experience and be beneficial for the project.