### PR TITLE
Shows both private and public projects for project list cmd

### DIFF
--- a/pkg/api/project_handler.go
+++ b/pkg/api/project_handler.go
@@ -86,6 +86,22 @@ func ListProject(opts ...ListFlags) (project.ListProjectsOK, error) {
 	return *response, nil
 }
 
+func ListAllProjects(opts ...ListFlags) (project.ListProjectsOK, error) {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return project.ListProjectsOK{}, err
+	}
+	var listFlags ListFlags
+	if len(opts) > 0 {
+		listFlags = opts[0]
+	}
+	response, err := client.Project.ListProjects(ctx, &project.ListProjectsParams{Page: &listFlags.Page, PageSize: &listFlags.PageSize, Q: &listFlags.Q, Sort: &listFlags.Sort, Name: &listFlags.Name})
+	if err != nil {
+		return project.ListProjectsOK{}, err
+	}
+	return *response, nil
+}
+
 func LogsProject(projectName string) (*project.GetLogsOK, error) {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -26,7 +26,7 @@ func GetRegistryNameFromUser() int64 {
 func GetProjectNameFromUser() string {
 	projectName := make(chan string)
 	go func() {
-		response, _ := api.ListProject()
+		response, _ := api.ListAllProjects()
 		pview.ProjectList(response.Payload, projectName)
 
 	}()

--- a/pkg/views/project/list/view.go
+++ b/pkg/views/project/list/view.go
@@ -14,11 +14,11 @@ import (
 
 var columns = []table.Column{
 	{Title: "ID", Width: 6},
-	{Title: "Project Name", Width: 12},
+	{Title: "Project Name", Width: 20},
 	{Title: "Access Level", Width: 12},
 	{Title: "Type", Width: 12},
 	{Title: "Repo Count", Width: 12},
-	{Title: "Creation Time", Width: 30},
+	{Title: "Creation Time", Width: 18},
 }
 
 func ListProjects(projects []*models.Project) {


### PR DESCRIPTION
Shows both private and public projects for project list cmd and allows the user to filter where the project list should be public/private

[Screencast from 17-11-24 03:05:51 PM IST.webm](https://github.com/user-attachments/assets/5a2cdb3a-bfdd-4e27-aaf3-bce9c2c2b536)

Solved another issue,
![Screenshot from 2024-11-17 15-18-43](https://github.com/user-attachments/assets/ddc36f01-f367-4736-9ed8-5ef6d7d049b7)

