### PR TITLE
feat add statictic command

### DIFF
--- a/cmd/harbor/root/cmd.go
+++ b/cmd/harbor/root/cmd.go
@@ -109,6 +109,7 @@ harbor help
 		repositry.Repository(),
 		user.User(),
 		artifact.Artifact(),
+		StatisticCommand(),
 	)
 
 	return root

--- a/cmd/harbor/root/statistic.go
+++ b/cmd/harbor/root/statistic.go
@@ -1,0 +1,37 @@
+package root
+
+import (
+	"fmt"
+
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/statistic"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	statisticview "github.com/goharbor/harbor-cli/pkg/views/statistic"
+	"github.com/spf13/cobra"
+)
+
+func StatisticCommand() *cobra.Command {
+    return &cobra.Command{
+        Use:   "statistic",
+        Short: "Get statistics about Harbor projects and repositories",
+        RunE: func(cmd *cobra.Command, args []string) error {
+            ctx, client, err := utils.ContextWithClient()
+            if err != nil {
+                return fmt.Errorf("failed to create client: %w", err)
+            }
+
+            params := &statistic.GetStatisticParams{
+                Context: ctx,
+            }
+
+            stats, err := client.Statistic.GetStatistic(params.Context, params)
+            if err != nil {
+                return fmt.Errorf("failed to retrieve statistics: %w", err)
+            }
+			
+            statisticview.PrintStatistics(stats.Payload)
+
+            return nil
+        },
+    }
+}
+ 

--- a/pkg/api/statistic_handler.go
+++ b/pkg/api/statistic_handler.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	 
+	"fmt"
+	"net/http"
+
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/statistic"
+ 
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	log "github.com/sirupsen/logrus"
+)
+
+type StatisticHandler struct {
+	client *statistic.Client
+}
+
+func NewStatisticHandler() (*StatisticHandler, error) {
+	_, client, err := utils.ContextWithClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create statistic handler: %w", err)
+	}
+
+	return &StatisticHandler{client: client.Statistic}, nil
+}
+
+func (h *StatisticHandler) GetStatistics(w http.ResponseWriter, r *http.Request) {
+	params := &statistic.GetStatisticParams{
+		Context: r.Context(),
+	}
+
+	stats, err := h.client.GetStatistic(params.Context, params)
+	if err != nil {
+		log.Errorf("failed to retrieve statistics: %v", err)
+		http.Error(w, "failed to retrieve statistics", http.StatusInternalServerError)
+		return
+	}
+
+	responseData, err := stats.GetPayload().MarshalBinary()
+	if err != nil {
+		log.Errorf("failed to marshal statistics: %v", err)
+		http.Error(w, "failed to process statistics", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(responseData)
+}

--- a/pkg/views/statistic/view.go
+++ b/pkg/views/statistic/view.go
@@ -1,0 +1,32 @@
+package statisticview
+
+import (
+    "fmt"
+    "github.com/charmbracelet/bubbles/table"
+    "github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+    "github.com/goharbor/harbor-cli/pkg/views/base/tablelist"
+    tea "github.com/charmbracelet/bubbletea"
+    "os"
+)
+
+var columns = []table.Column{
+    {Title: "Metric", Width: 30},
+    {Title: "Value", Width: 20},
+}
+
+func PrintStatistics(stats *models.Statistic) {
+    rows := []table.Row{
+        {"Total Projects", fmt.Sprintf("%d", stats.TotalProjectCount)},
+        {"Public Projects", fmt.Sprintf("%d", stats.PublicProjectCount)},
+        {"Private Projects", fmt.Sprintf("%d", stats.PrivateProjectCount)},
+        {"Total Repositories", fmt.Sprintf("%d", stats.TotalRepoCount)},
+        {"Total Storage Consumption", fmt.Sprintf("%d", stats.TotalStorageConsumption)},
+    }
+
+    m := tablelist.NewModel(columns, rows, len(rows))
+
+    if _, err := tea.NewProgram(m).Run(); err != nil {
+        fmt.Println("Error running program:", err)
+        os.Exit(1)
+    }
+}


### PR DESCRIPTION
Add CLI and API commands to retrieve and display Harbor statistics.

Command:
`harbor statistic` : Get statistics about Harbor projects and repositories

![statistic](https://github.com/user-attachments/assets/f4f7b334-0b96-47c5-85af-398a83396a86)
