### PR TITLE
Add jq to container image

### DIFF
--- a/dagger/main.go
+++ b/dagger/main.go
@@ -147,6 +147,7 @@ func (m *HarborCli) PublishImage(
 
 		ctr := dag.Container(dagger.ContainerOpts{Platform: dagger.Platform(os + "/" + arch)}).
 			From("alpine:latest").
+			WithExec([]string{"apk", "add", "--no-cache", "jq"}).
 			WithFile("/harbor", builder.File("./harbor")).
 			WithEntrypoint([]string{"./harbor"})
 		releaseImages = append(releaseImages, ctr)


### PR DESCRIPTION
It makes it easier to parse out fields, for example to get a registry id when doing something like this inside a container:
```shell
./harbor registry create --name docker.io ...
REGISTRY_ID=$(./harbor registry list -q "name=docker.io" -o json | jq '.Payload[].id')
./harbor project create docker.io --proxy-cache=true --registry-id "$REGISTRY_ID"
```