### PR TITLE
enforce exact argument count for cmds

### DIFF
--- a/cmd/harbor/root/labels/create.go
+++ b/cmd/harbor/root/labels/create.go
@@ -15,7 +15,7 @@ func CreateLabelCommand() *cobra.Command {
 		Short:   "create label",
 		Long:    "create label in harbor",
 		Example: "harbor label create",
-		Args:    cobra.NoArgs,
+		Args:    cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			var err error
 			createView := &create.CreateView{

--- a/cmd/harbor/root/labels/list.go
+++ b/cmd/harbor/root/labels/list.go
@@ -15,6 +15,7 @@ func ListLabelCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "list labels",
+		Args: cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			label, err := api.ListLabel(opts)
 			if err != nil {

--- a/cmd/harbor/root/project/list.go
+++ b/cmd/harbor/root/project/list.go
@@ -19,6 +19,7 @@ func ListProjectCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "list project",
+		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			if private && public {
 				log.Fatal("Cannot specify both --private and --public flags")

--- a/cmd/harbor/root/registry/create.go
+++ b/cmd/harbor/root/registry/create.go
@@ -14,7 +14,7 @@ func CreateRegistryCommand() *cobra.Command {
 		Use:     "create",
 		Short:   "create registry",
 		Example: "harbor registry create",
-		Args:    cobra.NoArgs,
+		Args:    cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			var err error
 			createView := &api.CreateRegView{

--- a/cmd/harbor/root/registry/list.go
+++ b/cmd/harbor/root/registry/list.go
@@ -16,6 +16,7 @@ func ListRegistryCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "list registry",
+		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			registry, err := api.ListRegistries(opts)
 

--- a/cmd/harbor/root/user/create.go
+++ b/cmd/harbor/root/user/create.go
@@ -14,7 +14,7 @@ func UserCreateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "create user",
-		Args:  cobra.NoArgs,
+		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			var err error
 			createView := &create.CreateView{

--- a/cmd/harbor/root/user/list.go
+++ b/cmd/harbor/root/user/list.go
@@ -15,7 +15,7 @@ func UserListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "list users",
-		Args:    cobra.NoArgs,
+		Args:    cobra.ExactArgs(0),
 		Aliases: []string{"ls"},
 		Run: func(cmd *cobra.Command, args []string) {
 			response, err := api.ListUsers(opts)


### PR DESCRIPTION
This PR fixes issue #293 by giving the below error 
```
rizul@rizu:~/harbor-cli$ ./harbor-cli project list create
Error: accepts 0 arg(s), received 1
```
This PR reviewed all commands where the No. of arguments were not specified and addresses that and also replaced cobra.NoArgs with cobra.ExactArgs(0) as later gives more defined error. 