### PR TITLE
Add Ping Command to Harbor CLI

### DIFF
--- a/cmd/harbor/root/cmd.go
+++ b/cmd/harbor/root/cmd.go
@@ -82,6 +82,7 @@ harbor help
 		HealthCommand(),
 		schedule.Schedule(),
 		labels.Labels(),
+		PingCommand(),
 	)
 
 	return root

--- a/cmd/harbor/root/ping.go
+++ b/cmd/harbor/root/ping.go
@@ -1,0 +1,30 @@
+package root
+
+import (
+	"fmt"
+
+	"github.com/goharbor/harbor-cli/pkg/api"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func PingCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ping",
+		Short: "Ping the server",
+		Long:  "Ping the server",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println("Pinging...")
+
+			err := api.Ping()
+			if err != nil {
+				log.Errorf("Failed to ping the server: %v", err)
+				return
+			}
+
+			fmt.Println("Successfully pinged the server!")
+		},
+	}
+
+	return cmd
+}


### PR DESCRIPTION
**Description**
This PR introduces the `ping` command to the Harbor CLI, allowing users to check connectivity to the Harbor server.

**Key features:**

-Displays `Pinging... `before sending the request.
-Prints `Successfully pinged the server!` on success.
-Logs an error message if the server is unreachable.

This command helps users verify that their Harbor instance is accessible.

Run `harbor ping`

Solves ping command's issue in #94  and aims for #315 