### PR TITLE
feat: Improve Performance of ` delete` Command with Concurrency

### DIFF
--- a/cmd/harbor/root/project/delete.go
+++ b/cmd/harbor/root/project/delete.go
@@ -14,6 +14,8 @@
 package project
 
 import (
+	"sync"
+
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	log "github.com/sirupsen/logrus"
@@ -23,22 +25,53 @@ import (
 // DeleteProjectCommand creates a new `harbor delete project` command
 func DeleteProjectCommand() *cobra.Command {
 	var forceDelete bool
-
 	cmd := &cobra.Command{
-		Use:   "delete",
-		Short: "delete project by name or id",
-		Args:  cobra.MaximumNArgs(1),
+		Use:     "delete [NAME]",
+		Short:   "delete project by name or id",
+		Example: `  harbor project delete [NAME]`,
+		Args:    cobra.MinimumNArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
-			var err error
+			var wg sync.WaitGroup
+			errChan := make(
+				chan error,
+				len(args),
+			) // Channel to collect errors
 
 			if len(args) > 0 {
-				err = api.DeleteProject(args[0], forceDelete)
+				for _, arg := range args {
+					wg.Add(1)
+					go func(projectName string) {
+						defer wg.Done()
+						if err := api.DeleteProject(projectName, forceDelete); err != nil {
+							errChan <- err
+						}
+					}(arg)
+				}
 			} else {
 				projectName := prompt.GetProjectNameFromUser()
-				err = api.DeleteProject(projectName, forceDelete)
+				err := api.DeleteProject(projectName, forceDelete)
+				if err != nil {
+					log.Errorf("failed to delete project: %v", err)
+				}
 			}
-			if err != nil {
-				log.Errorf("failed to delete project: %v", err)
+
+			// Wait for all goroutines to finish
+			go func() {
+				wg.Wait()
+				close(errChan)
+			}()
+
+			// Collect and handle errors
+			var finalErr error
+			for err := range errChan {
+				if finalErr == nil {
+					finalErr = err
+				} else {
+					log.Errorf("Error: %v", err)
+				}
+			}
+			if finalErr != nil {
+				log.Errorf("failed to delete some projects: %v", finalErr)
 			}
 		},
 	}

--- a/cmd/harbor/root/project/delete.go
+++ b/cmd/harbor/root/project/delete.go
@@ -26,9 +26,9 @@ import (
 func DeleteProjectCommand() *cobra.Command {
 	var forceDelete bool
 	cmd := &cobra.Command{
-		Use:     "delete [NAME]",
+		Use:     "delete",
 		Short:   "delete project by name or id",
-		Example: `  harbor project delete [NAME]`,
+		Example: `  harbor project delete [projectname]`,
 		Args:    cobra.MinimumNArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			var wg sync.WaitGroup

--- a/cmd/harbor/root/registry/delete.go
+++ b/cmd/harbor/root/registry/delete.go
@@ -27,7 +27,7 @@ func DeleteRegistryCommand() *cobra.Command {
 		Use:     "delete",
 		Short:   "delete registry by name or id",
 		Example: "harbor registry delete [registryname]",
-		Args:    cobra.MaximumNArgs(1),
+		Args:    cobra.MinimumNArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			var wg sync.WaitGroup
 			errChan := make(chan error, len(args))

--- a/cmd/harbor/root/registry/delete.go
+++ b/cmd/harbor/root/registry/delete.go
@@ -14,6 +14,8 @@
 package registry
 
 import (
+	"sync"
+
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	log "github.com/sirupsen/logrus"
@@ -23,21 +25,49 @@ import (
 func DeleteRegistryCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "delete",
-		Short:   "delete registry",
+		Short:   "delete registry by name or id",
 		Example: "harbor registry delete [registryname]",
 		Args:    cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			var err error
-
+			var wg sync.WaitGroup
+			errChan := make(chan error, len(args))
 			if len(args) > 0 {
-				registryName, _ := api.GetRegistryIdByName(args[0])
-				err = api.DeleteRegistry(registryName)
+				for _, arg := range args {
+					registryID, _ := api.GetRegistryIdByName(arg)
+					wg.Add(1)
+					go func(registryID int64) {
+						defer wg.Done()
+						if err := api.DeleteRegistry(registryID); err != nil {
+							errChan <- err
+						}
+					}(registryID)
+				}
 			} else {
 				registryId := prompt.GetRegistryNameFromUser()
-				err = api.DeleteRegistry(registryId)
+				err := api.DeleteRegistry(registryId)
+				if err != nil {
+					log.Errorf("failed to delete registry: %v", err)
+				}
 			}
-			if err != nil {
-				log.Errorf("failed to delete registry: %v", err)
+
+			// Wait for all goroutines to finish
+			go func() {
+				wg.Wait()
+				close(errChan)
+			}()
+
+			// Collect and handle errors
+			var finalErr error
+			for err := range errChan {
+				if finalErr == nil {
+					finalErr = err
+				} else {
+					log.Errorf("Error: %v", err)
+				}
+			}
+
+			if finalErr != nil {
+				log.Errorf("failed to delete registry: %v", finalErr)
 			}
 		},
 	}


### PR DESCRIPTION
## Fixes: #79

### Description:
This PR enhances the performance of the `harbor project delete` command by introducing concurrency to handle multiple project deletions in parallel. The changes ensure that the command is more efficient, especially when dealing with multiple projects.

### Changes:
- Concurrency Implementation:
- Added goroutines to execute `runDeleteProject` concurrently for each project specified in the command arguments.

### Error Handling:
- Implemented an error channel (errChan) to collect errors from each goroutine.
- Ensured all errors are logged appropriately after all goroutines have completed.

### Benefits:
- Performance: By running deletions concurrently, the command execution time is significantly reduced when dealing with multiple projects.
- Reliability: Enhanced error handling ensures that all errors are captured and logged, providing better visibility into potential issues.

### Testing:
- [x] Tested the command without args and with multiple project names to ensure concurrent deletions work as expected.

### Example Usage:
```sh

# Delete multiple projects concurrently
harbor project delete project1 project2 project3

# Delete a single project by prompting the user
harbor project delete
```
 