### PR TITLE
add initial .golangci.yaml config with formatter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,3 @@
-#linters-settings:
-#  gofumpt:
-#    extra-rules: true
 
 linters:
   enable:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,16 @@
+#linters-settings:
+#  gofumpt:
+#    extra-rules: true
+
+linters:
+  enable:
+    # default linters
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - typecheck
+    - unused
+
+    - gofmt

--- a/cmd/harbor/root/health.go
+++ b/cmd/harbor/root/health.go
@@ -2,8 +2,8 @@ package root
 
 import (
 	"github.com/goharbor/harbor-cli/pkg/api"
-	"github.com/spf13/cobra"
 	"github.com/goharbor/harbor-cli/pkg/views/health"
+	"github.com/spf13/cobra"
 )
 
 func HealthCommand() *cobra.Command {

--- a/pkg/api/health_handler.go
+++ b/pkg/api/health_handler.go
@@ -13,7 +13,7 @@ func GetHealth() (*health.GetHealthOK, error) {
 		return nil, err
 	}
 
-	response, err := client.Health.GetHealth(ctx,&health.GetHealthParams{})
+	response, err := client.Health.GetHealth(ctx, &health.GetHealthParams{})
 	if err != nil {
 		return nil, fmt.Errorf("error getting health status: %w", err)
 	}

--- a/pkg/views/health/view.go
+++ b/pkg/views/health/view.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/charmbracelet/bubbles/table"
-	"github.com/charmbracelet/bubbletea"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/health"
 	"github.com/goharbor/harbor-cli/pkg/views"
 	"github.com/goharbor/harbor-cli/pkg/views/base/tablelist"


### PR DESCRIPTION
Per #197:

> Add Formatting Check on Lint Workflow: To maintain consistent formatting.

This adds an initial `.golangci.yaml` config file and adds in the `gofmt` linter to check basic formatting. There are all kinds of other linters/formatter checks to add here, but didn't want to get too opinionated from the start.