### PR TITLE
docs: update README to include directory change after cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ dagger call build-dev --platform darwin/arm64 export --path=./harbor-cli
 If golang is installed in your system, you can also build the project using the following commands:
 
 ```bash
-git clone https://github.com/goharbor/harbor-cli.git
+git clone https://github.com/goharbor/harbor-cli.git && cd harbor-cli
 go build -o harbor-cli cmd/harbor/main.go
 ```
 


### PR DESCRIPTION
there was this issue that there was no command to move to cloned directory after cloning so this PR fixes that 
Earlier it gave error like this 
```
rizul@rizu:~$ go build -o harbor-cli cmd/harbor/main.go
package cmd/harbor/main.go is not in std (/snap/go/10748/src/cmd/harbor/main.go)
```