### PR TITLE
fix project search issue

### DIFF
--- a/pkg/views/base/tablelist/model.go
+++ b/pkg/views/base/tablelist/model.go
@@ -29,7 +29,7 @@ func NewModel(columns []table.Column, rows []table.Row, height int) Model {
 		table.WithColumns(columns),
 		table.WithRows(rows),
 		table.WithFocused(true),
-		table.WithHeight(height),
+		table.WithHeight(height+1),
 	)
 
 	// Set the styles for the table


### PR DESCRIPTION
## Fix table height calculation issue in `bubbletea` table formatting (#354)

### Problem  
- After an update in the `bubbletea` table formatting, the table height calculation started including the header.  
- When the length of data was `n`, the required height of the table became `n + 1` to account for the header.  
- This caused:  
  - Single entries to only display the header, not the row data.  
  - Missing the last row when listing multiple entries.  

---

### **Before**  
**Search Output:**  
```bash
rizul@rizu:~/OSS/harbor-cli$ ./harbor-cli project search 7777
┌──────────────────────────────────────────────────────────────────────────────────────────────┐
│  ID      Project Name          Access Level  Type          Repo Count    Creation Time       │
│ ──────────────────────────────────────────────────────────────────────────────────────────── │
│                                                                                              │
└──────────────────────────────────────────────────────────────────────────────────────────────┘
```
**List Output:**  
```bash
rizul@rizu:~/OSS/harbor-cli$ ./harbor-cli project list 
┌──────────────────────────────────────────────────────────────────────────────────────────────┐
│  ID      Project Name          Access Level  Type          Repo Count    Creation Time       │
│ ──────────────────────────────────────────────────────────────────────────────────────────── │
│  1220    1project4all          public        project       1             11 day ago          │
│  1277    7777                  public        project       1             7 day ago           │
│  1278    7778                  private       project       1             7 day ago           │
│  1279    7779                  private       project       1             7 day ago           │
│  1324    aaa006                private       project       0             2 day ago           │
│  1323    aaa007                private       project       0             2 day ago           │
│  1322    aaa008                private       project       0             2 day ago           │
│  1321    aaa009                private       project       0             2 day ago           │
│  1269    aaaa                  private       project       0             8 day ago           │
└──────────────────────────────────────────────────────────────────────────────────────────────┘
```

- The list command should display 10 entries, but only 9 are shown because the height was incorrectly calculated.
-  The search command shows only the header because the height was 1 for a single entry.


## Fix
Increased the table height by **1** to account for the header row.

## After Fix
- The `search` command now displays the single entry correctly.
- The `list` command displays all rows without cutting off the last entry.

```bash
rizul@rizu:~/OSS/harbor-cli$ ./harbor-cli project search 7777
┌──────────────────────────────────────────────────────────────────────────────────────────────┐
│  ID      Project Name          Access Level  Type          Repo Count    Creation Time       │
│ ──────────────────────────────────────────────────────────────────────────────────────────── │
│  1277    7777                  public        project       1             7 day ago           │
└──────────────────────────────────────────────────────────────────────────────────────────────┘

rizul@rizu:~/OSS/harbor-cli$ ./harbor-cli project list
┌──────────────────────────────────────────────────────────────────────────────────────────────┐
│  ID      Project Name          Access Level  Type          Repo Count    Creation Time       │
│ ──────────────────────────────────────────────────────────────────────────────────────────── │
│  1220    1project4all          public        project       1             11 day ago          │
│  1277    7777                  public        project       1             7 day ago           │
│  1278    7778                  private       project       1             7 day ago           │
│  1279    7779                  private       project       1             7 day ago           │
│  1324    aaa006                private       project       0             2 day ago           │
│  1323    aaa007                private       project       0             2 day ago           │
│  1322    aaa008                private       project       0             2 day ago           │
│  1321    aaa009                private       project       0             2 day ago           │
│  1269    aaaa                  private       project       0             8 day ago           │
│  1265    abc                   public        project       1             9 day ago           │
└──────────────────────────────────────────────────────────────────────────────────────────────┘
```

---

Fixes #354 and #304 