### PR TITLE
Enhance the Subcommand login about command login 

### DIFF
--- a/cmd/harbor/root/login.go
+++ b/cmd/harbor/root/login.go
@@ -54,7 +54,7 @@ func LoginCommand() *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.StringVarP(&Name, "name", "", "", "name for the set of credentials")
+	flags.StringVarP(&Name, "name", "n", "", "name for the set of credentials")
 	flags.StringVarP(&Username, "username", "u", "", "Username")
 	flags.StringVarP(&Password, "password", "p", "", "Password")
 


### PR DESCRIPTION
The command login miss a flag -n which is name for the set of credentials.