### PR TITLE
`projectRepo` parser-fix

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -39,7 +39,7 @@ func PrintPayloadInYAMLFormat(payload any) {
 }
 
 func ParseProjectRepo(projectRepo string) (string, string) {
-	split := strings.Split(projectRepo, "/")
+	split := strings.SplitN(projectRepo, "/", 2) //splits only at first slash
 	if len(split) != 2 {
 		log.Fatalf("invalid project/repository format: %s", projectRepo)
 	}


### PR DESCRIPTION
Fixes #298 
The function now splits on first slash only, and the first split is the `projectName` and the second one is the `repoName`