### PR TITLE
fix: generate new docs for change in existing commands

### DIFF
--- a/doc/doc.go
+++ b/doc/doc.go
@@ -164,9 +164,6 @@ func MarkdownTreeCustom(cmd *cobra.Command, dir string, filePrepender, linkHandl
 
 	basename := strings.ReplaceAll(cmd.CommandPath(), " ", "-") + markdownExtension
 	filename := filepath.Join(dir, basename)
-	if _, err := os.Stat(filename); err == nil {
-		return nil
-	}
 
 	f, err := os.Create(filename)
 	if err != nil {


### PR DESCRIPTION
## Description
This PR fixes the issue #362 where existing command documentation was not being updated when command details were modified. The documentation generator previously skipped generating markdown files if the file already existed, causing the documentation to become outdated.

## Changes Made
- Removed the file existence check `(os.Stat)` in `MarkdownTreeCustom` to ensure that markdown files are regenerated even if they already exist.
-  Now, the markdown files are created or overwritten each time documentation generation is triggered, ensuring they reflect the latest command details.

## How It Works
- Removed the `os.Stat` check that prevented existing markdown files from being updated.
- Markdown files are now created or updated every time the documentation is generated.

