### PR TITLE
fixed username validator

### DIFF
--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -44,10 +44,9 @@ func FormatSize(size int64) string {
 	return fmt.Sprintf("%.2fMiB", mbSize)
 }
 
+// ValidateUserName checks if the username is valid by length and allowed characters.
 func ValidateUserName(username string) bool {
-	pattern := `^[a-zA-Z0-9]{1,255}$`
-	re := regexp.MustCompile(pattern)
-	return re.MatchString(username)
+	return len(username) >= 1 && len(username) <= 255 && !strings.ContainsAny(username, `,"~#%$`)
 }
 
 func ValidateEmail(email string) bool {

--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -46,6 +46,7 @@ func FormatSize(size int64) string {
 
 // ValidateUserName checks if the username is valid by length and allowed characters.
 func ValidateUserName(username string) bool {
+	username = strings.TrimSpace(username)
 	return len(username) >= 1 && len(username) <= 255 && !strings.ContainsAny(username, `,"~#%$`)
 }
 


### PR DESCRIPTION
The username validator previously implemented only allowed alphanumeric characters, which resulted in rejecting valid usernames accepted by the server, such as `harbor-cli`. This inconsistency also caused failures in login tests.

To resolve this, the current implementation of the validator has been aligned with the server's username validation criteria. You can view the server-side validator [here](https://github.com/goharbor/harbor/blob/9e55afbb9a124dbe47562d56769ad4e9f14cb5ed/src/server/v2.0/handler/user.go#L514-L518).

This PR references issue #234 