### PR TITLE
Added flags for user list cmd

### DIFF
--- a/cmd/harbor/root/user/list.go
+++ b/cmd/harbor/root/user/list.go
@@ -10,13 +10,15 @@ import (
 )
 
 func UserListCmd() *cobra.Command {
+	var opts api.ListFlags
+
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "list users",
 		Args:    cobra.NoArgs,
 		Aliases: []string{"ls"},
 		Run: func(cmd *cobra.Command, args []string) {
-			response, err := api.ListUsers()
+			response, err := api.ListUsers(opts)
 			if err != nil {
 				log.Errorf("failed to list users: %v", err)
 				return
@@ -29,6 +31,12 @@ func UserListCmd() *cobra.Command {
 			}
 		},
 	}
+
+	flags := cmd.Flags()
+	flags.Int64VarP(&opts.Page, "page", "p", 1, "Page number")
+	flags.Int64VarP(&opts.PageSize, "page-size", "n", 25, "Size of per page")
+	flags.StringVarP(&opts.Q, "query", "q", "", "Query string to query resources")
+	flags.StringVarP(&opts.Sort, "sort", "s", "", "Sort the resource list in ascending or descending order")
 
 	return cmd
 

--- a/pkg/api/user_handler.go
+++ b/pkg/api/user_handler.go
@@ -67,14 +67,22 @@ func ElevateUser(userId int64) error {
 	return nil
 }
 
-func ListUsers() (*user.ListUsersOK, error) {
+func ListUsers(opts ...ListFlags) (*user.ListUsersOK, error) {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {
 		return nil, err
 	}
+	var listFlags ListFlags
+	if len(opts) > 0 {
+		listFlags = opts[0]
+	}
 
-	response, err := client.User.ListUsers(ctx, &user.ListUsersParams{})
-
+	response, err := client.User.ListUsers(ctx, &user.ListUsersParams{
+		Page:     &listFlags.Page,
+		PageSize: &listFlags.PageSize,
+		Q:        &listFlags.Q,
+		Sort:     &listFlags.Sort,
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**Added flags for the `user list` command**

Before there were no flags for the user list command, so only a limited number of user lists would be shown.
But now we can view all of the users list using flags