### PR TITLE
feat: add support for the generation of cli docs for harbor

### DIFF
--- a/cmd/harbor/root/cmd.go
+++ b/cmd/harbor/root/cmd.go
@@ -93,7 +93,7 @@ harbor help
 	cobra.OnInitialize(InitConfig)
 
 	root.PersistentFlags().StringVarP(&output, "output-format", "o", "", "Output format. One of: json|yaml")
-	root.PersistentFlags().StringVar(&cfgFile, "config", utils.DefaultConfigPath, "config file (default is $HOME/.harbor/config.yaml)")
+	root.PersistentFlags().StringVar(&cfgFile, "config", utils.DefaultConfigPath, "config file")
 	root.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
 
 	err := viper.BindPFlag("output-format", root.PersistentFlags().Lookup("output-format"))
@@ -104,6 +104,7 @@ harbor help
 	root.AddCommand(
 		versionCommand(),
 		LoginCommand(),
+		GenerateDocs(),
 		project.Project(),
 		registry.Registry(),
 		repositry.Repository(),

--- a/cmd/harbor/root/doc.go
+++ b/cmd/harbor/root/doc.go
@@ -1,0 +1,71 @@
+package root
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+)
+func GenerateDocs() *cobra.Command {
+
+	cmd := &cobra.Command{ 
+		Use: "gen-docs",
+		Short: "Generate documentation for Harbor CLI",
+		Long:   `Generate documentation for Harbor CLI`,
+		Hidden: true,
+		Run: func (cmd *cobra.Command, args []string) {
+			path, err:= cmd.Flags().GetString("dir")
+			if err != nil {
+				log.Fatal(err)
+			}
+			if path == "" {
+				path = "docs"
+			}
+			err = os.MkdirAll(path, os.ModePerm)
+			if err != nil {
+				log.Fatal(err)
+			}
+			err = doc.GenYamlTree(cmd.Root(), path)
+			if err != nil {
+				log.Fatal(err)
+			}
+			homeDir, err := os.UserHomeDir()
+			if err != nil {
+				log.Fatal(err)
+			}
+			err = replaceHomeDirWithEnvVar(path, homeDir, "$HOME")
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			log.Infof("Documentation generated in %s", path)
+		},
+	}
+
+	cmd.Flags().String("dir", "", "Directory to generate documentation in")
+	return cmd
+
+}
+
+func replaceHomeDirWithEnvVar(path, homeDir, envVar string) error {
+	return filepath.Walk(path, func(filePath string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			content, err := os.ReadFile(filePath)
+			if err != nil {
+				return err
+			}
+			updatedContent := strings.ReplaceAll(string(content), homeDir, envVar)
+			err = os.WriteFile(filePath, []byte(updatedContent), info.Mode())
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}

--- a/docs/harbor.yaml
+++ b/docs/harbor.yaml
@@ -1,0 +1,33 @@
+name: harbor
+synopsis: Official Harbor CLI
+description: Official Harbor CLI
+options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for harbor
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+example: |4
+    // Base command:
+    harbor
+
+    // Display help about the command:
+    harbor help
+see_also:
+    - harbor artifact - Manage artifacts
+    - harbor completion - Generate the autocompletion script for the specified shell
+    - harbor login - Log in to Harbor registry
+    - harbor project - Manage projects and assign resources to them
+    - harbor registry - Manage registries
+    - harbor repo - Manage repositories
+    - harbor user - Manage users
+    - harbor version - Version of Harbor CLI

--- a/docs/harbor_artifact.yaml
+++ b/docs/harbor_artifact.yaml
@@ -1,0 +1,27 @@
+name: harbor artifact
+synopsis: Manage artifacts
+description: Manage artifacts in Harbor Repository
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for artifact
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+example: '  harbor artifact list'
+see_also:
+    - harbor - Official Harbor CLI
+    - harbor artifact delete - delete an artifact
+    - harbor artifact info - Get info of an artifact
+    - harbor artifact list - list artifacts within a repository
+    - harbor artifact scan - Scan an artifact
+    - harbor artifact tags - Manage tags of an artifact

--- a/docs/harbor_artifact_delete.yaml
+++ b/docs/harbor_artifact_delete.yaml
@@ -1,0 +1,21 @@
+name: harbor artifact delete
+synopsis: delete an artifact
+usage: harbor artifact delete [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for delete
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+see_also:
+    - harbor artifact - Manage artifacts

--- a/docs/harbor_artifact_info.yaml
+++ b/docs/harbor_artifact_info.yaml
@@ -1,0 +1,23 @@
+name: harbor artifact info
+synopsis: Get info of an artifact
+description: Get info of an artifact
+usage: harbor artifact info [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for info
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+example: harbor artifact info <project>/<repository>/<reference>
+see_also:
+    - harbor artifact - Manage artifacts

--- a/docs/harbor_artifact_list.yaml
+++ b/docs/harbor_artifact_list.yaml
@@ -1,0 +1,21 @@
+name: harbor artifact list
+synopsis: list artifacts within a repository
+usage: harbor artifact list [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for list
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+see_also:
+    - harbor artifact - Manage artifacts

--- a/docs/harbor_artifact_scan.yaml
+++ b/docs/harbor_artifact_scan.yaml
@@ -1,0 +1,24 @@
+name: harbor artifact scan
+synopsis: Scan an artifact
+description: Scan an artifact in Harbor Repository
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for scan
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+example: harbor artifact scan start <project>/<repository>/<reference>
+see_also:
+    - harbor artifact - Manage artifacts
+    - harbor artifact scan start - Start a scan of an artifact
+    - harbor artifact scan stop - Stop a scan of an artifact

--- a/docs/harbor_artifact_scan_start.yaml
+++ b/docs/harbor_artifact_scan_start.yaml
@@ -1,0 +1,23 @@
+name: harbor artifact scan start
+synopsis: Start a scan of an artifact
+description: Start a scan of an artifact in Harbor Repository
+usage: harbor artifact scan start [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for start
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+example: harbor artifact scan start <project>/<repository>/<reference>
+see_also:
+    - harbor artifact scan - Scan an artifact

--- a/docs/harbor_artifact_scan_stop.yaml
+++ b/docs/harbor_artifact_scan_stop.yaml
@@ -1,0 +1,23 @@
+name: harbor artifact scan stop
+synopsis: Stop a scan of an artifact
+description: Stop a scan of an artifact in Harbor Repository
+usage: harbor artifact scan stop [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for stop
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+example: harbor artifact scan stop <project>/<repository>/<reference>
+see_also:
+    - harbor artifact scan - Scan an artifact

--- a/docs/harbor_artifact_tags.yaml
+++ b/docs/harbor_artifact_tags.yaml
@@ -1,0 +1,24 @@
+name: harbor artifact tags
+synopsis: Manage tags of an artifact
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for tags
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+example: ' harbor artifact tags list <project>/<repository>/<reference>'
+see_also:
+    - harbor artifact - Manage artifacts
+    - harbor artifact tags create - Create a tag of an artifact
+    - harbor artifact tags delete - Delete a tag of an artifact
+    - harbor artifact tags list - List tags of an artifact

--- a/docs/harbor_artifact_tags_create.yaml
+++ b/docs/harbor_artifact_tags_create.yaml
@@ -1,0 +1,22 @@
+name: harbor artifact tags create
+synopsis: Create a tag of an artifact
+usage: harbor artifact tags create [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for create
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+example: harbor artifact tags create <project>/<repository>/<reference> <tag>
+see_also:
+    - harbor artifact tags - Manage tags of an artifact

--- a/docs/harbor_artifact_tags_delete.yaml
+++ b/docs/harbor_artifact_tags_delete.yaml
@@ -1,0 +1,22 @@
+name: harbor artifact tags delete
+synopsis: Delete a tag of an artifact
+usage: harbor artifact tags delete [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for delete
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+example: harbor artifact tags delete <project>/<repository>/<reference> <tag>
+see_also:
+    - harbor artifact tags - Manage tags of an artifact

--- a/docs/harbor_artifact_tags_list.yaml
+++ b/docs/harbor_artifact_tags_list.yaml
@@ -1,0 +1,22 @@
+name: harbor artifact tags list
+synopsis: List tags of an artifact
+usage: harbor artifact tags list [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for list
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+example: harbor artifact tags list <project>/<repository>/<reference>
+see_also:
+    - harbor artifact tags - Manage tags of an artifact

--- a/docs/harbor_completion.yaml
+++ b/docs/harbor_completion.yaml
@@ -1,0 +1,27 @@
+name: harbor completion
+synopsis: Generate the autocompletion script for the specified shell
+description: |
+    Generate the autocompletion script for harbor for the specified shell.
+    See each sub-command's help for details on how to use the generated script.
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for completion
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+see_also:
+    - harbor - Official Harbor CLI
+    - harbor completion bash - Generate the autocompletion script for bash
+    - harbor completion fish - Generate the autocompletion script for fish
+    - harbor completion powershell - Generate the autocompletion script for powershell
+    - harbor completion zsh - Generate the autocompletion script for zsh

--- a/docs/harbor_completion_bash.yaml
+++ b/docs/harbor_completion_bash.yaml
@@ -1,0 +1,45 @@
+name: harbor completion bash
+synopsis: Generate the autocompletion script for bash
+description: |
+    Generate the autocompletion script for the bash shell.
+
+    This script depends on the 'bash-completion' package.
+    If it is not installed already, you can install it via your OS's package manager.
+
+    To load completions in your current shell session:
+
+    	source <(harbor completion bash)
+
+    To load completions for every new session, execute once:
+
+    #### Linux:
+
+    	harbor completion bash > /etc/bash_completion.d/harbor
+
+    #### macOS:
+
+    	harbor completion bash > $(brew --prefix)/etc/bash_completion.d/harbor
+
+    You will need to start a new shell for this setup to take effect.
+usage: harbor completion bash
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for bash
+    - name: no-descriptions
+      default_value: "false"
+      usage: disable completion descriptions
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+see_also:
+    - harbor completion - Generate the autocompletion script for the specified shell

--- a/docs/harbor_completion_fish.yaml
+++ b/docs/harbor_completion_fish.yaml
@@ -1,0 +1,36 @@
+name: harbor completion fish
+synopsis: Generate the autocompletion script for fish
+description: |
+    Generate the autocompletion script for the fish shell.
+
+    To load completions in your current shell session:
+
+    	harbor completion fish | source
+
+    To load completions for every new session, execute once:
+
+    	harbor completion fish > ~/.config/fish/completions/harbor.fish
+
+    You will need to start a new shell for this setup to take effect.
+usage: harbor completion fish [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for fish
+    - name: no-descriptions
+      default_value: "false"
+      usage: disable completion descriptions
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+see_also:
+    - harbor completion - Generate the autocompletion script for the specified shell

--- a/docs/harbor_completion_powershell.yaml
+++ b/docs/harbor_completion_powershell.yaml
@@ -1,0 +1,33 @@
+name: harbor completion powershell
+synopsis: Generate the autocompletion script for powershell
+description: |
+    Generate the autocompletion script for powershell.
+
+    To load completions in your current shell session:
+
+    	harbor completion powershell | Out-String | Invoke-Expression
+
+    To load completions for every new session, add the output of the above command
+    to your powershell profile.
+usage: harbor completion powershell [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for powershell
+    - name: no-descriptions
+      default_value: "false"
+      usage: disable completion descriptions
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+see_also:
+    - harbor completion - Generate the autocompletion script for the specified shell

--- a/docs/harbor_completion_zsh.yaml
+++ b/docs/harbor_completion_zsh.yaml
@@ -1,0 +1,47 @@
+name: harbor completion zsh
+synopsis: Generate the autocompletion script for zsh
+description: |
+    Generate the autocompletion script for the zsh shell.
+
+    If shell completion is not already enabled in your environment you will need
+    to enable it.  You can execute the following once:
+
+    	echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+    To load completions in your current shell session:
+
+    	source <(harbor completion zsh)
+
+    To load completions for every new session, execute once:
+
+    #### Linux:
+
+    	harbor completion zsh > "${fpath[1]}/_harbor"
+
+    #### macOS:
+
+    	harbor completion zsh > $(brew --prefix)/share/zsh/site-functions/_harbor
+
+    You will need to start a new shell for this setup to take effect.
+usage: harbor completion zsh [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for zsh
+    - name: no-descriptions
+      default_value: "false"
+      usage: disable completion descriptions
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+see_also:
+    - harbor completion - Generate the autocompletion script for the specified shell

--- a/docs/harbor_login.yaml
+++ b/docs/harbor_login.yaml
@@ -1,0 +1,30 @@
+name: harbor login
+synopsis: Log in to Harbor registry
+description: Authenticate with Harbor Registry.
+usage: harbor login [server] [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for login
+    - name: name
+      usage: name for the set of credentials
+    - name: password
+      shorthand: p
+      usage: Password
+    - name: username
+      shorthand: u
+      usage: Username
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+see_also:
+    - harbor - Official Harbor CLI

--- a/docs/harbor_project.yaml
+++ b/docs/harbor_project.yaml
@@ -1,0 +1,27 @@
+name: harbor project
+synopsis: Manage projects and assign resources to them
+description: Manage projects in Harbor
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for project
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+example: '  harbor project list'
+see_also:
+    - harbor - Official Harbor CLI
+    - harbor project create - create project
+    - harbor project delete - delete project by name or id
+    - harbor project list - list project
+    - harbor project logs - get project logs
+    - harbor project view - get project by name or id

--- a/docs/harbor_project_create.yaml
+++ b/docs/harbor_project_create.yaml
@@ -1,0 +1,33 @@
+name: harbor project create
+synopsis: create project
+usage: harbor project create [project name] [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for create
+    - name: proxy-cache
+      default_value: "false"
+      usage: Whether the project is a proxy cache project
+    - name: public
+      default_value: "false"
+      usage: Project is public or private
+    - name: registry-id
+      usage: |
+        ID of referenced registry when creating the proxy cache project
+    - name: storage-limit
+      default_value: "-1"
+      usage: Storage quota of the project
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+see_also:
+    - harbor project - Manage projects and assign resources to them

--- a/docs/harbor_project_delete.yaml
+++ b/docs/harbor_project_delete.yaml
@@ -1,0 +1,21 @@
+name: harbor project delete
+synopsis: delete project by name or id
+usage: harbor project delete [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for delete
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+see_also:
+    - harbor project - Manage projects and assign resources to them

--- a/docs/harbor_project_list.yaml
+++ b/docs/harbor_project_list.yaml
@@ -1,0 +1,37 @@
+name: harbor project list
+synopsis: list project
+usage: harbor project list [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for list
+    - name: name
+      usage: Name of the project
+    - name: page
+      default_value: "1"
+      usage: Page number
+    - name: page-size
+      default_value: "10"
+      usage: Size of per page
+    - name: public
+      default_value: "false"
+      usage: Project is public or private
+    - name: query
+      shorthand: q
+      usage: Query string to query resources
+    - name: sort
+      usage: Sort the resource list in ascending or descending order
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+see_also:
+    - harbor project - Manage projects and assign resources to them

--- a/docs/harbor_project_logs.yaml
+++ b/docs/harbor_project_logs.yaml
@@ -1,0 +1,21 @@
+name: harbor project logs
+synopsis: get project logs
+usage: harbor project logs [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for logs
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+see_also:
+    - harbor project - Manage projects and assign resources to them

--- a/docs/harbor_project_view.yaml
+++ b/docs/harbor_project_view.yaml
@@ -1,0 +1,21 @@
+name: harbor project view
+synopsis: get project by name or id
+usage: harbor project view [NAME|ID] [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for view
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+see_also:
+    - harbor project - Manage projects and assign resources to them

--- a/docs/harbor_registry.yaml
+++ b/docs/harbor_registry.yaml
@@ -1,0 +1,28 @@
+name: harbor registry
+synopsis: Manage registries
+description: Manage registries in Harbor
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for registry
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+example: '  harbor registry list'
+see_also:
+    - harbor - Official Harbor CLI
+    - harbor registry create - create registry
+    - harbor registry delete - delete registry by id
+    - harbor registry info - get registry info
+    - harbor registry list - list registry
+    - harbor registry update - update registry
+    - harbor registry view - get registry by id

--- a/docs/harbor_registry_create.yaml
+++ b/docs/harbor_registry_create.yaml
@@ -1,0 +1,39 @@
+name: harbor registry create
+synopsis: create registry
+usage: harbor registry create [flags]
+options:
+    - name: credential-access-key
+      usage: Access key, e.g. user name when credential type is 'basic'
+    - name: credential-access-secret
+      usage: Access secret, e.g. password when credential type is 'basic'
+    - name: credential-type
+      default_value: basic
+      usage: Credential type, such as 'basic', 'oauth'
+    - name: description
+      usage: Description of the registry
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for create
+    - name: insecure
+      default_value: "true"
+      usage: Whether Harbor will verify the server certificate
+    - name: name
+      usage: Name of the registry
+    - name: type
+      usage: Type of the registry
+    - name: url
+      usage: Registry endpoint URL
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+see_also:
+    - harbor registry - Manage registries

--- a/docs/harbor_registry_delete.yaml
+++ b/docs/harbor_registry_delete.yaml
@@ -1,0 +1,21 @@
+name: harbor registry delete
+synopsis: delete registry by id
+usage: harbor registry delete [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for delete
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+see_also:
+    - harbor registry - Manage registries

--- a/docs/harbor_registry_info.yaml
+++ b/docs/harbor_registry_info.yaml
@@ -1,0 +1,21 @@
+name: harbor registry info
+synopsis: get registry info
+usage: harbor registry info [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for info
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+see_also:
+    - harbor registry - Manage registries

--- a/docs/harbor_registry_list.yaml
+++ b/docs/harbor_registry_list.yaml
@@ -1,0 +1,32 @@
+name: harbor registry list
+synopsis: list registry
+usage: harbor registry list [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for list
+    - name: page
+      default_value: "1"
+      usage: Page number
+    - name: page-size
+      default_value: "10"
+      usage: Size of per page
+    - name: query
+      shorthand: q
+      usage: Query string to query resources
+    - name: sort
+      usage: Sort the resource list in ascending or descending order
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+see_also:
+    - harbor registry - Manage registries

--- a/docs/harbor_registry_update.yaml
+++ b/docs/harbor_registry_update.yaml
@@ -1,0 +1,39 @@
+name: harbor registry update
+synopsis: update registry
+usage: harbor registry update [flags]
+options:
+    - name: credential-access-key
+      usage: Access key, e.g. user name when credential type is 'basic'
+    - name: credential-access-secret
+      usage: Access secret, e.g. password when credential type is 'basic'
+    - name: credential-type
+      usage: Credential type, such as 'basic', 'oauth'
+    - name: description
+      usage: Description of the registry
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for update
+    - name: insecure
+      default_value: "true"
+      usage: |
+        Whether or not the certificate will be verified when Harbor tries to access the server
+    - name: name
+      usage: Name of the registry
+    - name: type
+      usage: Type of the registry
+    - name: url
+      usage: Registry endpoint URL
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+see_also:
+    - harbor registry - Manage registries

--- a/docs/harbor_registry_view.yaml
+++ b/docs/harbor_registry_view.yaml
@@ -1,0 +1,21 @@
+name: harbor registry view
+synopsis: get registry by id
+usage: harbor registry view [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for view
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+see_also:
+    - harbor registry - Manage registries

--- a/docs/harbor_repo.yaml
+++ b/docs/harbor_repo.yaml
@@ -1,0 +1,24 @@
+name: harbor repo
+synopsis: Manage repositories
+description: Manage repositories in Harbor context
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for repo
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+see_also:
+    - harbor - Official Harbor CLI
+    - harbor repo delete - Delete a repository
+    - harbor repo info - Get repository information
+    - harbor repo list - list repositories within a project

--- a/docs/harbor_repo_delete.yaml
+++ b/docs/harbor_repo_delete.yaml
@@ -1,0 +1,23 @@
+name: harbor repo delete
+synopsis: Delete a repository
+description: Delete a repository within a project in Harbor
+usage: harbor repo delete [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for delete
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+example: '  harbor repository delete [project_name]/[repository_name]'
+see_also:
+    - harbor repo - Manage repositories

--- a/docs/harbor_repo_info.yaml
+++ b/docs/harbor_repo_info.yaml
@@ -1,0 +1,23 @@
+name: harbor repo info
+synopsis: Get repository information
+description: Get information of a particular repository in a project
+usage: harbor repo info [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for info
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+example: '  harbor repo info <project_name>/<repo_name>'
+see_also:
+    - harbor repo - Manage repositories

--- a/docs/harbor_repo_list.yaml
+++ b/docs/harbor_repo_list.yaml
@@ -1,0 +1,21 @@
+name: harbor repo list
+synopsis: list repositories within a project
+usage: harbor repo list [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for list
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+see_also:
+    - harbor repo - Manage repositories

--- a/docs/harbor_user.yaml
+++ b/docs/harbor_user.yaml
@@ -1,0 +1,26 @@
+name: harbor user
+synopsis: Manage users
+description: Manage users in Harbor
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for user
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+example: '  harbor user list'
+see_also:
+    - harbor - Official Harbor CLI
+    - harbor user create - create user
+    - harbor user delete - delete user
+    - harbor user elevate - elevate user
+    - harbor user list - list users

--- a/docs/harbor_user_create.yaml
+++ b/docs/harbor_user_create.yaml
@@ -1,0 +1,31 @@
+name: harbor user create
+synopsis: create user
+usage: harbor user create [flags]
+options:
+    - name: comment
+      usage: Comment
+    - name: email
+      usage: Email
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for create
+    - name: password
+      usage: Password
+    - name: realname
+      usage: Realname
+    - name: username
+      usage: Username
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+see_also:
+    - harbor user - Manage users

--- a/docs/harbor_user_delete.yaml
+++ b/docs/harbor_user_delete.yaml
@@ -1,0 +1,21 @@
+name: harbor user delete
+synopsis: delete user
+usage: harbor user delete [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for delete
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+see_also:
+    - harbor user - Manage users

--- a/docs/harbor_user_elevate.yaml
+++ b/docs/harbor_user_elevate.yaml
@@ -1,0 +1,22 @@
+name: harbor user elevate
+synopsis: elevate user
+description: elevate user to admin role
+usage: harbor user elevate [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for elevate
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+see_also:
+    - harbor user - Manage users

--- a/docs/harbor_user_list.yaml
+++ b/docs/harbor_user_list.yaml
@@ -1,0 +1,21 @@
+name: harbor user list
+synopsis: list users
+usage: harbor user list [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for list
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+see_also:
+    - harbor user - Manage users

--- a/docs/harbor_version.yaml
+++ b/docs/harbor_version.yaml
@@ -1,0 +1,24 @@
+name: harbor version
+synopsis: Version of Harbor CLI
+description: |
+    Get Harbor CLI version, git commit, go version, build time, release channel, os/arch, etc.
+usage: harbor version [flags]
+options:
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for version
+inherited_options:
+    - name: config
+      default_value: $HOME/.config/harbor/config.yaml
+      usage: config file
+    - name: output-format
+      shorthand: o
+      usage: 'Output format. One of: json|yaml'
+    - name: verbose
+      shorthand: v
+      default_value: "false"
+      usage: verbose output
+example: '  harbor version'
+see_also:
+    - harbor - Official Harbor CLI

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/charmbracelet/x/input v0.1.3 // indirect
 	github.com/charmbracelet/x/term v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.1.2 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
@@ -42,6 +43,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sagikazarmark/locafero v0.6.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/sahilm/fuzzy v0.1.1 // indirect
@@ -51,6 +53,7 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	golang.org/x/term v0.22.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,7 @@ github.com/charmbracelet/x/term v0.1.1 h1:3cosVAiPOig+EV4X9U+3LDgtwwAoEzJjNdwbXD
 github.com/charmbracelet/x/term v0.1.1/go.mod h1:wB1fHt5ECsu3mXYusyzcngVWWlu1KKUmmLhfgr/Flxw=
 github.com/charmbracelet/x/windows v0.1.2 h1:Iumiwq2G+BRmgoayww/qfcvof7W/3uLoelhxojXlRWg=
 github.com/charmbracelet/x/windows v0.1.2/go.mod h1:GLEO/l+lizvFDBPLIOk+49gdX49L9YWMB5t+DZd0jkQ=
+github.com/cpuguy83/go-md2man/v2 v2.0.4 h1:wfIWP927BUkWJb2NmU/kNDYIBTh/ziUX91+lVfRxZq4=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -135,6 +136,7 @@ github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.6.0 h1:ON7AQg37yzcRPU69mt7gwhFEBwxI6P9T4Qu3N51bwOk=
 github.com/sagikazarmark/locafero v0.6.0/go.mod h1:77OmuIc6VTraTXKXIs/uvUxKGUXjE1GbemJYHqdNjX0=
@@ -219,6 +221,8 @@ golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
 golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.22.0 h1:BbsgPEJULsl2fV/AT3v15Mjva5yXKQDyKf+TbDz7QJk=
+golang.org/x/term v0.22.0/go.mod h1:F3qCibpT5AMpCRfhfT53vVJwhLtIVHhB9XDjfFvnMI4=
 golang.org/x/text v0.16.0 h1:a94ExnEXNtEwYLGJSIUxnWoxoRz/ZcCsV63ROupILh4=
 golang.org/x/text v0.16.0/go.mod h1:GhwF1Be+LQoKShO3cGOHzqOgRrGaYc9AvblQOmPVHnI=
 google.golang.org/genproto/googleapis/api v0.0.0-20240725223205-93522f1f2a9f h1:b1Ln/PG8orm0SsBbHZWke8dDp2lrCD4jSmfglFpTZbk=

--- a/hack/doc.sh
+++ b/hack/doc.sh
@@ -1,0 +1,1 @@
+go run cmd/harbor/main.go gen-docs

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -26,11 +26,11 @@ var (
 )
 
 func SetLocation() {
-	home, err := os.UserHomeDir()
+	home, err := os.UserConfigDir()
 	if err != nil {
 		log.Fatal(err)
 	}
-	HarborFolder = filepath.Join(home, ".harbor")
+	HarborFolder = filepath.Join(home, "harbor")
 	DefaultConfigPath = filepath.Join(HarborFolder, "config.yaml")
 }
 


### PR DESCRIPTION
Hello Team, 

By adding support for generating YAML CLI documentation for Harbor, we can manage the documentation in one place and easily reference it on the Harbor website.

