### PR TITLE
update pull-request function to use source

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -49,4 +49,4 @@ jobs:
         with:
           version: "latest"
           verb: call
-          args: pull-request --directory-arg=. --github-token=${{ env.GITHUB_TOKEN }}
+          args: pull-request --source=. --github-token=${{ env.GITHUB_TOKEN }}

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -68,8 +68,12 @@ func (m *HarborCli) Lint(
 
 }
 
-func (m *HarborCli) PullRequest(ctx context.Context, directoryArg *dagger.Directory, githubToken string) {
-	goreleaser := goreleaserContainer(directoryArg, githubToken).WithExec([]string{"release", "--snapshot", "--clean"})
+func (m *HarborCli) PullRequest(ctx context.Context,
+	// +optional
+	// +defaultPath="./"
+	source *dagger.Directory,
+	githubToken string) {
+	goreleaser := goreleaserContainer(source, githubToken).WithExec([]string{"release", "--snapshot", "--clean"})
 	_, err := goreleaser.Stderr(ctx)
 	if err != nil {
 		log.Printf("❌ Error occured during snapshot release for the recently merged pull-request: %s", err)


### PR DESCRIPTION
Updates the last dagger function `pull-request` to use `source`