### PR TITLE
use local dagger module in pull-request workflow

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -21,5 +21,4 @@ jobs:
         with:
           version: "latest"
           verb: call
-          module: github.com/bishal7679/harbor-cli@v0.6.4
-          args: docker-publish --directory-arg=. --cosign-key=${{ secrets.COSIGN_KEY }} --cosign-password=${{ env.COSIGN_PASSWORD }}  --reg-username=${{ env.REGISTRY_USERNAME }}  --reg-password=${{ env.REGISTRY_PASSWORD }}
+          args: publish-image --source=. --cosign-key=${{ secrets.COSIGN_KEY }} --cosign-password=${{ env.COSIGN_PASSWORD }}  --reg-username=${{ env.REGISTRY_USERNAME }}  --reg-password=${{ env.REGISTRY_PASSWORD }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -32,5 +32,4 @@ jobs:
         with:
           version: "latest"
           verb: call
-          module: github.com/bishal7679/harbor-cli@v0.6.1
-          args: release --directory-arg=. --github-token=${{ env.GITHUB_TOKEN }}
+          args: release --source=. --github-token=${{ env.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           version: "latest"
           verb: call
-          args: lint --directory-arg=.
+          args: lint --source=.
 
       - name: Call Pull-Request Function
         uses: dagger/dagger-for-github@v6.1.0

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -39,7 +39,6 @@ jobs:
         with:
           version: "latest"
           verb: call
-          module: github.com/bishal7679/harbor-cli@v0.6.1
           args: lint-code --directory-arg=.
 
       - name: Call Pull-Request Function
@@ -50,5 +49,4 @@ jobs:
         with:
           version: "latest"
           verb: call
-          module: github.com/bishal7679/harbor-cli@v0.6.1
           args: pull-request --directory-arg=. --github-token=${{ env.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           version: "latest"
           verb: call
-          args: lint-code --directory-arg=.
+          args: lint --directory-arg=.
 
       - name: Call Pull-Request Function
         uses: dagger/dagger-for-github@v6.1.0

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -2,10 +2,9 @@ package main
 
 import (
 	"context"
+	"dagger/harbor-cli/internal/dagger"
 	"fmt"
 	"log"
-        "dagger/harbor-cli/internal/dagger"
-
 )
 
 const (
@@ -78,8 +77,13 @@ func (m *HarborCli) PullRequest(ctx context.Context, directoryArg *dagger.Direct
 	log.Println("Pull-Request tasks completed successfully 🎉")
 }
 
-func (m *HarborCli) Release(ctx context.Context, directoryArg *dagger.Directory, githubToken string) {
-	goreleaser := goreleaserContainer(directoryArg, githubToken).WithExec([]string{"release", "--clean"})
+func (m *HarborCli) Release(
+	ctx context.Context,
+	// +optional
+	// +defaultPath="./"
+	source *dagger.Directory,
+	githubToken string) {
+	goreleaser := goreleaserContainer(source, githubToken).WithExec([]string{"release", "--clean"})
 	_, err := goreleaser.Stderr(ctx)
 	if err != nil {
 		log.Printf("Error occured during release: %s", err)


### PR DESCRIPTION
Per #197:

> Remove Module Dependency: Eliminate the dependency on the module, as seen in [this section](https://github.com/goharbor/harbor-cli/blob/62c3945a773d405a4cc8bfa9bad11031b69c54dc/.github/workflows/pull-request.yml#L42C10-L42C58). It's an unnecessary overhead.

> Dagger Flag Update: Replace --directory-arg with the --source flag in the workflow, and set it as the default using the latest Dagger version.

- Drops the usage of a remote `dagger` module and instead looks to use the one local to the repository
- Updates dagger function(s) to use common `source` parameter