### PR TITLE
Dagger Code Review

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -32,4 +32,4 @@ jobs:
         with:
           version: "latest"
           verb: call
-          args: "publish-image --source=. --cosign-password='${{ env.COSIGN_PASSWORD }}' --cosign-key='${{ env.COSIGN_KEY }}' --reg-username='${{ env.REGISTRY_USERNAME }}' --reg-password='${{ env.REGISTRY_PASSWORD }}' --reg-address='${{ env.REGISTRY_ADDRESS }}' --publish-address='${{ env.PUBLISH_ADDRESS }}' --tag='${{ env.TAG }}'"
+          args: "publish-image --cosign-password='env:${{ env.COSIGN_PASSWORD }}' --cosign-key='env:${{ env.COSIGN_KEY }}' --reg-username='${{ env.REGISTRY_USERNAME }}' --reg-password='env:${{ env.REGISTRY_PASSWORD }}' --reg-address='${{ env.REGISTRY_ADDRESS }}' --publish-address='${{ env.PUBLISH_ADDRESS }}' --tag='${{ env.TAG }}'"

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -19,12 +19,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: "1.22.5"
-          cache: true
-
       - name: Call Dagger Function
         uses: dagger/dagger-for-github@v6.13.0
         env: 
@@ -32,4 +26,4 @@ jobs:
         with:
           version: "latest"
           verb: call
-          args: release --source=. --github-token=${{ env.GITHUB_TOKEN }}
+          args: release --github-token='env:${{ env.GITHUB_TOKEN }}'

--- a/README.md
+++ b/README.md
@@ -123,9 +123,8 @@ Make sure you have latest [Dagger](https://docs.dagger.io/) installed in your sy
 #### Using Dagger
 ```bash
 git clone https://github.com/goharbor/harbor-cli.git && cd harbor-cli
-dagger call build-dev --platform darwin/arm64 export --path=.
+dagger call build-dev --platform darwin/arm64 export --path=./harbor-dev
 ./harbor-dev --help
-
 ```
 
 ```bash

--- a/dagger.json
+++ b/dagger.json
@@ -8,5 +8,5 @@
     }
   ],
   "source": "dagger",
-  "engineVersion": "v0.13.3"
+  "engineVersion": "v0.13.5"
 }

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -200,6 +200,9 @@ func (m *HarborCli) RunDoc(
 	fmt.Println("Running doc.go file using Dagger...")
 	return dag.Container().
 		From("golang:latest").
+		WithMountedCache("/go/pkg/mod", dag.CacheVolume("go-mod")).
+		WithMountedCache("/go/build-cache", dag.CacheVolume("go-build")).
+		WithEnvVariable("GOCACHE", "/go/build-cache").
 		WithMountedDirectory("/src", source).
 		WithWorkdir("/src/doc").
 		WithExec([]string{"go", "run", "doc.go"}).

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -191,6 +191,7 @@ func goreleaserContainer(directoryArg *dagger.Directory, githubToken string) *da
 		WithSecretVariable("GITHUB_TOKEN", token)
 }
 
+// Generate CLI Documentation with doc.go and return the directory containing the generated files
 func (m *HarborCli) RunDoc(
 	ctx context.Context,
 	// +optional


### PR DESCRIPTION
Hello! 

I went through the existing Dagger module and refactored things a bit to encourage best practices around types, documentation, constructors, etc. 

Here's an overview of the changes. 

1. Refactor GHA workflow to use secrets from env instead of strings 
2. Refactor GHA workflow to not set up go since it is never used directly 
3. Use constructor pattern to clean up functions 
4. More consistently apply code style 
5. Use secrets instead of strings for secrets because this prevents them from ever leaking in logs or cache 
6. Temporarily make build function private due to this bug: https://github.com/dagger/dagger/issues/8202#issuecomment-2317291483 
7. Have the new Build Dev function return a file instead of directory since its redundant. 

