### PR TITLE
Enhance `registry create` Command

### DIFF
--- a/cmd/harbor/root/registry/create.go
+++ b/cmd/harbor/root/registry/create.go
@@ -39,19 +39,42 @@ func CreateRegistryCommand() *cobra.Command {
 			if err != nil {
 				log.Errorf("failed to create registry: %v", err)
 			}
-
 		},
 	}
 
 	flags := cmd.Flags()
 	flags.StringVarP(&opts.Name, "name", "", "", "Name of the registry")
-	flags.StringVarP(&opts.Type, "type", "", "harbor", "Type of the registry")
+	flags.StringVarP(&opts.Type, "type", "", "", "Type of the registry")
 	flags.StringVarP(&opts.URL, "url", "", "", "Registry endpoint URL")
 	flags.StringVarP(&opts.Description, "description", "", "", "Description of the registry")
-	flags.BoolVarP(&opts.Insecure, "insecure", "", true, "Whether or not the certificate will be verified when Harbor tries to access the server")
-	flags.StringVarP(&opts.Credential.AccessKey, "credential-access-key", "", "", "Access key, e.g. user name when credential type is 'basic'")
-	flags.StringVarP(&opts.Credential.AccessSecret, "credential-access-secret", "", "", "Access secret, e.g. password when credential type is 'basic'")
-	flags.StringVarP(&opts.Credential.Type, "credential-type", "", "basic", "Credential type, such as 'basic', 'oauth'")
+	flags.BoolVarP(
+		&opts.Insecure,
+		"insecure",
+		"",
+		true,
+		"Whether or not the certificate will be verified when Harbor tries to access the server",
+	)
+	flags.StringVarP(
+		&opts.Credential.AccessKey,
+		"credential-access-key",
+		"",
+		"",
+		"Access key, e.g. user name when credential type is 'basic'",
+	)
+	flags.StringVarP(
+		&opts.Credential.AccessSecret,
+		"credential-access-secret",
+		"",
+		"",
+		"Access secret, e.g. password when credential type is 'basic'",
+	)
+	flags.StringVarP(
+		&opts.Credential.Type,
+		"credential-type",
+		"",
+		"basic",
+		"Credential type, such as 'basic', 'oauth'",
+	)
 
 	return cmd
 }

--- a/cmd/harbor/root/registry/create.go
+++ b/cmd/harbor/root/registry/create.go
@@ -9,7 +9,7 @@ import (
 
 // NewCreateRegistryCommand creates a new `harbor create registry` command
 func CreateRegistryCommand() *cobra.Command {
-	var opts create.CreateView
+	var opts api.CreateRegView
 
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -17,12 +17,12 @@ func CreateRegistryCommand() *cobra.Command {
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			var err error
-			createView := &create.CreateView{
+			createView := &api.CreateRegView{
 				Name:        opts.Name,
 				Type:        opts.Type,
 				Description: opts.Description,
 				URL:         opts.URL,
-				Credential: create.RegistryCredential{
+				Credential: api.RegistryCredential{
 					AccessKey:    opts.Credential.AccessKey,
 					Type:         opts.Credential.Type,
 					AccessSecret: opts.Credential.AccessSecret,
@@ -52,7 +52,7 @@ func CreateRegistryCommand() *cobra.Command {
 		"insecure",
 		"",
 		true,
-		"Whether or not the certificate will be verified when Harbor tries to access the server",
+		"Whether Harbor will verify the server certificate",
 	)
 	flags.StringVarP(
 		&opts.Credential.AccessKey,
@@ -79,9 +79,9 @@ func CreateRegistryCommand() *cobra.Command {
 	return cmd
 }
 
-func createRegistryView(createView *create.CreateView) error {
+func createRegistryView(createView *api.CreateRegView) error {
 	if createView == nil {
-		createView = &create.CreateView{}
+		createView = &api.CreateRegView{}
 	}
 
 	create.CreateRegistryView(createView)

--- a/cmd/harbor/root/registry/update.go
+++ b/cmd/harbor/root/registry/update.go
@@ -12,7 +12,7 @@ import (
 
 // NewUpdateRegistryCommand creates a new `harbor update registry` command
 func UpdateRegistryCommand() *cobra.Command {
-	var opts create.CreateView
+	var opts api.CreateRegView
 
 	cmd := &cobra.Command{
 		Use:   "update",
@@ -22,12 +22,12 @@ func UpdateRegistryCommand() *cobra.Command {
 			var err error
 			var registryId int64
 
-			updateView := &create.CreateView{
+			updateView := &api.CreateRegView{
 				Name:        opts.Name,
 				Type:        opts.Type,
 				Description: opts.Description,
 				URL:         opts.URL,
-				Credential: create.RegistryCredential{
+				Credential: api.RegistryCredential{
 					AccessKey:    opts.Credential.AccessKey,
 					Type:         opts.Credential.Type,
 					AccessSecret: opts.Credential.AccessSecret,
@@ -62,17 +62,41 @@ func UpdateRegistryCommand() *cobra.Command {
 	flags.StringVarP(&opts.Type, "type", "", "", "Type of the registry")
 	flags.StringVarP(&opts.URL, "url", "", "", "Registry endpoint URL")
 	flags.StringVarP(&opts.Description, "description", "", "", "Description of the registry")
-	flags.BoolVarP(&opts.Insecure, "insecure", "", true, "Whether or not the certificate will be verified when Harbor tries to access the server")
-	flags.StringVarP(&opts.Credential.AccessKey, "credential-access-key", "", "", "Access key, e.g. user name when credential type is 'basic'")
-	flags.StringVarP(&opts.Credential.AccessSecret, "credential-access-secret", "", "", "Access secret, e.g. password when credential type is 'basic'")
-	flags.StringVarP(&opts.Credential.Type, "credential-type", "", "", "Credential type, such as 'basic', 'oauth'")
+	flags.BoolVarP(
+		&opts.Insecure,
+		"insecure",
+		"",
+		true,
+		"Whether or not the certificate will be verified when Harbor tries to access the server",
+	)
+	flags.StringVarP(
+		&opts.Credential.AccessKey,
+		"credential-access-key",
+		"",
+		"",
+		"Access key, e.g. user name when credential type is 'basic'",
+	)
+	flags.StringVarP(
+		&opts.Credential.AccessSecret,
+		"credential-access-secret",
+		"",
+		"",
+		"Access secret, e.g. password when credential type is 'basic'",
+	)
+	flags.StringVarP(
+		&opts.Credential.Type,
+		"credential-type",
+		"",
+		"",
+		"Credential type, such as 'basic', 'oauth'",
+	)
 
 	return cmd
 }
 
-func updateRegistryView(updateView *create.CreateView, projectID int64) error {
+func updateRegistryView(updateView *api.CreateRegView, projectID int64) error {
 	if updateView == nil {
-		updateView = &create.CreateView{}
+		updateView = &api.CreateRegView{}
 	}
 
 	create.CreateRegistryView(updateView)

--- a/pkg/api/registry_handler.go
+++ b/pkg/api/registry_handler.go
@@ -4,7 +4,6 @@ import (
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/registry"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	"github.com/goharbor/harbor-cli/pkg/views/registry/create"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -27,7 +26,6 @@ func ListRegistries(opts ...ListFlags) (*registry.ListRegistriesOK, error) {
 		Name:     &listFlags.Name,
 		Sort:     &listFlags.Sort,
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -35,14 +33,29 @@ func ListRegistries(opts ...ListFlags) (*registry.ListRegistriesOK, error) {
 	return response, nil
 }
 
-func CreateRegistry(opts create.CreateView) error {
+func CreateRegistry(opts CreateRegView) error {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {
 		return err
 	}
 
-	_, err = client.Registry.CreateRegistry(ctx, &registry.CreateRegistryParams{Registry: &models.Registry{Credential: &models.RegistryCredential{AccessKey: opts.Credential.AccessKey, AccessSecret: opts.Credential.AccessSecret, Type: opts.Credential.Type}, Description: opts.Description, Insecure: opts.Insecure, Name: opts.Name, Type: opts.Type, URL: opts.URL}})
-
+	_, err = client.Registry.CreateRegistry(
+		ctx,
+		&registry.CreateRegistryParams{
+			Registry: &models.Registry{
+				Credential: &models.RegistryCredential{
+					AccessKey:    opts.Credential.AccessKey,
+					AccessSecret: opts.Credential.AccessSecret,
+					Type:         opts.Credential.Type,
+				},
+				Description: opts.Description,
+				Insecure:    opts.Insecure,
+				Name:        opts.Name,
+				Type:        opts.Type,
+				URL:         opts.URL,
+			},
+		},
+	)
 	if err != nil {
 		return err
 	}
@@ -57,7 +70,6 @@ func DeleteRegistry(registryName int64) error {
 		return err
 	}
 	_, err = client.Registry.DeleteRegistry(ctx, &registry.DeleteRegistryParams{ID: registryName})
-
 	if err != nil {
 		return err
 	}
@@ -74,7 +86,6 @@ func InfoRegistry(registryId int64) error {
 	}
 
 	response, err := client.Registry.GetRegistry(ctx, &registry.GetRegistryParams{ID: registryId})
-
 	if err != nil {
 		return err
 	}
@@ -89,7 +100,6 @@ func GetRegistry(registryId int64) error {
 		return err
 	}
 	response, err := client.Registry.GetRegistry(ctx, &registry.GetRegistryParams{ID: registryId})
-
 	if err != nil {
 		return err
 	}
@@ -98,7 +108,7 @@ func GetRegistry(registryId int64) error {
 	return nil
 }
 
-func UpdateRegistry(updateView *create.CreateView, projectID int64) error {
+func UpdateRegistry(updateView *CreateRegView, projectID int64) error {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {
 		return err
@@ -113,8 +123,10 @@ func UpdateRegistry(updateView *create.CreateView, projectID int64) error {
 		Insecure:       &updateView.Insecure,
 	}
 
-	_, err = client.Registry.UpdateRegistry(ctx, &registry.UpdateRegistryParams{ID: projectID, Registry: registryUpdate})
-
+	_, err = client.Registry.UpdateRegistry(
+		ctx,
+		&registry.UpdateRegistryParams{ID: projectID, Registry: registryUpdate},
+	)
 	if err != nil {
 		return err
 	}
@@ -122,4 +134,21 @@ func UpdateRegistry(updateView *create.CreateView, projectID int64) error {
 	log.Info("registry updated successfully")
 
 	return nil
+}
+
+// Get List of Registry Providers
+func GetRegistryProviders() ([]string, error) {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return nil, err
+	}
+	response, err := client.Registry.ListRegistryProviderTypes(
+		ctx,
+		&registry.ListRegistryProviderTypesParams{},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Payload, nil
 }

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -8,3 +8,20 @@ type ListFlags struct {
 	Sort     string
 	Public   bool
 }
+
+// CreateView for Registry
+type CreateRegView struct {
+	Name        string
+	Type        string
+	Description string
+	URL         string
+	Credential  RegistryCredential
+	Insecure    bool
+}
+
+// Credential for Registry
+type RegistryCredential struct {
+	AccessKey    string `json:"access_key,omitempty"`
+	Type         string `json:"type,omitempty"`
+	AccessSecret string `json:"access_secret,omitempty"`
+}

--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -24,4 +25,13 @@ func FormatCreatedTime(timestamp string) (string, error) {
 	} else {
 		return fmt.Sprintf("%d day ago", days), nil
 	}
+}
+
+func FormatUrl(url string) string {
+	// Check if URL starts with "http://" or "https://"
+	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
+		// If not, prepend "https://"
+		url = "https://" + url
+	}
+	return url
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,15 +1,11 @@
 package utils
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
 
-	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/registry"
-	rview "github.com/goharbor/harbor-cli/pkg/views/registry/select"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 // Returns Harbor v2 client for given clientConfig
@@ -25,26 +21,6 @@ func PrintPayloadInJSONFormat(payload any) {
 	}
 
 	fmt.Println(string(jsonStr))
-}
-
-func GetRegistryTypeFromUser() string {
-	registryType := make(chan string)
-	go func() {
-		credentialName := viper.GetString("current-credential-name")
-		client := GetClientByCredentialName(credentialName)
-		ctx := context.Background()
-		response, err := client.Registry.ListRegistryProviderTypes(
-			ctx,
-			&registry.ListRegistryProviderTypesParams{},
-		)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		rview.RegistryListTypes(response.Payload, registryType)
-	}()
-
-	return <-registryType
 }
 
 func ParseProjectRepo(projectRepo string) (string, string) {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,11 +1,15 @@
 package utils
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
 
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/registry"
+	rview "github.com/goharbor/harbor-cli/pkg/views/registry/select"
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 )
 
 // Returns Harbor v2 client for given clientConfig
@@ -21,6 +25,26 @@ func PrintPayloadInJSONFormat(payload any) {
 	}
 
 	fmt.Println(string(jsonStr))
+}
+
+func GetRegistryTypeFromUser() string {
+	registryType := make(chan string)
+	go func() {
+		credentialName := viper.GetString("current-credential-name")
+		client := GetClientByCredentialName(credentialName)
+		ctx := context.Background()
+		response, err := client.Registry.ListRegistryProviderTypes(
+			ctx,
+			&registry.ListRegistryProviderTypesParams{},
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		rview.RegistryListTypes(response.Payload, registryType)
+	}()
+
+	return <-registryType
 }
 
 func ParseProjectRepo(projectRepo string) (string, string) {

--- a/pkg/views/registry/create/view.go
+++ b/pkg/views/registry/create/view.go
@@ -2,39 +2,59 @@ package create
 
 import (
 	"errors"
+	"fmt"
+	"strconv"
 
 	"github.com/charmbracelet/huh"
+	"github.com/goharbor/harbor-cli/pkg/api"
 	log "github.com/sirupsen/logrus"
 )
 
-type CreateView struct {
-	Name        string
-	Type        string
-	Description string
-	URL         string
-	Credential  RegistryCredential
-	Insecure    bool
+// struct to hold registry options
+type RegistryOption struct {
+	ID   string
+	Name string
 }
 
-type RegistryCredential struct {
-	AccessKey    string `json:"access_key,omitempty"`
-	Type         string `json:"type,omitempty"`
-	AccessSecret string `json:"access_secret,omitempty"`
-}
+func CreateRegistryView(createView *api.CreateRegView) {
+	registries, _ := api.GetRegistryProviders()
 
-func CreateRegistryView(createView *CreateView) {
+	// Initialize a slice to hold registry options
+	var registryOptions []RegistryOption
+
+	// Iterate over registries to populate registryOptions
+	for i, registry := range registries {
+		registryOptions = append(registryOptions, RegistryOption{
+			ID:   strconv.FormatInt(int64(i), 10),
+			Name: fmt.Sprintf("%s", registry),
+		})
+	}
+
+	// Initialize a slice to hold select options
+	var registrySelectOptions []huh.Option[string]
+
+	// Iterate over registryOptions to populate registrySelectOptions
+	for _, option := range registryOptions {
+		registrySelectOptions = append(
+			registrySelectOptions,
+			huh.NewOption(option.Name, option.Name),
+		)
+	}
+
 	theme := huh.ThemeCharm()
 	err := huh.NewForm(
 		huh.NewGroup(
-			huh.NewInput().
-				Title("Provider").
+			huh.NewSelect[string]().
+				Title("Select a Registry Provider").
 				Value(&createView.Type).
+				Options(registrySelectOptions...).
 				Validate(func(str string) error {
 					if str == "" {
-						return errors.New("provider cannot be empty")
+						return errors.New("registry provider cannot be empty")
 					}
 					return nil
 				}),
+
 			huh.NewInput().
 				Title("Name").
 				Value(&createView.Name).
@@ -69,7 +89,6 @@ func CreateRegistryView(createView *CreateView) {
 				Negative("no"),
 		),
 	).WithTheme(theme).Run()
-
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/views/registry/list/view.go
+++ b/pkg/views/registry/list/view.go
@@ -37,26 +37,6 @@ func ListRegistry(registry []*models.Registry) {
 		})
 	}
 
-	// t := table.New(
-	// 	table.WithColumns(columns),
-	// 	table.WithRows(rows),
-	// 	table.WithFocused(true),
-	// 	table.WithHeight(len(rows)),
-	// )
-
-	// // Set the styles for the table
-	// s := table.DefaultStyles()
-	// s.Header = s.Header.
-	// 	BorderStyle(lipgloss.NormalBorder()).
-	// 	BorderBottom(true).
-	// 	Bold(false)
-
-	// s.Selected = s.Selected.
-	// 	Foreground(s.Cell.GetForeground()).
-	// 	Background(s.Cell.GetBackground()).
-	// 	Bold(false)
-	// t.SetStyles(s)
-
 	m := tablelist.NewModel(columns, rows, len(rows))
 
 	if _, err := tea.NewProgram(m).Run(); err != nil {

--- a/pkg/views/registry/select/view.go
+++ b/pkg/views/registry/select/view.go
@@ -23,7 +23,6 @@ func RegistryList(registry []*models.Registry, choice chan<- int64) {
 	m := selection.NewModel(itemsList, "Registry")
 
 	p, err := tea.NewProgram(m, tea.WithAltScreen()).Run()
-
 	if err != nil {
 		fmt.Println("Error running program:", err)
 		os.Exit(1)
@@ -32,42 +31,4 @@ func RegistryList(registry []*models.Registry, choice chan<- int64) {
 	if p, ok := p.(selection.Model); ok {
 		choice <- items[p.Choice]
 	}
-
 }
-
-func RegistryListTypes(registries []string, choice chan<- string) {
-
-	itemsList := make([]list.Item, len(registries))
-
-	items := map[string]string{}
-
-	for i, reg := range registries {
-		items[reg] = reg
-		itemsList[i] = item(reg)
-	}
-
-	const defaultWidth = 20
-
-	l := list.New(itemsList, itemDelegate{}, defaultWidth, listHeight)
-	l.Title = "Select a Registry"
-	l.SetShowStatusBar(false)
-	l.SetFilteringEnabled(false)
-	l.Styles.Title = views.TitleStyle
-	l.Styles.PaginationStyle = views.PaginationStyle
-	l.Styles.HelpStyle = views.HelpStyle
-
-	m := model{list: l}
-
-	p, err := tea.NewProgram(m, tea.WithAltScreen()).Run()
-
-	if err != nil {
-		fmt.Println("Error running program:", err)
-		os.Exit(1)
-	}
-
-	if p, ok := p.(model); ok {
-		choice <- items[p.choice]
-	}
-
-}
-

--- a/pkg/views/registry/select/view.go
+++ b/pkg/views/registry/select/view.go
@@ -34,3 +34,40 @@ func RegistryList(registry []*models.Registry, choice chan<- int64) {
 	}
 
 }
+
+func RegistryListTypes(registries []string, choice chan<- string) {
+
+	itemsList := make([]list.Item, len(registries))
+
+	items := map[string]string{}
+
+	for i, reg := range registries {
+		items[reg] = reg
+		itemsList[i] = item(reg)
+	}
+
+	const defaultWidth = 20
+
+	l := list.New(itemsList, itemDelegate{}, defaultWidth, listHeight)
+	l.Title = "Select a Registry"
+	l.SetShowStatusBar(false)
+	l.SetFilteringEnabled(false)
+	l.Styles.Title = views.TitleStyle
+	l.Styles.PaginationStyle = views.PaginationStyle
+	l.Styles.HelpStyle = views.HelpStyle
+
+	m := model{list: l}
+
+	p, err := tea.NewProgram(m, tea.WithAltScreen()).Run()
+
+	if err != nil {
+		fmt.Println("Error running program:", err)
+		os.Exit(1)
+	}
+
+	if p, ok := p.(model); ok {
+		choice <- items[p.choice]
+	}
+
+}
+


### PR DESCRIPTION
## Overview:
This PR improves the user experience of the registry create command by fetching and presenting default registries available. This enhancement guides users to select the correct registry provider, reducing the likelihood of errors and streamlining the setup process.

### Problem: 
Previously, users had to manually enter registry provider details, which often led to errors and a frustrating experience. Incorrect registry configurations could result in errors that were difficult to diagnose and fix.

### Solution:
To address this issue, I have implemented a feature that fetches a list of registry providers in harbor and presents them to the user during the registry create process. This allows users to select a registry from a predefined list, ensuring correct configuration and reducing errors.

### Changes Made:
- Added functionality to fetch a list of default registries and an interactive list of registries for the user to choose from.

## Screenshots:
### Before:
![Before](https://github.com/goharbor/harbor-cli/assets/89722848/6b1f9cca-da3a-4b0d-b156-e92b9557840c)


### After:
![after](https://github.com/goharbor/harbor-cli/assets/89722848/27d5a52a-3b7c-4bc8-a4c0-208e36028a96)

