### PR TITLE
Trigger docker-publish workflow only on release or tag events

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -1,11 +1,11 @@
 name: Docker Publish
 
 on:
+  release:
+    types: [published]
   push:
-    branches: [docker-publish]
-  pull_request:
-    paths-ignore:
-      - '*.md'
+    tags:
+      - "v*"
 
 jobs:
   docker-publish:


### PR DESCRIPTION
Per #197 :

> Docker Publish Workflow: Update the [docker_publish_workflow](https://github.com/goharbor/harbor-cli/blob/main/.github/workflows/docker_publish.yml) to trigger only on tag creation or release events, preventing runs on PRs.

Updates the `docker-publish` workflow to only run for release and tag events.