### PR TITLE
chore: move the ping to health handler

### DIFF
--- a/cmd/harbor/root/health.go
+++ b/cmd/harbor/root/health.go
@@ -11,6 +11,10 @@ func HealthCommand() *cobra.Command {
 		Use:   "health",
 		Short: "Get the health status of Harbor components",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			err := api.Ping()
+			if err != nil {
+				return err
+			}
 			status, err := api.GetHealth()
 			if err != nil {
 				return err

--- a/pkg/api/ping_handler.go
+++ b/pkg/api/ping_handler.go
@@ -1,0 +1,23 @@
+package api
+
+import (
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/ping"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/sirupsen/logrus"
+)
+
+func Ping() error {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		logrus.Errorf("failed to get client: %v", err)
+		return err
+	}
+
+	_, err = client.Ping.GetPing(ctx, &ping.GetPingParams{})
+	if err != nil {
+		logrus.Errorf("failed to ping the server: %v", err)
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
fix #211 
part of #94 
~~move the ping command handler and verify the API server first, before checking the status of the Harbor components.~~

Edit:
Add a Ping step to the health command that pings the server before checking its health status. Removing the need for separate ping command.