### PR TITLE
fixed extra args in cmds

### DIFF
--- a/cmd/harbor/root/health.go
+++ b/cmd/harbor/root/health.go
@@ -3,6 +3,7 @@ package root
 import (
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/views/health"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -10,6 +11,11 @@ func HealthCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "health",
 		Short: "Get the health status of Harbor components",
+		PreRun: func(cmd *cobra.Command, args []string) {
+			if len(args) > 0 {
+				log.Fatalf("Error: accepts 0 arg(s), received %d: %v", len(args), args)
+			}
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			status, err := api.GetHealth()
 			if err != nil {

--- a/cmd/harbor/root/labels/create.go
+++ b/cmd/harbor/root/labels/create.go
@@ -15,7 +15,11 @@ func CreateLabelCommand() *cobra.Command {
 		Short:   "create label",
 		Long:    "create label in harbor",
 		Example: "harbor label create",
-		Args:    cobra.NoArgs,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			if len(args) > 0 {
+				log.Fatalf("Error: accepts 0 arg(s), received %d: %v", len(args), args)
+			}
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			var err error
 			createView := &create.CreateView{

--- a/cmd/harbor/root/labels/list.go
+++ b/cmd/harbor/root/labels/list.go
@@ -15,6 +15,11 @@ func ListLabelCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "list labels",
+		PreRun: func(cmd *cobra.Command, args []string) {
+			if len(args) > 0 {
+				log.Fatalf("Error: accepts 0 arg(s), received %d: %v", len(args), args)
+			}
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			label, err := api.ListLabel(opts)
 			if err != nil {

--- a/cmd/harbor/root/project/list.go
+++ b/cmd/harbor/root/project/list.go
@@ -19,6 +19,11 @@ func ListProjectCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "list project",
+		PreRun: func(cmd *cobra.Command, args []string) {
+			if len(args) > 0 {
+				log.Fatalf("Error: accepts 0 arg(s), received %d: %v", len(args), args)
+			}
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if private && public {
 				log.Fatal("Cannot specify both --private and --public flags")

--- a/cmd/harbor/root/registry/create.go
+++ b/cmd/harbor/root/registry/create.go
@@ -14,7 +14,11 @@ func CreateRegistryCommand() *cobra.Command {
 		Use:     "create",
 		Short:   "create registry",
 		Example: "harbor registry create",
-		Args:    cobra.NoArgs,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			if len(args) > 0 {
+				log.Fatalf("Error: accepts 0 arg(s), received %d: %v", len(args), args)
+			}
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			var err error
 			createView := &api.CreateRegView{

--- a/cmd/harbor/root/registry/list.go
+++ b/cmd/harbor/root/registry/list.go
@@ -16,6 +16,11 @@ func ListRegistryCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "list registry",
+		PreRun: func(cmd *cobra.Command, args []string) {
+			if len(args) > 0 {
+				log.Fatalf("Error: accepts 0 arg(s), received %d: %v", len(args), args)
+			}
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			registry, err := api.ListRegistries(opts)
 

--- a/cmd/harbor/root/schedule/list.go
+++ b/cmd/harbor/root/schedule/list.go
@@ -15,6 +15,11 @@ func ListScheduleCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "show all schedule jobs in Harbor",
+		PreRun: func(cmd *cobra.Command, args []string) {
+			if len(args) > 0 {
+				log.Fatalf("Error: accepts 0 arg(s), received %d: %v", len(args), args)
+			}
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			schedule, err := api.ListSchedule(opts)
 

--- a/cmd/harbor/root/user/create.go
+++ b/cmd/harbor/root/user/create.go
@@ -14,7 +14,11 @@ func UserCreateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "create user",
-		Args:  cobra.NoArgs,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			if len(args) > 0 {
+				log.Fatalf("Error: accepts 0 arg(s), received %d: %v", len(args), args)
+			}
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			var err error
 			createView := &create.CreateView{

--- a/cmd/harbor/root/user/list.go
+++ b/cmd/harbor/root/user/list.go
@@ -13,9 +13,13 @@ func UserListCmd() *cobra.Command {
 	var opts api.ListFlags
 
 	cmd := &cobra.Command{
-		Use:     "list",
-		Short:   "list users",
-		Args:    cobra.NoArgs,
+		Use:   "list",
+		Short: "list users",
+		PreRun: func(cmd *cobra.Command, args []string) {
+			if len(args) > 0 {
+				log.Fatalf("Error: accepts 0 arg(s), received %d: %v", len(args), args)
+			}
+		},
 		Aliases: []string{"ls"},
 		Run: func(cmd *cobra.Command, args []string) {
 			response, err := api.ListUsers(opts)

--- a/cmd/harbor/root/version.go
+++ b/cmd/harbor/root/version.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/goharbor/harbor-cli/cmd/harbor/internal/version"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -15,6 +16,11 @@ func versionCommand() *cobra.Command {
 		Short:   "Version of Harbor CLI",
 		Long:    `Get Harbor CLI version, git commit, go version, build time, release channel, os/arch, etc.`,
 		Example: `  harbor version`,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			if len(args) > 0 {
+				log.Fatalf("Error: accepts 0 arg(s), received %d: %v", len(args), args)
+			}
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runVersion()
 		},


### PR DESCRIPTION
This PR fixes issue #293 and extends its coverage to other commands by ensuring that an error message is sent if any extra arguments are provided to commands that do not require them.

Current behavior:

```
./harbor-cli label create newLabel
FATA[0000] Error: accepts 0 arg(s), received 1: [newLabel]

./harbor-cli project list extra args
FATA[0000] Error: accepts 0 arg(s), received 2: [extra args]
```

The fix adds a PreRun step before the command is executed to exit if any arguments are provided.