### PR TITLE
Added detailed instructions for building from source on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ git clone https://github.com/goharbor/harbor-cli.git
 cd harbor-cli/cmd/harbor
 go build .
 ```
-Now, move harbor.exe to your preferred directory (e.g. C:\Program Files\harbor\`harbor.exe`)
+Now, move harbor.exe to your preferred directory (e.g. C:\Program Files\harbor\ `harbor.exe`)
 Add the directory to your PATH environment variable:
    - Open the Start menu and search for "Environment Variables"
    - Click on "Edit the system environment variables"

--- a/README.md
+++ b/README.md
@@ -102,12 +102,29 @@ Windows | ✅
 
 ## Build From Source
 
+### Linux and MacOS
 ```bash
 git clone https://github.com/goharbor/harbor-cli.git
 cd harbor-cli/cmd/harbor
 go build .
 sudo mv harbor /usr/local/bin/
 ```
+
+### Windows
+```bash
+git clone https://github.com/goharbor/harbor-cli.git
+cd harbor-cli/cmd/harbor
+go build .
+```
+Now, move harbor.exe to your preferred directory (e.g. C:\Program Files\harbor\`harbor.exe`)
+Add the directory to your PATH environment variable:
+   - Open the Start menu and search for "Environment Variables"
+   - Click on "Edit the system environment variables"
+   - Click the "Environment Variables" button
+   - Under "System variables", find and select the "Path" variable, then click "Edit"
+   - Click "New" and add the directory path (e.g., `C:\Program Files\harbor`)
+   - Click "OK" to close all dialogs
+
 
 ## Linux and MacOS
 


### PR DESCRIPTION
Update Windows build instructions in "build from source"

- Added steps for moving `harbor.exe` to a preferred directory (e.g., `C:\Program Files\harbor\`).
- Included detailed instructions for adding the directory to the PATH environment variable on Windows.
