### PR TITLE
Default Page size

### DIFF
--- a/cmd/harbor/root/labels/list.go
+++ b/cmd/harbor/root/labels/list.go
@@ -16,6 +16,9 @@ func ListLabelCommand() *cobra.Command {
 		Use:   "list",
 		Short: "list labels",
 		Run: func(cmd *cobra.Command, args []string) {
+			if !cmd.Flags().Changed("page-size") {
+				opts.PageSize = utils.ResolvePageSize(20)
+			}
 			label, err := api.ListLabel(opts)
 			if err != nil {
 				log.Fatalf("failed to get label list: %v", err)

--- a/cmd/harbor/root/project/list.go
+++ b/cmd/harbor/root/project/list.go
@@ -20,6 +20,9 @@ func ListProjectCommand() *cobra.Command {
 		Use:   "list",
 		Short: "list project",
 		Run: func(cmd *cobra.Command, args []string) {
+			if !cmd.Flags().Changed("page-size") {
+				opts.PageSize = utils.ResolvePageSize(10)
+			}
 			if private && public {
 				log.Fatal("Cannot specify both --private and --public flags")
 			} else if private {

--- a/cmd/harbor/root/registry/list.go
+++ b/cmd/harbor/root/registry/list.go
@@ -17,6 +17,9 @@ func ListRegistryCommand() *cobra.Command {
 		Use:   "list",
 		Short: "list registry",
 		Run: func(cmd *cobra.Command, args []string) {
+			if !cmd.Flags().Changed("page-size") {
+				opts.PageSize = utils.ResolvePageSize(10)
+			}
 			registry, err := api.ListRegistries(opts)
 
 			if err != nil {

--- a/cmd/harbor/root/schedule/list.go
+++ b/cmd/harbor/root/schedule/list.go
@@ -16,6 +16,9 @@ func ListScheduleCommand() *cobra.Command {
 		Use:   "list",
 		Short: "show all schedule jobs in Harbor",
 		Run: func(cmd *cobra.Command, args []string) {
+			if !cmd.Flags().Changed("page-size") {
+				opts.PageSize = utils.ResolvePageSize(10)
+			}
 			schedule, err := api.ListSchedule(opts)
 			if err != nil {
 				log.Fatalf("failed to get schedule list: %v", err)

--- a/cmd/harbor/root/user/list.go
+++ b/cmd/harbor/root/user/list.go
@@ -18,6 +18,9 @@ func UserListCmd() *cobra.Command {
 		Args:    cobra.NoArgs,
 		Aliases: []string{"ls"},
 		Run: func(cmd *cobra.Command, args []string) {
+			if !cmd.Flags().Changed("page-size") {
+				opts.PageSize = utils.ResolvePageSize(10)
+			}
 			response, err := api.ListUsers(opts)
 			if err != nil {
 				log.Errorf("failed to list users: %v", err)

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 
 	log "github.com/sirupsen/logrus"
@@ -20,6 +21,7 @@ type Credential struct {
 }
 
 type HarborConfig struct {
+	PageSize              int          `mapstructure:"page-size" yaml:"page-size"`
 	CurrentCredentialName string       `mapstructure:"current-credential-name" yaml:"current-credential-name"`
 	Credentials           []Credential `mapstructure:"credentials" yaml:"credentials"`
 }
@@ -330,11 +332,13 @@ func CreateConfigFile(configPath string) error {
 
 		defaultConfig := HarborConfig{
 			CurrentCredentialName: "",
+			PageSize:              10,
 			Credentials:           []Credential{},
 		}
 
 		v.Set("current-credential-name", defaultConfig.CurrentCredentialName)
 		v.Set("credentials", defaultConfig.Credentials)
+		v.Set("page-size", defaultConfig.PageSize)
 
 		if err := v.WriteConfigAs(configPath); err != nil {
 			log.Fatalf("failed to write config file: %v", err)
@@ -392,6 +396,7 @@ func AddCredentialsToConfigFile(credential Credential, configPath string) error 
 
 	v.Set("current-credential-name", c.CurrentCredentialName)
 	v.Set("credentials", c.Credentials)
+	v.Set("page-size", c.PageSize)
 
 	if err := v.WriteConfig(); err != nil {
 		log.Fatalf("failed to write updated config file: %v", err)
@@ -436,6 +441,7 @@ func UpdateCredentialsInConfigFile(updatedCredential Credential, configPath stri
 
 	v.Set("current-credential-name", c.CurrentCredentialName)
 	v.Set("credentials", c.Credentials)
+	v.Set("page-size", c.PageSize)
 
 	if err := v.WriteConfig(); err != nil {
 		log.Fatalf("failed to write updated config file: %v", err)
@@ -443,4 +449,23 @@ func UpdateCredentialsInConfigFile(updatedCredential Credential, configPath stri
 
 	log.Infof("Updated credential '%s' in config file at %s", updatedCredential.Name, configPath)
 	return nil
+}
+
+// obtaining the defaault page-size from the config/environment
+func ResolvePageSize(x int64) int64 {
+	config, err := GetCurrentHarborConfig()
+	if err != nil {
+		return x
+	}
+	if config != nil && config.PageSize > 0 {
+		return int64(config.PageSize)
+	}
+	envPageSize := os.Getenv("HARBOR_CLI_DEFAULT_PAGE_SIZE")
+	if envPageSize != "" {
+		if val, err := strconv.ParseInt(envPageSize, 10, 64); err == nil && val > 0 {
+			return val
+		}
+	}
+
+	return x
 }


### PR DESCRIPTION
Fix #244 
also fix #261 
## Description  
This PR enhances the handling of the `page-size` parameter by introducing a hierarchical priority mechanism and integrating it into the command execution flow.  

### Hierarchy for `page-size` Resolution  
1. **Flag**: The value provided via the command flag takes the highest priority.  
2. **ResolvePageSize Utility**: If no flag is provided, the utility determines the `page-size` in the following order:  
   - Value from the configuration file.  
   - Value from the `HARBOR_CLI_DEFAULT_PAGE_SIZE` environment variable.  
   - Hardcoded default value (`x`).  

### Key Changes  
1. **Command Execution**:  
   - Updated `list` commands to prioritize `page-size` values using the hierarchy mentioned above.  
2. **Config Updates**:  
   - Introduced a new parameter for `page-size` in the configuration.  
   - Added initialization for this parameter in the relevant configuration files.