### PR TITLE
Add Ping command  

### DIFF
--- a/cmd/harbor/root/cmd.go
+++ b/cmd/harbor/root/cmd.go
@@ -104,6 +104,7 @@ harbor help
 	root.AddCommand(
 		versionCommand(),
 		LoginCommand(),
+		GetPing(),
 		project.Project(),
 		registry.Registry(),
 		repositry.Repository(),

--- a/cmd/harbor/root/ping.go
+++ b/cmd/harbor/root/ping.go
@@ -8,7 +8,7 @@ import (
     "github.com/goharbor/go-client/pkg/sdk/v2.0/client/ping"
 )
 
-func GetPing() *cobra.Command {
+func PingCommand() *cobra.Command {
     cmd := &cobra.Command{
         Use:   "ping",
         Short: "Ping the Harbor API server",

--- a/cmd/harbor/root/ping.go
+++ b/cmd/harbor/root/ping.go
@@ -19,7 +19,7 @@ func GetPing() *cobra.Command {
                 return err
             }
 
-            // Initialize params even if not used
+            //Initialize params even if not used
             params := &ping.GetPingParams{}
 
             response, err := client.Ping.GetPing(ctx, params)

--- a/cmd/harbor/root/ping.go
+++ b/cmd/harbor/root/ping.go
@@ -19,7 +19,7 @@ func GetPing() *cobra.Command {
                 return err
             }
 
-            //Initialize params even if not used
+            // Initialize params even if not used
             params := &ping.GetPingParams{}
 
             response, err := client.Ping.GetPing(ctx, params)

--- a/cmd/harbor/root/ping.go
+++ b/cmd/harbor/root/ping.go
@@ -1,0 +1,37 @@
+package root
+
+import (
+    "fmt"
+    "github.com/goharbor/harbor-cli/pkg/utils"
+    "github.com/spf13/cobra"
+    "github.com/sirupsen/logrus"
+    "github.com/goharbor/go-client/pkg/sdk/v2.0/client/ping"
+)
+
+func GetPing() *cobra.Command {
+    cmd := &cobra.Command{
+        Use:   "ping",
+        Short: "Ping the Harbor API server",
+        RunE: func(cmd *cobra.Command, args []string) error {
+            ctx, client, err := utils.ContextWithClient()
+            if err != nil {
+                logrus.Errorf("failed to get client: %v", err)
+                return err
+            }
+
+            // Initialize params even if not used
+            params := &ping.GetPingParams{}
+
+            response, err := client.Ping.GetPing(ctx, params)
+            if err != nil {
+                logrus.Errorf("ping request failed: %v", err)
+                return err
+            }
+
+            fmt.Printf("Ping successful: %s\n", response.Payload)
+            return nil
+        },
+    }
+
+    return cmd
+}


### PR DESCRIPTION
Implemented the ping command for the Harbor CLI. It uses the Harbor SDK to send a ping request and outputs the server's response. Includes basic error handling and logging. Issue #152 

![ping](https://github.com/user-attachments/assets/ef4d746e-576f-4103-b824-27bbbedc9048)


