### PR TITLE
Deleting multiple project at once

### DIFF
--- a/cmd/harbor/root/project/delete.go
+++ b/cmd/harbor/root/project/delete.go
@@ -34,6 +34,9 @@ func DeleteProjectCommand() *cobra.Command {
 			if len(args) > 0 {
 				for _, arg := range args {
 					err = api.DeleteProject(arg, forceDelete)
+					if err != nil {
+						log.Errorf("failed to delete project: %v", err)
+					}
 				}
 			} else {
 				projectName := prompt.GetProjectNameFromUser()

--- a/cmd/harbor/root/project/delete.go
+++ b/cmd/harbor/root/project/delete.go
@@ -32,7 +32,9 @@ func DeleteProjectCommand() *cobra.Command {
 			var err error
 
 			if len(args) > 0 {
-				err = api.DeleteProject(args[0], forceDelete)
+				for _, arg := range args {
+					err = api.DeleteProject(arg, forceDelete)
+				}
 			} else {
 				projectName := prompt.GetProjectNameFromUser()
 				err = api.DeleteProject(projectName, forceDelete)


### PR DESCRIPTION
While deleting projects uing `harbor-cli project delete project1 project2`, the `project2` is not deleted, thus I think it's important that a logic be implemented to handle multiple projects while deleting.

In this draft I try to implement this in a well organized way including displaying views as mentioned in #316 