### PR TITLE
fixes args issue for commands

### DIFF
--- a/cmd/harbor/root/labels/create.go
+++ b/cmd/harbor/root/labels/create.go
@@ -1,10 +1,11 @@
 package labels
 
 import (
-	"github.com/goharbor/harbor-cli/pkg/api"
-	"github.com/goharbor/harbor-cli/pkg/views/label/create"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/views/label/create"
 )
 
 func CreateLabelCommand() *cobra.Command {
@@ -15,7 +16,7 @@ func CreateLabelCommand() *cobra.Command {
 		Short:   "create label",
 		Long:    "create label in harbor",
 		Example: "harbor label create",
-		Args:    cobra.NoArgs,
+		Args:    cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			var err error
 			createView := &create.CreateView{

--- a/cmd/harbor/root/labels/create.go
+++ b/cmd/harbor/root/labels/create.go
@@ -1,11 +1,10 @@
 package labels
 
 import (
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
-
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/views/label/create"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
 func CreateLabelCommand() *cobra.Command {

--- a/cmd/harbor/root/labels/list.go
+++ b/cmd/harbor/root/labels/list.go
@@ -1,13 +1,12 @@
 package labels
 
 import (
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/label/list"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func ListLabelCommand() *cobra.Command {

--- a/cmd/harbor/root/labels/list.go
+++ b/cmd/harbor/root/labels/list.go
@@ -1,12 +1,13 @@
 package labels
 
 import (
-	"github.com/goharbor/harbor-cli/pkg/api"
-	"github.com/goharbor/harbor-cli/pkg/utils"
-	"github.com/goharbor/harbor-cli/pkg/views/label/list"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/goharbor/harbor-cli/pkg/views/label/list"
 )
 
 func ListLabelCommand() *cobra.Command {
@@ -15,6 +16,7 @@ func ListLabelCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "list labels",
+		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			label, err := api.ListLabel(opts)
 			if err != nil {

--- a/cmd/harbor/root/project/list.go
+++ b/cmd/harbor/root/project/list.go
@@ -2,13 +2,12 @@ package project
 
 import (
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/project"
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	list "github.com/goharbor/harbor-cli/pkg/views/project/list"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func ListProjectCommand() *cobra.Command {

--- a/cmd/harbor/root/project/list.go
+++ b/cmd/harbor/root/project/list.go
@@ -2,12 +2,13 @@ package project
 
 import (
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/project"
-	"github.com/goharbor/harbor-cli/pkg/api"
-	"github.com/goharbor/harbor-cli/pkg/utils"
-	list "github.com/goharbor/harbor-cli/pkg/views/project/list"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	list "github.com/goharbor/harbor-cli/pkg/views/project/list"
 )
 
 func ListProjectCommand() *cobra.Command {
@@ -19,6 +20,7 @@ func ListProjectCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "list project",
+		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			if private && public {
 				log.Fatal("Cannot specify both --private and --public flags")

--- a/cmd/harbor/root/registry/create.go
+++ b/cmd/harbor/root/registry/create.go
@@ -1,11 +1,10 @@
 package registry
 
 import (
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
-
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/views/registry/create"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
 func CreateRegistryCommand() *cobra.Command {

--- a/cmd/harbor/root/registry/create.go
+++ b/cmd/harbor/root/registry/create.go
@@ -1,10 +1,11 @@
 package registry
 
 import (
-	"github.com/goharbor/harbor-cli/pkg/api"
-	"github.com/goharbor/harbor-cli/pkg/views/registry/create"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/views/registry/create"
 )
 
 func CreateRegistryCommand() *cobra.Command {
@@ -14,7 +15,7 @@ func CreateRegistryCommand() *cobra.Command {
 		Use:     "create",
 		Short:   "create registry",
 		Example: "harbor registry create",
-		Args:    cobra.NoArgs,
+		Args:    cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			var err error
 			createView := &api.CreateRegView{

--- a/cmd/harbor/root/registry/list.go
+++ b/cmd/harbor/root/registry/list.go
@@ -1,12 +1,13 @@
 package registry
 
 import (
-	"github.com/goharbor/harbor-cli/pkg/api"
-	"github.com/goharbor/harbor-cli/pkg/utils"
-	"github.com/goharbor/harbor-cli/pkg/views/registry/list"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/goharbor/harbor-cli/pkg/views/registry/list"
 )
 
 // NewListRegistryCommand creates a new `harbor list registry` command
@@ -16,6 +17,7 @@ func ListRegistryCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "list registry",
+		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			registry, err := api.ListRegistries(opts)
 

--- a/cmd/harbor/root/registry/list.go
+++ b/cmd/harbor/root/registry/list.go
@@ -1,13 +1,12 @@
 package registry
 
 import (
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/registry/list"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // NewListRegistryCommand creates a new `harbor list registry` command

--- a/cmd/harbor/root/user/create.go
+++ b/cmd/harbor/root/user/create.go
@@ -1,11 +1,11 @@
 package user
 
 import (
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
-
 	"github.com/goharbor/harbor-cli/pkg/api"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/goharbor/harbor-cli/pkg/views/user/create"
+	"github.com/spf13/cobra"
 )
 
 func UserCreateCmd() *cobra.Command {

--- a/cmd/harbor/root/user/create.go
+++ b/cmd/harbor/root/user/create.go
@@ -1,11 +1,11 @@
 package user
 
 import (
-	"github.com/goharbor/harbor-cli/pkg/api"
 	log "github.com/sirupsen/logrus"
-
-	"github.com/goharbor/harbor-cli/pkg/views/user/create"
 	"github.com/spf13/cobra"
+
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/views/user/create"
 )
 
 func UserCreateCmd() *cobra.Command {
@@ -14,7 +14,7 @@ func UserCreateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "create user",
-		Args:  cobra.NoArgs,
+		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			var err error
 			createView := &create.CreateView{

--- a/cmd/harbor/root/user/list.go
+++ b/cmd/harbor/root/user/list.go
@@ -1,13 +1,12 @@
 package user
 
 import (
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/user/list"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func UserListCmd() *cobra.Command {

--- a/cmd/harbor/root/user/list.go
+++ b/cmd/harbor/root/user/list.go
@@ -1,12 +1,13 @@
 package user
 
 import (
-	"github.com/goharbor/harbor-cli/pkg/api"
-	"github.com/goharbor/harbor-cli/pkg/utils"
-	"github.com/goharbor/harbor-cli/pkg/views/user/list"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/goharbor/harbor-cli/pkg/views/user/list"
 )
 
 func UserListCmd() *cobra.Command {
@@ -15,7 +16,7 @@ func UserListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "list users",
-		Args:    cobra.NoArgs,
+		Args:    cobra.ExactArgs(0),
 		Aliases: []string{"ls"},
 		Run: func(cmd *cobra.Command, args []string) {
 			response, err := api.ListUsers(opts)


### PR DESCRIPTION
This PR fixes issue #293 by giving the below error 
```
rizul@rizu:~/harbor-cli$ ./harbor-cli project list create
Error: accepts 0 arg(s), received 1
```
This PR reviewed all commands where the No. of arguments were not specified and addresses that and also replaced cobra.NoArgs with cobra.ExactArgs(0) as later gives more defined error. 