### PR TITLE
Added e2e for the `login` command using flags.

### DIFF
--- a/cmd/harbor/root/login.go
+++ b/cmd/harbor/root/login.go
@@ -27,7 +27,7 @@ func LoginCommand() *cobra.Command {
 		Short: "Log in to Harbor registry",
 		Long:  "Authenticate with Harbor Registry.",
 		Args:  cobra.MaximumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 
 			if len(args) > 0 {
 				serverAddress = args[0]
@@ -49,9 +49,9 @@ func LoginCommand() *cobra.Command {
 			}
 
 			if err != nil {
-				fmt.Println(err)
+				return err
 			}
-
+			return nil
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -10,12 +10,14 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
+	github.com/stretchr/testify v1.9.0
 )
 
 require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/catppuccin/go v0.2.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
@@ -29,6 +31,7 @@ require (
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.15.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
@@ -36,7 +39,6 @@ require (
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
-	github.com/stretchr/testify v1.9.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect

--- a/test/e2e/login_test.go
+++ b/test/e2e/login_test.go
@@ -1,0 +1,125 @@
+package e2e
+
+import (
+	"github.com/goharbor/harbor-cli/cmd/harbor/root"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_Success(t *testing.T) {
+	cmd := root.LoginCommand()
+	var err error
+
+	validServerAddresses := []string{
+		"http://demo.goharbor.io:80",
+		"https://demo.goharbor.io:8443",
+		"http://demo.goharbor.io",
+		"https://demo.goharbor.io",
+		"demo.goharbor.io",
+	}
+
+	for _, serverAddress := range validServerAddresses {
+		args := []string{
+			serverAddress,
+		}
+		cmd.SetArgs(args)
+
+		err = cmd.Flags().Set("name", "test")
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = cmd.Flags().Set("username", "admin")
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = cmd.Flags().Set("password", "Harbor12345")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = cmd.Execute()
+
+		assert.NoError(t, err)
+	}
+}
+
+func Test_Failure_WrongServer(t *testing.T) {
+	cmd := root.LoginCommand()
+	var err error
+
+	args := []string{
+		"demo.goharbor.io",
+	}
+	cmd.SetArgs(args)
+
+	err = cmd.Flags().Set("name", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = cmd.Flags().Set("username", "admin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = cmd.Flags().Set("password", "Harbor12345")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = cmd.Execute()
+
+	assert.Error(t, err)
+}
+
+func Test_Failure_WrongUsername(t *testing.T) {
+	cmd := root.LoginCommand()
+	var err error
+
+	args := []string{
+		"http://demo.goharbor.io",
+	}
+	cmd.SetArgs(args)
+
+	err = cmd.Flags().Set("name", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = cmd.Flags().Set("username", "wrong")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = cmd.Flags().Set("password", "Harbor12345")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = cmd.Execute()
+
+	assert.Error(t, err)
+}
+
+func Test_Failure_WrongPassword(t *testing.T) {
+	cmd := root.LoginCommand()
+	var err error
+
+	args := []string{
+		"http://demo.goharbor.io",
+	}
+	cmd.SetArgs(args)
+
+	err = cmd.Flags().Set("name", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = cmd.Flags().Set("username", "admin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = cmd.Flags().Set("password", "wrong")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = cmd.Execute()
+
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Fixes: #23 

This PR requires PR #89 to be merged as that solves the feature.

The test data are written directly on the code. However, we need to decide how the test data will be managed and where should be stored. Looking for guidelines @Vad1mo @amands98.

These tests do not mock as the motive of e2e is to test if the whole procedure is working fine. Only external modules can be mocked if necessary. Mocking the internal modules would not let to check the integration of all the modules.

I had to change the `Run` function to `RunE` function, because otherwise the assertions could not be tested. The problem is with the `fmt.Println()` function, as it will not write to the buffer provided in the test function.
I have checked many places and investigated. Their method works because those functions do not use `Println()` to show the failure.
https://nayaktapan37.medium.com/testing-cobra-commands-in-golang-ca1fe4ad6657
https://github.com/spf13/cobra/issues/1790
https://github.com/govcms-tests/govcms-cli/blob/3216b7334c184e2cd52f013f588d2af9529b4929/docs/testing_cobra.mdhttps://github.com/spf13/cobra-cli/tree/main/cmd