### PR TITLE
feat: add cli for health status

### DIFF
--- a/cmd/harbor/root/cmd.go
+++ b/cmd/harbor/root/cmd.go
@@ -109,6 +109,7 @@ harbor help
 		repositry.Repository(),
 		user.User(),
 		artifact.Artifact(),
+		HealthCommand(),
 	)
 
 	return root

--- a/cmd/harbor/root/health.go
+++ b/cmd/harbor/root/health.go
@@ -1,0 +1,24 @@
+package root
+
+import (
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/spf13/cobra"
+	"github.com/goharbor/harbor-cli/pkg/views/health"
+)
+
+func HealthCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "health",
+		Short: "Get the health status of Harbor components",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			status, err := api.GetHealth()
+			if err != nil {
+				return err
+			}
+			health.PrintHealthStatus(status)
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/pkg/api/health_handler.go
+++ b/pkg/api/health_handler.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/health"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/spf13/viper"
+)
+
+func GetHealth() (*health.GetHealthOK, error) {
+	credentialName := viper.GetString("current-credential-name")
+	client := utils.GetClientByCredentialName(credentialName)
+
+	ctx := context.Background()
+	params := health.NewGetHealthParams().WithContext(ctx)
+
+	response, err := client.Health.GetHealth(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("error getting health status: %w", err)
+	}
+
+	return response, nil
+}
+
+ 

--- a/pkg/api/health_handler.go
+++ b/pkg/api/health_handler.go
@@ -10,10 +10,10 @@ import (
 )
 
 func GetHealth() (*health.GetHealthOK, error) {
-	credentialName := viper.GetString("current-credential-name")
-	client := utils.GetClientByCredentialName(credentialName)
-
-	ctx := context.Background()
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return err
+	}
 	params := health.NewGetHealthParams().WithContext(ctx)
 
 	response, err := client.Health.GetHealth(ctx, params)

--- a/pkg/api/health_handler.go
+++ b/pkg/api/health_handler.go
@@ -1,27 +1,22 @@
 package api
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/health"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	"github.com/spf13/viper"
 )
 
 func GetHealth() (*health.GetHealthOK, error) {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {
-		return err
+		return nil, err
 	}
-	params := health.NewGetHealthParams().WithContext(ctx)
 
-	response, err := client.Health.GetHealth(ctx, params)
+	response, err := client.Health.GetHealth(ctx,&health.GetHealthParams{})
 	if err != nil {
 		return nil, fmt.Errorf("error getting health status: %w", err)
 	}
 
 	return response, nil
 }
-
- 

--- a/pkg/views/health/view.go
+++ b/pkg/views/health/view.go
@@ -5,27 +5,32 @@ import (
 	"github.com/charmbracelet/bubbles/table"
 	"github.com/charmbracelet/bubbletea"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/health"
+	"github.com/goharbor/harbor-cli/pkg/views"
 	"github.com/goharbor/harbor-cli/pkg/views/base/tablelist"
 )
 
 var columns = []table.Column{
 	{Title: "Component", Width: 20},
-	{Title: "Status", Width: 20},
+	{Title: "Status", Width: 30},
 }
 
 type HealthModel struct {
 	tableModel tablelist.Model
 }
 
+func styleStatus(status string) string {
+	if status == "healthy" {
+		return views.GreenStyle.Render(status)
+	}
+	return views.RedStyle.Render(status)
+}
+
 func NewHealthModel(status *health.GetHealthOK) HealthModel {
 	var rows []table.Row
-
-	rows = append(rows, table.Row{"Overall", status.Payload.Status})
-
 	for _, component := range status.Payload.Components {
 		rows = append(rows, table.Row{
 			component.Name,
-			component.Status,
+			styleStatus(component.Status),
 		})
 	}
 	
@@ -35,8 +40,7 @@ func NewHealthModel(status *health.GetHealthOK) HealthModel {
 
 func PrintHealthStatus(status *health.GetHealthOK) {
 	m := NewHealthModel(status)
-	fmt.Println("Harbor Health Status:")
-	fmt.Printf("Status: %s\n", status.Payload.Status)
+	fmt.Printf("Harbor Health Status:: %s\n", styleStatus(status.Payload.Status))
 
 	p := tea.NewProgram(m.tableModel)
 	if _, err := p.Run(); err != nil {

--- a/pkg/views/health/view.go
+++ b/pkg/views/health/view.go
@@ -1,0 +1,46 @@
+package health
+
+import (
+	"fmt"
+	"github.com/charmbracelet/bubbles/table"
+	"github.com/charmbracelet/bubbletea"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/health"
+	"github.com/goharbor/harbor-cli/pkg/views/base/tablelist"
+)
+
+var columns = []table.Column{
+	{Title: "Component", Width: 20},
+	{Title: "Status", Width: 20},
+}
+
+type HealthModel struct {
+	tableModel tablelist.Model
+}
+
+func NewHealthModel(status *health.GetHealthOK) HealthModel {
+	var rows []table.Row
+
+	rows = append(rows, table.Row{"Overall", status.Payload.Status})
+
+	for _, component := range status.Payload.Components {
+		rows = append(rows, table.Row{
+			component.Name,
+			component.Status,
+		})
+	}
+	
+	tbl := tablelist.NewModel(columns, rows, len(rows)+1) // +1 for header
+	return HealthModel{tableModel: tbl}
+}
+
+func PrintHealthStatus(status *health.GetHealthOK) {
+	m := NewHealthModel(status)
+	fmt.Println("Harbor Health Status:")
+	fmt.Printf("Status: %s\n", status.Payload.Status)
+
+	p := tea.NewProgram(m.tableModel)
+	if _, err := p.Run(); err != nil {
+		fmt.Println("Error running program:", err)
+		return
+	}
+}

--- a/pkg/views/styles.go
+++ b/pkg/views/styles.go
@@ -11,6 +11,8 @@ var (
 	SelectedItemStyle = lipgloss.NewStyle().PaddingLeft(2).Foreground(lipgloss.Color("170"))
 	PaginationStyle   = list.DefaultStyles().PaginationStyle.PaddingLeft(4)
 	HelpStyle         = list.DefaultStyles().HelpStyle.PaddingLeft(4).PaddingBottom(1)
+	RedStyle          = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000"))
+	GreenStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("#04B575"))
 )
 
 var BaseStyle = lipgloss.NewStyle().


### PR DESCRIPTION
This pr provides a status check of various system components, allowing administrators to quickly assess the overall health and operational status of the Harbor registry system.

Command:
`harbor health` : Get the health status of Harbor components

![health](https://github.com/user-attachments/assets/2ac3450a-7019-4658-8f88-ee144e7c36bd)
