### PR TITLE
feat: add systeminfo cli command

### DIFF
--- a/cmd/harbor/root/cmd.go
+++ b/cmd/harbor/root/cmd.go
@@ -9,6 +9,7 @@ import (
 	"github.com/goharbor/harbor-cli/cmd/harbor/root/project"
 	"github.com/goharbor/harbor-cli/cmd/harbor/root/registry"
 	repositry "github.com/goharbor/harbor-cli/cmd/harbor/root/repository"
+	"github.com/goharbor/harbor-cli/cmd/harbor/root/systeminfo"
 	"github.com/goharbor/harbor-cli/cmd/harbor/root/user"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/spf13/cobra"
@@ -107,6 +108,7 @@ harbor help
 		project.Project(),
 		registry.Registry(),
 		repositry.Repository(),
+		systeminfo.NewSystemInfoCommand(),
 		user.User(),
 		artifact.Artifact(),
 	)

--- a/cmd/harbor/root/cmd.go
+++ b/cmd/harbor/root/cmd.go
@@ -108,7 +108,7 @@ harbor help
 		project.Project(),
 		registry.Registry(),
 		repositry.Repository(),
-		systeminfo.NewSystemInfoCommand(),
+		systeminfo.SystemInfoCommand(),
 		user.User(),
 		artifact.Artifact(),
 	)

--- a/cmd/harbor/root/systeminfo/cert.go
+++ b/cmd/harbor/root/systeminfo/cert.go
@@ -11,7 +11,7 @@ import (
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/systeminfo"
 )
 
-func newGetCertCommand() *cobra.Command {
+func GetCertCommand() *cobra.Command {
 	var outputFile string
 
 	cmd := &cobra.Command{

--- a/cmd/harbor/root/systeminfo/cert.go
+++ b/cmd/harbor/root/systeminfo/cert.go
@@ -1,0 +1,58 @@
+package systeminfo
+
+import (
+	"context"
+	"fmt"
+	"os"
+ 
+
+	"github.com/spf13/cobra"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/systeminfo"
+)
+
+func newGetCertCommand() *cobra.Command {
+	var outputFile string
+
+	cmd := &cobra.Command{
+		Use:   "cert",
+		Short: "Get the default root certificate",
+		Long:  `Download the default root certificate from the Harbor system.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := utils.GetClient()
+			if err != nil {
+				return fmt.Errorf("failed to get client: %w", err)
+			}
+			
+			if outputFile == "" {
+				outputFile = "harbor_root.crt"
+			}
+			file, err := os.Create(outputFile)
+			if err != nil {
+				return fmt.Errorf("failed to create output file: %w", err)
+			}
+			defer file.Close()
+			
+			params := systeminfo.NewGetCertParams()
+			_, err = client.Systeminfo.GetCert(context.Background(), params, file)
+			if err != nil {
+				switch err := err.(type) {
+				case *systeminfo.GetCertNotFound:
+					return fmt.Errorf("certificate not found. This could mean:\n" +
+						"1. The certificate endpoint is not available in your Harbor version\n" +
+						"2. Harbor is not configured to serve the root certificate\n" +
+						"3. You may not have the necessary permissions\n" +
+						"Please check your Harbor configuration and try again")
+				default:
+					return fmt.Errorf("failed to get certificate: %w", err)
+				}
+			}
+			
+			fmt.Printf("Certificate downloaded to %s\n", outputFile)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&outputFile, "output", "", "Output file for the certificate (default: harbor_root.crt)")
+
+	return cmd
+}

--- a/cmd/harbor/root/systeminfo/cmd.go
+++ b/cmd/harbor/root/systeminfo/cmd.go
@@ -5,7 +5,7 @@ import (
 
 )
 
-func NewSystemInfoCommand() *cobra.Command {
+func SystemInfoCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "systeminfo",
 		Short: "Interact with system information",
@@ -13,9 +13,9 @@ func NewSystemInfoCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		newGetInfoCommand(),
-		newGetVolumesCommand(),
-		newGetCertCommand(),
+		GetInfoCommand(),
+		GetVolumesCommand(),
+		GetCertCommand(),
 	)
 
 	return cmd

--- a/cmd/harbor/root/systeminfo/cmd.go
+++ b/cmd/harbor/root/systeminfo/cmd.go
@@ -1,0 +1,22 @@
+package systeminfo
+
+import (
+	"github.com/spf13/cobra"
+
+)
+
+func NewSystemInfoCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "systeminfo",
+		Short: "Interact with system information",
+		Long:  `Commands to interact with the Harbor system information, including general info, volumes, and certificates.`,
+	}
+
+	cmd.AddCommand(
+		newGetInfoCommand(),
+		newGetVolumesCommand(),
+		newGetCertCommand(),
+	)
+
+	return cmd
+}

--- a/cmd/harbor/root/systeminfo/info.go
+++ b/cmd/harbor/root/systeminfo/info.go
@@ -1,0 +1,33 @@
+package systeminfo
+
+import (
+	"context"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/systeminfo"
+	"github.com/goharbor/harbor-cli/pkg/views/systeminfo/info"
+)
+
+func newGetInfoCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "info",
+		Short: "Get general system information",
+		Long:  `Retrieve general information about the Harbor system.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := utils.GetClient()
+			if err != nil {
+				return fmt.Errorf("failed to get client: %w", err)
+			}
+			
+			params := systeminfo.NewGetSystemInfoParams()
+			resp, err := client.Systeminfo.GetSystemInfo(context.Background(), params)
+			if err != nil {
+				return fmt.Errorf("failed to get system info: %w", err)
+			}
+			
+			info.PrintSystemInfo(resp.Payload)   
+			return nil
+		},
+	}
+}

--- a/cmd/harbor/root/systeminfo/info.go
+++ b/cmd/harbor/root/systeminfo/info.go
@@ -9,7 +9,7 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/views/systeminfo/info"
 )
 
-func newGetInfoCommand() *cobra.Command {
+func GetInfoCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "info",
 		Short: "Get general system information",

--- a/cmd/harbor/root/systeminfo/volume.go
+++ b/cmd/harbor/root/systeminfo/volume.go
@@ -9,7 +9,7 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/views/systeminfo/volume"
 )
 
-func newGetVolumesCommand() *cobra.Command {
+func GetVolumesCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "volumes",
 		Short: "Get system volume information",

--- a/cmd/harbor/root/systeminfo/volume.go
+++ b/cmd/harbor/root/systeminfo/volume.go
@@ -1,0 +1,33 @@
+package systeminfo
+
+import (
+	"context"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/systeminfo"
+	"github.com/goharbor/harbor-cli/pkg/views/systeminfo/volume"
+)
+
+func newGetVolumesCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "volumes",
+		Short: "Get system volume information",
+		Long:  `Retrieve information about the volumes in the Harbor system.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := utils.GetClient()
+			if err != nil {
+				return fmt.Errorf("failed to get client: %w", err)
+			}
+			
+			params := systeminfo.NewGetVolumesParams()
+			resp, err := client.Systeminfo.GetVolumes(context.Background(), params)
+			if err != nil {
+				return fmt.Errorf("failed to get volume info: %w", err)
+			}
+			
+			volume.PrintVolumeInfo(resp.Payload.Storage)
+			return nil
+		},
+	}
+}

--- a/pkg/api/systeminfo_handler.go
+++ b/pkg/api/systeminfo_handler.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/systeminfo"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
+)
+
+type SystemInfoAPI struct {
+	Client *systeminfo.Client
+}
+
+func NewSystemInfoAPI(transport runtime.ClientTransport, formats strfmt.Registry, authInfo runtime.ClientAuthInfoWriter) *SystemInfoAPI {
+	return &SystemInfoAPI{
+		Client: systeminfo.New(transport, formats, authInfo),
+	}
+}
+
+func (api *SystemInfoAPI) GetSystemInfo(ctx context.Context) (*models.GeneralInfo, error) {
+	params := systeminfo.NewGetSystemInfoParams()
+	resp, err := api.Client.GetSystemInfo(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get system info: %w", err)
+	}
+	return resp.Payload, nil
+}
+
+func (api *SystemInfoAPI) GetVolumes(ctx context.Context) (*systeminfo.GetVolumesOK, error) {
+	params := systeminfo.NewGetVolumesParams()
+	resp, err := api.Client.GetVolumes(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get volumes info: %w", err)
+	}
+	return resp, nil
+}
+
+func (api *SystemInfoAPI) GetCert(ctx context.Context, writer io.Writer) error {
+	if writer == nil {
+		return fmt.Errorf("writer cannot be nil")
+	}
+	params := systeminfo.NewGetCertParams()
+	_, err := api.Client.GetCert(ctx, params, writer)
+	if err != nil {
+		return fmt.Errorf("failed to get certificate: %w", err)
+	}
+	return nil
+}

--- a/pkg/views/systeminfo/info/view.go
+++ b/pkg/views/systeminfo/info/view.go
@@ -1,0 +1,69 @@
+package info
+
+import (
+	"fmt"
+	"os"
+	
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/views/base/tablelist"
+	"github.com/go-openapi/strfmt"
+)
+
+var columns = []table.Column{
+	{Title: "Field", Width: 30},
+	{Title: "Value", Width: 30},
+}
+
+func PrintSystemInfo(info *models.GeneralInfo) {
+	var rows []table.Row
+	currentTime := getStringFromDateTime(info.CurrentTime)
+
+	rows = append(rows, table.Row{"Harbor Version", getString(info.HarborVersion)})
+	rows = append(rows, table.Row{"Auth Mode", getString(info.AuthMode)})
+	rows = append(rows, table.Row{"Primary Auth Mode", formatBool(info.PrimaryAuthMode)})
+	rows = append(rows, table.Row{"Self Registration", formatBool(info.SelfRegistration)})
+	rows = append(rows, table.Row{"Has CA Root", formatBool(info.HasCaRoot)})
+	rows = append(rows, table.Row{"Notification Enabled", formatBool(info.NotificationEnable)})
+	rows = append(rows, table.Row{"Read Only", formatBool(info.ReadOnly)})
+	rows = append(rows, table.Row{"External URL", getString(info.ExternalURL)})
+	rows = append(rows, table.Row{"Project Creation Restriction", getString(info.ProjectCreationRestriction)})
+	rows = append(rows, table.Row{"Current Time", currentTime})
+	rows = append(rows, table.Row{"Registry URL", getString(info.RegistryURL)})
+	rows = append(rows, table.Row{"Registry Storage Provider", getString(info.RegistryStorageProviderName)})
+	rows = append(rows, table.Row{"OIDC Provider Name", getString(info.OIDCProviderName)})
+	rows = append(rows, table.Row{"Banner Message", getString(info.BannerMessage)})
+	m := tablelist.NewModel(columns, rows, len(rows))
+	if _, err := tea.NewProgram(m).Run(); err != nil {
+		fmt.Println("Error running program:", err)
+		os.Exit(1)
+	}
+}
+
+func getString(s *string) string {
+	if s == nil {
+		return "N/A"
+	}
+	if *s == "" {
+		return "(empty)"
+	}
+	return *s
+}
+
+func getStringFromDateTime(dt *strfmt.DateTime) string {
+	if dt == nil {
+		return "N/A"
+	}
+	return dt.String()
+}
+
+func formatBool(b *bool) string {
+	if b == nil {
+		return "N/A"
+	}
+	if *b {
+		return "Yes"
+	}
+	return "No"
+}

--- a/pkg/views/systeminfo/volume/view.go
+++ b/pkg/views/systeminfo/volume/view.go
@@ -1,0 +1,51 @@
+package volume
+
+import (
+	"fmt"
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/views/base/tablelist"
+)
+
+var columns = []table.Column{
+	{Title: "Volume", Width: 8},
+	{Title: "Total", Width: 20},
+	{Title: "Free", Width: 15},
+}
+
+func PrintVolumeInfo(storage []*models.Storage) {
+	var rows []table.Row
+
+	if len(storage) == 0 {
+		fmt.Println("No volume information available.")
+		return
+	}
+
+	for i, vol := range storage {
+		rows = append(rows, table.Row{
+			fmt.Sprintf("%d", i+1),
+			formatSize(vol.Total),
+			formatSize(vol.Free),
+		})
+	}
+
+	m := tablelist.NewModel(columns, rows, len(rows))
+
+	if _, err := tea.NewProgram(m).Run(); err != nil {
+		fmt.Println("Error running program:", err)
+	}
+}
+
+func formatSize(size uint64) string {
+	const unit = 1024
+	if size < unit {
+		return fmt.Sprintf("%d B", size)
+	}
+	div, exp := uint64(unit), 0
+	for n := size / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(size)/float64(div), "KMGTPE"[exp])
+}


### PR DESCRIPTION
Commands to interact with the Harbor system information, including general info, volumes, and certificates.

`harbor systeminfo volumes`
![image](https://github.com/user-attachments/assets/0f9c37d9-059b-4956-ac75-eabc3aee5f76)

`harbor systeminfo info`
![image](https://github.com/user-attachments/assets/f2651c09-aba2-45e0-9909-c6f634450426)


`harbor systeminfo cert`
![image](https://github.com/user-attachments/assets/a12a880a-1e65-4b64-9708-8d66d1740768)

The `systeminfo.GetCertNotFound` error is triggered because the function client.`Systeminfo.GetCert` does not find the certificate it's supposed to retrieve as the certificate endpoint is not available.