### PR TITLE
Add BuildDev function to build the Go binary for the specified platform

### DIFF
--- a/dagger/main.go
+++ b/dagger/main.go
@@ -51,7 +51,7 @@ func (m *HarborCli) Build(
 	return outputs
 }
 
-// Build builds the Go binary for the specified platforms, like '--platform "linux/amd64"'
+// Builds the Go binary for the specified platforms, like '--platform "linux/amd64"'
 func (m *HarborCli) BuildDev(
 	ctx context.Context,
 	// +optional
@@ -59,7 +59,7 @@ func (m *HarborCli) BuildDev(
 	source *dagger.Directory,
 	platform string) *dagger.Directory {
 
-	fmt.Println("🛠️  Building with Dagger...")
+	fmt.Println("🛠️  Building Go Binary for the specified platforms with Dagger...")
 
 	os := platformFormat.MustParse(platform).OS
 	arch := platformFormat.MustParse(platform).Architecture


### PR DESCRIPTION
Fixed #214 

Run the command as follows: `dagger call build-dev --platform="darwin/amd64" export --path=./bin`.