### PR TITLE
table doesn't get printed twice

### DIFF
--- a/cmd/harbor/root/repository/list.go
+++ b/cmd/harbor/root/repository/list.go
@@ -59,7 +59,6 @@ func ListRepositoryCommand() *cobra.Command {
 			} else {
 				list.ListRepositories(repos.Payload)
 			}
-			list.ListRepositories(repos.Payload)
 		},
 	}
 


### PR DESCRIPTION
Description:
This PR fixes [#346](https://github.com/goharbor/harbor-cli/issues/346).

Before:
```
./harbor-cli repo list
┌────────────────────────────────────────────────────────────────────────────────────────┐
│  Name                      Artifacts     Pulls         Last Modified Time              │
│ ────────────────────────────────────────────────────────────────────────────────────── │
│                                                                                        │
└────────────────────────────────────────────────────────────────────────────────────────┘
┌────────────────────────────────────────────────────────────────────────────────────────┐
│  Name                      Artifacts     Pulls         Last Modified Time              │
│ ────────────────────────────────────────────────────────────────────────────────────── │
│                                                                                        │
└────────────────────────────────────────────────────────────────────────────────────────┘
```

After:
The code `list.ListRepositories(repos.Payload)` was written twice. Removed that extra line
```
./harbor-cli repo list
┌────────────────────────────────────────────────────────────────────────────────────────┐
│  Name                      Artifacts     Pulls         Last Modified Time              │
│ ────────────────────────────────────────────────────────────────────────────────────── │
│                                                                                        │
└────────────────────────────────────────────────────────────────────────────────────────┘
```