### PR TITLE
feat: Add ping command to check Harbor connectivity

### DIFF
--- a/cmd/harbor/root/cmd.go
+++ b/cmd/harbor/root/cmd.go
@@ -82,6 +82,7 @@ harbor help
 		HealthCommand(),
 		schedule.Schedule(),
 		labels.Labels(),
+		PingCommand(),
 	)
 
 	return root

--- a/cmd/harbor/root/ping.go
+++ b/cmd/harbor/root/ping.go
@@ -1,0 +1,34 @@
+package root
+
+import (
+	"fmt"
+
+	"github.com/goharbor/harbor-cli/pkg/api"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func PingCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ping",
+		Short: "Ping the Harbor server",
+		Long:  `Check connectivity to the Harbor server. Returns an error if Harbor is unreachable.`,
+		Example: `  harbor ping
+
+  # Example usage with verbose output
+  harbor ping -v
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := api.Ping()
+			if err != nil {
+				log.Errorf("Failed to ping Harbor: %v", err)
+				return err
+			}
+
+			fmt.Println("Pong! Successfully contacted the Harbor server.")
+			return nil
+		},
+	}
+
+	return cmd
+}


### PR DESCRIPTION
**Description:**
This PR introduces a new ping command to the Harbor CLI, allowing users to verify connectivity with the Harbor server. The command calls the existing api.Ping() function and returns a success message (Pong!) if the server is reachable.

**Changes Introduced:**

- Added a new ping command in cmd/harbor/root/ping.go.
- Registered PingCommand() in cmd/harbor/root/cmd.go.
- Calls api.Ping() from pkg/api/ping_handler.go.

**Usage Example:**
```
harbor ping
```
Output (if successful):
```
Pong! Successfully contacted the Harbor server.
```
contributes towards #94 and #315