### PR TITLE
add projectID flag option to delete project command

### DIFF
--- a/cmd/harbor/root/project/delete.go
+++ b/cmd/harbor/root/project/delete.go
@@ -23,19 +23,20 @@ import (
 // DeleteProjectCommand creates a new `harbor delete project` command
 func DeleteProjectCommand() *cobra.Command {
 	var forceDelete bool
+	var useProjectID bool
 
 	cmd := &cobra.Command{
 		Use:   "delete",
-		Short: "delete project by name or id",
+		Short: "Delete project by name or ID",
 		Args:  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			var err error
 
 			if len(args) > 0 {
-				err = api.DeleteProject(args[0], forceDelete)
+				err = api.DeleteProject(args[0], forceDelete, useProjectID)
 			} else {
 				projectName := prompt.GetProjectNameFromUser()
-				err = api.DeleteProject(projectName, forceDelete)
+				err = api.DeleteProject(projectName, forceDelete, false)
 			}
 			if err != nil {
 				log.Errorf("failed to delete project: %v", err)
@@ -45,6 +46,7 @@ func DeleteProjectCommand() *cobra.Command {
 
 	flags := cmd.Flags()
 	flags.BoolVar(&forceDelete, "force", false, "Deletes all repositories and artifacts within the project")
+	flags.BoolVar(&useProjectID, "projectID", false, "If set, treats the provided argument as a project ID instead of a project name")
 
 	return cmd
 }

--- a/cmd/harbor/root/project/view.go
+++ b/cmd/harbor/root/project/view.go
@@ -32,16 +32,16 @@ func ViewCommand() *cobra.Command {
 		Args:  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			var err error
-			var projectName string
+			var projectNameOrID string
 			var project *project.GetProjectOK
 
 			if len(args) > 0 {
-				projectName = args[0]
+				projectNameOrID = args[0]
 			} else {
-				projectName = prompt.GetProjectNameFromUser()
+				projectNameOrID = prompt.GetProjectNameFromUser()
 			}
 
-			project, err = api.GetProject(projectName)
+			project, err = api.GetProject(projectNameOrID, false)
 			if err != nil {
 				log.Errorf("failed to get project: %v", err)
 				return

--- a/cmd/harbor/root/repository/delete.go
+++ b/cmd/harbor/root/repository/delete.go
@@ -31,11 +31,11 @@ func RepoDeleteCmd() *cobra.Command {
 			var err error
 			if len(args) > 0 {
 				projectName, repoName := utils.ParseProjectRepo(args[0])
-				err = api.RepoDelete(projectName, repoName)
+				err = api.RepoDelete(projectName, repoName, false)
 			} else {
 				projectName := prompt.GetProjectNameFromUser()
 				repoName := prompt.GetRepoNameFromUser(projectName)
-				err = api.RepoDelete(projectName, repoName)
+				err = api.RepoDelete(projectName, repoName, false)
 			}
 			if err != nil {
 				log.Errorf("failed to delete repository: %v", err)

--- a/cmd/harbor/root/repository/list.go
+++ b/cmd/harbor/root/repository/list.go
@@ -44,7 +44,7 @@ func ListRepositoryCommand() *cobra.Command {
 				projectName = prompt.GetProjectNameFromUser()
 			}
 
-			repos, err = api.ListRepository(projectName)
+			repos, err = api.ListRepository(projectName, false)
 			if err != nil {
 				log.Errorf("failed to list repositories: %v", err)
 				return

--- a/pkg/api/repository_handler.go
+++ b/pkg/api/repository_handler.go
@@ -20,10 +20,19 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func RepoDelete(projectName, repoName string) error {
+func RepoDelete(projectNameOrID, repoName string, useProjectID bool) error {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {
 		return err
+	}
+
+	projectName := projectNameOrID
+	if useProjectID {
+		project, err := GetProject(projectNameOrID, useProjectID)
+		if err != nil {
+			return err
+		}
+		projectName = project.Payload.Name
 	}
 	_, err = client.Repository.DeleteRepository(ctx, &repository.DeleteRepositoryParams{ProjectName: projectName, RepositoryName: repoName})
 
@@ -51,10 +60,19 @@ func RepoView(projectName, repoName string) (*repository.GetRepositoryOK, error)
 	return response, nil
 }
 
-func ListRepository(projectName string) (repository.ListRepositoriesOK, error) {
+func ListRepository(projectNameOrID string, useProjectID bool) (repository.ListRepositoriesOK, error) {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {
 		return repository.ListRepositoriesOK{}, err
+	}
+	projectName := projectNameOrID
+
+	if useProjectID {
+		project, err := GetProject(projectNameOrID, useProjectID)
+		if err != nil {
+			return repository.ListRepositoriesOK{}, err
+		}
+		projectName = project.Payload.Name
 	}
 
 	response, err := client.Repository.ListRepositories(ctx, &repository.ListRepositoriesParams{ProjectName: projectName})

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -49,7 +49,7 @@ func GetRepoNameFromUser(projectName string) string {
 	repositoryName := make(chan string)
 
 	go func() {
-		response, err := api.ListRepository(projectName)
+		response, err := api.ListRepository(projectName, false)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -153,3 +153,8 @@ func PrintFormat[T any](resp T, format string) error {
 	}
 	return fmt.Errorf("unable to output in the specified '%s' format", format)
 }
+
+func CreateBoolPointer(b bool) *bool {
+    return &b
+}
+


### PR DESCRIPTION
# Which problem is this PR solving?
- fixes #309 

# Description of the changes
- add `projectID` flag to `delete` command in `project` command.
- add `projectID` parameter to all corresponding functions
- update project and repository handler functions accordingly

# How was this change tested?
- Running the delete command on one of the projects and verify it getting deleted:
![Screenshot 2025-02-07 at 4 54 55 AM](https://github.com/user-attachments/assets/0eaf366d-6286-4edf-b4bb-43327bd10f16)
