### PR TITLE
Add scan all command

### DIFF
--- a/cmd/harbor/root/cmd.go
+++ b/cmd/harbor/root/cmd.go
@@ -2,6 +2,7 @@ package root
 
 import (
 	"fmt"
+	scan_all "github.com/goharbor/harbor-cli/cmd/harbor/root/scan-all"
 	"log"
 	"os"
 
@@ -106,6 +107,7 @@ harbor help
 		repositry.Repository(),
 		user.User(),
 		artifact.Artifact(),
+		scan_all.ScanAllCommand(),
 	)
 
 	return root

--- a/cmd/harbor/root/cmd.go
+++ b/cmd/harbor/root/cmd.go
@@ -107,7 +107,7 @@ harbor help
 		repositry.Repository(),
 		user.User(),
 		artifact.Artifact(),
-		scan_all.ScanAllCommand(),
+		scan_all.ScanAll(),
 	)
 
 	return root

--- a/cmd/harbor/root/scan-all/cmd.go
+++ b/cmd/harbor/root/scan-all/cmd.go
@@ -13,6 +13,7 @@ func ScanAll() *cobra.Command {
 		StopScanAllCommand(),
 		ViewScanAllScheduleCommand(),
 		GetScanAllMetricsCommand(),
+		RunScanAllCommand(),
 	)
 
 	return cmd

--- a/cmd/harbor/root/scan-all/cmd.go
+++ b/cmd/harbor/root/scan-all/cmd.go
@@ -1,0 +1,19 @@
+package scan_all
+
+import "github.com/spf13/cobra"
+
+func ScanAllCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "scan-all",
+		Short: "Scan all artifacts",
+	}
+
+	cmd.AddCommand(
+		UpdateScanAllScheduleCommand(),
+		StopScanAllCommand(),
+		ViewScanAllScheduleCommand(),
+		GetScanAllMetricsCommand(),
+	)
+
+	return cmd
+}

--- a/cmd/harbor/root/scan-all/cmd.go
+++ b/cmd/harbor/root/scan-all/cmd.go
@@ -2,7 +2,7 @@ package scan_all
 
 import "github.com/spf13/cobra"
 
-func ScanAllCommand() *cobra.Command {
+func ScanAll() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "scan-all",
 		Short: "Scan all artifacts",

--- a/cmd/harbor/root/scan-all/metrics.go
+++ b/cmd/harbor/root/scan-all/metrics.go
@@ -29,6 +29,7 @@ func GetScanAllMetricsCommand() *cobra.Command {
 	}
 
 	flags := cmd.Flags()
+	// latest scheduled metrics is deprecated in the API
 	flags.BoolVarP(&scheduled, "scheduled", "s", false, "Get the metrics of the latest scheduled scan all process")
 
 	return cmd

--- a/cmd/harbor/root/scan-all/metrics.go
+++ b/cmd/harbor/root/scan-all/metrics.go
@@ -1,0 +1,35 @@
+package scan_all
+
+import (
+	"fmt"
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/spf13/cobra"
+)
+
+func GetScanAllMetricsCommand() *cobra.Command {
+	var scheduled bool
+
+	cmd := &cobra.Command{
+		Use:   "metrics",
+		Short: "Get the metrics of the latest scan all process",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			metrics, err := api.GetScanAllMetrics(scheduled)
+			if err != nil {
+				return err
+			}
+
+			fmt.Println("Total: ", metrics.Total)
+			fmt.Println("Ongoing: ", metrics.Ongoing)
+			fmt.Println("Completed: ", metrics.Completed)
+			fmt.Println("Trigger: ", metrics.Trigger)
+			fmt.Println("Metrics: ", metrics.Metrics)
+
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.BoolVarP(&scheduled, "scheduled", "s", false, "Get the metrics of the latest scheduled scan all process")
+
+	return cmd
+}

--- a/cmd/harbor/root/scan-all/run.go
+++ b/cmd/harbor/root/scan-all/run.go
@@ -1,0 +1,19 @@
+package scan_all
+
+import (
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/spf13/cobra"
+)
+
+func RunScanAllCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "Scan all artifacts now",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return api.UpdateScanAllSchedule(models.ScheduleObj{Type: "Manual"})
+		},
+	}
+
+	return cmd
+}

--- a/cmd/harbor/root/scan-all/run.go
+++ b/cmd/harbor/root/scan-all/run.go
@@ -15,7 +15,7 @@ func RunScanAllCommand() *cobra.Command {
 			// Random cron expression and random time need to be passed to the API, even though they are not used, otherwise it returns bad request
 			randomCron := "0 * * * * *"
 			randomTime := strfmt.DateTime{}
-			return api.UpdateScanAllSchedule(models.ScheduleObj{Type: "Manual", Cron: randomCron, NextScheduledTime: randomTime})
+			return api.CreateScanAllSchedule(models.ScheduleObj{Type: "Manual", Cron: randomCron, NextScheduledTime: randomTime})
 		},
 	}
 

--- a/cmd/harbor/root/scan-all/run.go
+++ b/cmd/harbor/root/scan-all/run.go
@@ -1,6 +1,7 @@
 package scan_all
 
 import (
+	"github.com/go-openapi/strfmt"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/spf13/cobra"
@@ -11,7 +12,10 @@ func RunScanAllCommand() *cobra.Command {
 		Use:   "run",
 		Short: "Scan all artifacts now",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return api.UpdateScanAllSchedule(models.ScheduleObj{Type: "Manual"})
+			// Random cron expression and random time need to be passed to the API, even though they are not used, otherwise it returns bad request
+			randomCron := "0 * * * * *"
+			randomTime := strfmt.DateTime{}
+			return api.UpdateScanAllSchedule(models.ScheduleObj{Type: "Manual", Cron: randomCron, NextScheduledTime: randomTime})
 		},
 	}
 

--- a/cmd/harbor/root/scan-all/stop.go
+++ b/cmd/harbor/root/scan-all/stop.go
@@ -1,0 +1,18 @@
+package scan_all
+
+import (
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/spf13/cobra"
+)
+
+func StopScanAllCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "stop",
+		Short: "Stop scanning all artifacts",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return api.StopScanAll()
+		},
+	}
+
+	return cmd
+}

--- a/cmd/harbor/root/scan-all/update_schedule.go
+++ b/cmd/harbor/root/scan-all/update_schedule.go
@@ -2,6 +2,7 @@ package scan_all
 
 import (
 	"errors"
+	"github.com/go-openapi/strfmt"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/views/scan-all/update"
@@ -29,13 +30,20 @@ func UpdateScanAllScheduleCommand() *cobra.Command {
 				if scheduleType == "None" {
 					return api.UpdateScanAllSchedule(models.ScheduleObj{Type: "None"})
 				} else if scheduleType == "Hourly" || scheduleType == "Daily" || scheduleType == "Weekly" {
-					return api.UpdateScanAllSchedule(models.ScheduleObj{Type: scheduleType})
+					// Random cron expression and random time need to be passed to the API, even though they are not used, otherwise it returns bad request
+					randomCron := "0 * * * * *"
+					randomTime := strfmt.DateTime{}
+					return api.UpdateScanAllSchedule(models.ScheduleObj{Type: scheduleType, Cron: randomCron, NextScheduledTime: randomTime})
 				} else if scheduleType == "Custom" {
 					if cron != "" {
-						return api.UpdateScanAllSchedule(models.ScheduleObj{Type: "Schedule", Cron: cron})
+						// Random time need to be passed to the API, same reason as above
+						randomTime := strfmt.DateTime{}
+						return api.UpdateScanAllSchedule(models.ScheduleObj{Type: "Schedule", Cron: cron, NextScheduledTime: randomTime})
 					} else {
 						update.UpdateSchedule(&cron)
-						return api.UpdateScanAllSchedule(models.ScheduleObj{Type: "Schedule", Cron: cron})
+						// Random time need to be passed to the API, same reason as above
+						randomTime := strfmt.DateTime{}
+						return api.UpdateScanAllSchedule(models.ScheduleObj{Type: "Schedule", Cron: cron, NextScheduledTime: randomTime})
 					}
 				} else {
 					return errors.New("invalid schedule type")
@@ -45,7 +53,7 @@ func UpdateScanAllScheduleCommand() *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.StringVar(&cron, "cron", "", "Cron expression")
+	flags.StringVar(&cron, "cron", "", "Cron expression (include the expression in double quotes)")
 
 	return cmd
 }

--- a/cmd/harbor/root/scan-all/update_schedule.go
+++ b/cmd/harbor/root/scan-all/update_schedule.go
@@ -13,8 +13,9 @@ func UpdateScanAllScheduleCommand() *cobra.Command {
 	var cron string
 
 	cmd := &cobra.Command{
-		Use:   "update-schedule",
-		Short: "update-schedule [schedule-type: None|Hourly|Daily|Weekly|Custom|Now]",
+		Use:     "update-schedule",
+		Short:   "update-schedule [schedule-type: None|Hourly|Daily|Weekly|Custom]",
+		Aliases: []string{"us"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return errors.New("schedule type is required")
@@ -24,8 +25,6 @@ func UpdateScanAllScheduleCommand() *cobra.Command {
 				scheduleType = args[0]
 				if scheduleType == "None" {
 					return api.UpdateScanAllSchedule(models.ScheduleObj{Type: "None"})
-				} else if scheduleType == "Now" {
-					return api.UpdateScanAllSchedule(models.ScheduleObj{Type: "Manual"})
 				} else if scheduleType == "Hourly" || scheduleType == "Daily" || scheduleType == "Weekly" {
 					return api.UpdateScanAllSchedule(models.ScheduleObj{Type: scheduleType})
 				} else if scheduleType == "Custom" {

--- a/cmd/harbor/root/scan-all/update_schedule.go
+++ b/cmd/harbor/root/scan-all/update_schedule.go
@@ -1,0 +1,49 @@
+package scan_all
+
+import (
+	"errors"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/views/scan-all/update"
+	"github.com/spf13/cobra"
+)
+
+func UpdateScanAllScheduleCommand() *cobra.Command {
+	var scheduleType string
+	var cron string
+
+	cmd := &cobra.Command{
+		Use:   "update-schedule",
+		Short: "update-schedule [schedule-type: None|Hourly|Daily|Weekly|Custom|Now]",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return errors.New("schedule type is required")
+			} else if len(args) > 1 {
+				return errors.New("too many arguments")
+			} else {
+				scheduleType = args[0]
+				if scheduleType == "None" {
+					return api.UpdateScanAllSchedule(models.ScheduleObj{Type: "None"})
+				} else if scheduleType == "Now" {
+					return api.UpdateScanAllSchedule(models.ScheduleObj{Type: "Manual"})
+				} else if scheduleType == "Hourly" || scheduleType == "Daily" || scheduleType == "Weekly" {
+					return api.UpdateScanAllSchedule(models.ScheduleObj{Type: scheduleType})
+				} else if scheduleType == "Custom" {
+					if cron != "" {
+						return api.UpdateScanAllSchedule(models.ScheduleObj{Type: "Schedule", Cron: cron})
+					} else {
+						update.UpdateSchedule(&cron)
+						return api.UpdateScanAllSchedule(models.ScheduleObj{Type: "Schedule", Cron: cron})
+					}
+				} else {
+					return errors.New("invalid schedule type")
+				}
+			}
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&cron, "cron", "", "Cron expression")
+
+	return cmd
+}

--- a/cmd/harbor/root/scan-all/update_schedule.go
+++ b/cmd/harbor/root/scan-all/update_schedule.go
@@ -6,6 +6,9 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/views/scan-all/update"
 	"github.com/spf13/cobra"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+	"strings"
 )
 
 func UpdateScanAllScheduleCommand() *cobra.Command {
@@ -14,7 +17,7 @@ func UpdateScanAllScheduleCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "update-schedule",
-		Short:   "update-schedule [schedule-type: None|Hourly|Daily|Weekly|Custom]",
+		Short:   "update-schedule [schedule-type: none|hourly|daily|weekly|custom]",
 		Aliases: []string{"us"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
@@ -22,7 +25,7 @@ func UpdateScanAllScheduleCommand() *cobra.Command {
 			} else if len(args) > 1 {
 				return errors.New("too many arguments")
 			} else {
-				scheduleType = args[0]
+				scheduleType = cases.Title(language.English).String(strings.ToLower(args[0]))
 				if scheduleType == "None" {
 					return api.UpdateScanAllSchedule(models.ScheduleObj{Type: "None"})
 				} else if scheduleType == "Hourly" || scheduleType == "Daily" || scheduleType == "Weekly" {

--- a/cmd/harbor/root/scan-all/view_schedule.go
+++ b/cmd/harbor/root/scan-all/view_schedule.go
@@ -1,0 +1,26 @@
+package scan_all
+
+import (
+	"fmt"
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/spf13/cobra"
+)
+
+func ViewScanAllScheduleCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "view-schedule",
+		Short: "View the scan all schedule",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			schedule, err := api.GetScanAllSchedule()
+			if err != nil {
+				return err
+			}
+			fmt.Println("Current cron: ", schedule.Cron)
+			fmt.Println("Current next scan time: ", schedule.NextScheduledTime)
+			fmt.Println("Current scan all type: ", schedule.Type)
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cmd/harbor/root/scan-all/view_schedule.go
+++ b/cmd/harbor/root/scan-all/view_schedule.go
@@ -6,10 +6,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// This command does not work because the API does not return the response body
+// API: https://demo.goharbor.io/devcenter-api-2.0
 func ViewScanAllScheduleCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "view-schedule",
-		Short: "View the scan all schedule",
+		Use:     "view-schedule",
+		Short:   "View the scan all schedule",
+		Aliases: []string{"vs"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			schedule, err := api.GetScanAllSchedule()
 			if err != nil {

--- a/pkg/api/scan_all_handler.go
+++ b/pkg/api/scan_all_handler.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/scan_all"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	log "github.com/sirupsen/logrus"
+)
+
+func UpdateScanAllSchedule(schedule models.ScheduleObj) error {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return err
+	}
+
+	response, err := client.ScanAll.UpdateScanAllSchedule(ctx, &scan_all.UpdateScanAllScheduleParams{Schedule: &models.Schedule{Schedule: &schedule}})
+
+	if err != nil {
+		return err
+	}
+
+	if response != nil {
+		log.Info("Schedule updated successfully")
+	}
+	return nil
+}
+
+func StopScanAll() error {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return err
+	}
+
+	response, err := client.ScanAll.StopScanAll(ctx, &scan_all.StopScanAllParams{})
+
+	if err != nil {
+		return err
+	}
+
+	if response != nil {
+		log.Info("Scan all stopped successfully")
+	}
+	return nil
+}
+
+func GetScanAllSchedule() (*models.ScheduleObj, error) {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := client.ScanAll.GetScanAllSchedule(ctx, &scan_all.GetScanAllScheduleParams{})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Payload.Schedule, nil
+}
+
+func GetScanAllMetrics(scheduled bool) (*models.Stats, error) {
+	ctx, client, clientErr := utils.ContextWithClient()
+	if clientErr != nil {
+		return nil, clientErr
+	}
+
+	var response interface{}
+	var responseErr error
+	if scheduled {
+		response, responseErr = client.ScanAll.GetLatestScheduledScanAllMetrics(ctx, &scan_all.GetLatestScheduledScanAllMetricsParams{})
+	} else {
+		response, responseErr = client.ScanAll.GetLatestScanAllMetrics(ctx, &scan_all.GetLatestScanAllMetricsParams{})
+	}
+
+	if responseErr != nil {
+		return nil, responseErr
+	}
+
+	return response.(*models.Stats), nil
+}

--- a/pkg/api/scan_all_handler.go
+++ b/pkg/api/scan_all_handler.go
@@ -7,6 +7,25 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+func CreateScanAllSchedule(schedule models.ScheduleObj) error {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return err
+	}
+
+	response, err := client.ScanAll.CreateScanAllSchedule(ctx, &scan_all.CreateScanAllScheduleParams{Schedule: &models.Schedule{Schedule: &schedule}})
+
+	if err != nil {
+		return err
+	}
+
+	if response != nil {
+		// The CreateScanAllSchedule API is used only for scanning all artifacts now
+		log.Info("Scan started successfully")
+	}
+	return nil
+}
+
 func UpdateScanAllSchedule(schedule models.ScheduleObj) error {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {

--- a/pkg/api/scan_all_handler.go
+++ b/pkg/api/scan_all_handler.go
@@ -64,17 +64,17 @@ func GetScanAllMetrics(scheduled bool) (*models.Stats, error) {
 		return nil, clientErr
 	}
 
-	var response interface{}
-	var responseErr error
 	if scheduled {
-		response, responseErr = client.ScanAll.GetLatestScheduledScanAllMetrics(ctx, &scan_all.GetLatestScheduledScanAllMetricsParams{})
+		response, responseErr := client.ScanAll.GetLatestScheduledScanAllMetrics(ctx, &scan_all.GetLatestScheduledScanAllMetricsParams{})
+		if responseErr != nil {
+			return nil, responseErr
+		}
+		return response.Payload, nil
 	} else {
-		response, responseErr = client.ScanAll.GetLatestScanAllMetrics(ctx, &scan_all.GetLatestScanAllMetricsParams{})
+		response, responseErr := client.ScanAll.GetLatestScanAllMetrics(ctx, &scan_all.GetLatestScanAllMetricsParams{})
+		if responseErr != nil {
+			return nil, responseErr
+		}
+		return response.Payload, nil
 	}
-
-	if responseErr != nil {
-		return nil, responseErr
-	}
-
-	return response.(*models.Stats), nil
 }

--- a/pkg/views/scan-all/update/view.go
+++ b/pkg/views/scan-all/update/view.go
@@ -1,0 +1,28 @@
+package update
+
+import (
+	"errors"
+	"github.com/charmbracelet/huh"
+	log "github.com/sirupsen/logrus"
+)
+
+func UpdateSchedule(cron *string) {
+	theme := huh.ThemeCharm()
+	err := huh.NewForm(
+		huh.NewGroup(
+			huh.NewInput().
+				Title("Enter the cron").
+				Value(cron).
+				Validate(func(str string) error {
+					if str == "" {
+						return errors.New("cron cannot be empty")
+					}
+					return nil
+				}),
+		),
+	).WithTheme(theme).Run()
+
+	if err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
This PR adds the command for scanning all artifacts.

When updating the schedule, in case of custom schedule, the schedule is shown as a cron in the web UI when updated using the [swagger API](https://demo.goharbor.io/devcenter-api-2.0), but it does not show the cron when updated using the command line. It only prints `Scheduled`.