### PR TITLE
feat: set `project list` cmd to list all projects by default

### DIFF
--- a/cmd/harbor/root/project/list.go
+++ b/cmd/harbor/root/project/list.go
@@ -15,6 +15,7 @@ package project
 
 import (
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/project"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	list "github.com/goharbor/harbor-cli/pkg/views/project/list"
@@ -27,37 +28,41 @@ func ListProjectCommand() *cobra.Command {
 	var opts api.ListFlags
 	var private bool
 	var public bool
-	var projects project.ListProjectsOK
+	var allProjects []*models.Project
 	var err error
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "list project",
+		Short: "List projects",
 		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			if private && public {
 				log.Fatal("Cannot specify both --private and --public flags")
-			} else if private {
+				return
+			}
+			var listFunc func(...api.ListFlags) (project.ListProjectsOK, error)
+			if private {
 				opts.Public = false
-				projects, err = api.ListProject(opts)
+				listFunc = api.ListProject
 			} else if public {
 				opts.Public = true
-				projects, err = api.ListProject(opts)
+				listFunc = api.ListProject
 			} else {
-				projects, err = api.ListAllProjects(opts)
+				listFunc = api.ListAllProjects
 			}
 
+			allProjects, err = fetchProjects(listFunc, opts)
 			if err != nil {
 				log.Fatalf("failed to get projects list: %v", err)
 				return
 			}
 			FormatFlag := viper.GetString("output-format")
 			if FormatFlag != "" {
-				err = utils.PrintFormat(projects, FormatFlag)
+				err = utils.PrintFormat(allProjects, FormatFlag)
 				if err != nil {
 					log.Error(err)
 				}
 			} else {
-				list.ListProjects(projects.Payload)
+				list.ListProjects(allProjects)
 			}
 		},
 	}
@@ -65,11 +70,42 @@ func ListProjectCommand() *cobra.Command {
 	flags := cmd.Flags()
 	flags.StringVarP(&opts.Name, "name", "", "", "Name of the project")
 	flags.Int64VarP(&opts.Page, "page", "", 1, "Page number")
-	flags.Int64VarP(&opts.PageSize, "page-size", "", 10, "Size of per page")
+	flags.Int64VarP(&opts.PageSize, "page-size", "", 0, "Size of per page (0 to fetch all)")
 	flags.BoolVarP(&private, "private", "", false, "Show only private projects")
 	flags.BoolVarP(&public, "public", "", false, "Show only public projects")
 	flags.StringVarP(&opts.Q, "query", "q", "", "Query string to query resources")
 	flags.StringVarP(&opts.Sort, "sort", "", "", "Sort the resource list in ascending or descending order")
 
 	return cmd
+}
+
+func fetchProjects(listFunc func(...api.ListFlags) (project.ListProjectsOK, error), opts api.ListFlags) ([]*models.Project, error) {
+	var allProjects []*models.Project
+	if opts.PageSize == 0 {
+		opts.PageSize = 100
+		opts.Page = 1
+
+		for {
+			projects, err := listFunc(opts)
+			if err != nil {
+				return nil, err
+			}
+
+			allProjects = append(allProjects, projects.Payload...)
+
+			if len(projects.Payload) < int(opts.PageSize) {
+				break
+			}
+
+			opts.Page++
+		}
+	} else {
+		projects, err := listFunc(opts)
+		if err != nil {
+			return nil, err
+		}
+		allProjects = projects.Payload
+	}
+
+	return allProjects, nil
 }


### PR DESCRIPTION
# feat: update `project list` cmd to return all projects by default

## Summary
This PR updates the `project list` command to return **all projects** by default, even if no `--page-size` is specified. Previously, the command would only return **10 projects** by default due to the Harbor API's default behavior. This update ensures that the CLI will keep requesting additional pages until all projects are retrieved, unless a `--page-size` is explicitly provided.

## Changes
- Updated the `project list` command to:
  - If `--page-size` is **not provided**, the CLI will:
    - Set the `page-size` to `100` (maximum allowed by Harbor API).  
    - Keep requesting subsequent pages until all projects are retrieved.  
  - If `--page-size` is **provided**, it will use the specified value.  
- Optimized the pagination logic to minimize redundancy and improve efficiency.  
- Ensured consistent output formatting using `utils.PrintFormat`.

## Why
- The Harbor API defaults to returning **only 10 projects** per request when no `page-size` is specified.  
- This leads to incomplete results in the case of CLI unless the user explicitly sets a `--page-size` and `--page`.  
- This fix improves the user experience by returning **all projects** without manually adjusting the page size and page.  

## How
- Implemented a loop to handle paginated results:
  - Request projects with a `page-size` of `100`.  
  - Keep fetching until fewer than `100` projects are returned, indicating the last page.  
- Ensured that pagination works correctly even if `--page-size` is provided.  

## Checklist
- [x] Code tested locally  
- [ ] Updated documentation  
