### PR TITLE
bug: fix push-latest-images and publish-release

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -59,7 +59,7 @@ jobs:
           args: build-dev --platform linux/amd64 export --path=./harbor-dev
 
   push-latest-images:
-    if: github.event.pull_request == null && !startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
     needs:
       - lint
       - test-code
@@ -84,7 +84,7 @@ jobs:
 
 
   publish-release:
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
     needs:
       - lint
       - test-code


### PR DESCRIPTION
fixed #278 
I recently updated the workflow trigger conditions for `push-latest-images` and `publish-release`.