### PR TITLE
adds build function to pull-request workflow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -41,6 +41,13 @@ jobs:
           verb: call
           args: lint --source=.
 
+      - name: Call Build Function
+        uses: dagger/dagger-for-github@v6.1.0
+        with:
+          version: "latest"
+          verb: call
+          args: build --source=.
+
       - name: Call Pull-Request Function
         uses: dagger/dagger-for-github@v6.1.0
         if: always()


### PR DESCRIPTION
Per #197 :

> Add Build Check Workflow: To check if building binaries for multiple operating systems and architectures are working as expected.

This adds the existing `build` dagger function to the `pull-request` workflow to ensure that binaries for multiple OS and arch combinations can be done successfully.