### PR TITLE
bump dagger github action to latest

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
 
       - name: Call Docker-Publish Function
-        uses: dagger/dagger-for-github@v6.1.0
+        uses: dagger/dagger-for-github@v6.13.0
         with:
           version: "latest"
           verb: call

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -26,7 +26,7 @@ jobs:
           cache: true
 
       - name: Call Dagger Function
-        uses: dagger/dagger-for-github@v6.1.0
+        uses: dagger/dagger-for-github@v6.13.0
         env: 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -35,14 +35,14 @@ jobs:
         run: go test -v ./...
 
       - name: Call Linting Function
-        uses: dagger/dagger-for-github@v6.1.0
+        uses: dagger/dagger-for-github@v6.13.0
         with:
           version: "latest"
           verb: call
           args: lint --source=.
 
       - name: Call Pull-Request Function
-        uses: dagger/dagger-for-github@v6.1.0
+        uses: dagger/dagger-for-github@v6.13.0
         if: always()
         env: 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This bumps the dagger-for-github action to the latest stable (which aligns with the dagger version in `dagger.json`)