### PR TITLE
feat(artifact labels): add or delete label on artifact

### DIFF
--- a/cmd/harbor/root/artifact/cmd.go
+++ b/cmd/harbor/root/artifact/cmd.go
@@ -31,6 +31,7 @@ func Artifact() *cobra.Command {
 		DeleteArtifactCommand(),
 		ScanArtifactCommand(),
 		ArtifactTagsCmd(),
+		LabelsArtifactCommmand(),
 	)
 
 	return cmd

--- a/cmd/harbor/root/artifact/label.go
+++ b/cmd/harbor/root/artifact/label.go
@@ -1,0 +1,126 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package artifact
+
+import (
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+// LabelsArtifactCommmand compound command to label artifacts
+func LabelsArtifactCommmand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "label",
+		Short: "label command for artifacts",
+		Long:  `label command for artifact`,
+		Example: `harbor artifact label add <project>/<repository>/<reference> <label name>
+harbor artifact label del <project>/<repository>/<reference> <label name>
+		`,
+		Run: func(cmd *cobra.Command, args []string) {
+			log.Error("Please use label command with subcommand add or del")
+			log.Errorf("Example: %s", cmd.Example)
+		},
+	}
+	cmd.AddCommand(AddLabelArtifactCommmand())
+	cmd.AddCommand(DelLabelArtifactCommmand())
+	return cmd
+}
+
+// AddLabelArtifactCommmand add label command to artifact
+func AddLabelArtifactCommmand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "add",
+		Short:   "add label to an artifact",
+		Long:    `add label to artifact`,
+		Example: `harbor artifact label add <project>/<repository>/<reference> <label name>`,
+		Args:    cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			var err error
+			var projectName, repoName, reference string
+
+			if len(args) > 0 {
+				projectName, repoName, reference = utils.ParseProjectRepoReference(args[0])
+			}
+
+			labels, err := api.ListLabel()
+			if err != nil {
+				log.Errorf("failed to list label: %v", err)
+				return
+			}
+
+			var label *models.Label
+			for _, currentLabel := range labels.GetPayload() {
+				if currentLabel.Name == args[1] {
+					label = currentLabel
+				}
+			}
+
+			_, err = api.AddLabelArtifact(projectName, repoName, reference, label)
+			if err != nil {
+				log.Errorf("failed to add label on artifact: %v", err)
+				return
+			}
+
+			log.Infof("Label %s added on artifact %s.", args[1], args[0])
+		},
+	}
+
+	return cmd
+}
+
+// DelLabelArtifactCommmand delete label command to artifact
+func DelLabelArtifactCommmand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "delete",
+		Aliases: []string{"del"},
+		Short:   "del label to an artifact",
+		Long:    `del label to artifact`,
+		Example: `harbor artifact label del <project>/<repository>/<reference> <label name>`,
+		Args:    cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			var err error
+			var projectName, repoName, reference string
+
+			if len(args) > 0 {
+				projectName, repoName, reference = utils.ParseProjectRepoReference(args[0])
+			}
+
+			labels, err := api.ListLabel()
+			if err != nil {
+				log.Errorf("failed to list label: %v", err)
+				return
+			}
+
+			var label *models.Label
+			for _, currentLabel := range labels.GetPayload() {
+				if currentLabel.Name == args[1] {
+					label = currentLabel
+				}
+			}
+
+			_, err = api.RemoveLabelArtifact(projectName, repoName, reference, label)
+			if err != nil {
+				log.Errorf("failed to remove label on artifact: %v", err)
+				return
+			}
+
+			log.Infof("Label %s removed on artifact %s.", args[1], args[0])
+		},
+	}
+
+	return cmd
+}

--- a/pkg/api/artifact_handler.go
+++ b/pkg/api/artifact_handler.go
@@ -196,3 +196,49 @@ func CreateTag(projectName, repoName, reference, tagName string) error {
 	log.Infof("Tag created successfully: %s/%s@%s:%s", projectName, repoName, reference, tagName)
 	return nil
 }
+
+// AddLabelArtifact put label on a specific artifact.
+func AddLabelArtifact(projectName, repoName, reference string, label *models.Label) (*artifact.AddLabelOK, error) {
+	ctx, client, err := utils.ContextWithClient()
+	var response = &artifact.AddLabelOK{}
+	if err != nil {
+		return response, err
+	}
+
+	response, err = client.Artifact.AddLabel(ctx, &artifact.AddLabelParams{
+		ProjectName:    projectName,
+		RepositoryName: repoName,
+		Reference:      reference,
+		Label:          label,
+	})
+
+	if err != nil {
+		log.Errorf("Failed to set label on artifact: %v", err)
+		return response, err
+	}
+
+	return response, nil
+}
+
+// LabelArtifact delete a label from a specific artifact.
+func RemoveLabelArtifact(projectName, repoName, reference string, label *models.Label) (*artifact.RemoveLabelOK, error) {
+	ctx, client, err := utils.ContextWithClient()
+	var response = &artifact.RemoveLabelOK{}
+	if err != nil {
+		return response, err
+	}
+
+	response, err = client.Artifact.RemoveLabel(ctx, &artifact.RemoveLabelParams{
+		ProjectName:    projectName,
+		RepositoryName: repoName,
+		Reference:      reference,
+		LabelID:        label.ID,
+	})
+
+	if err != nil {
+		log.Errorf("Failed to remove label on artifact: %v", err)
+		return response, err
+	}
+
+	return response, nil
+}


### PR DESCRIPTION
This pull request add new cobra sub command to be able to label or delete label on artifact.
I ran the linters but did not find any suitable test framework to run against.

Below the help

```
label command for artifact

Usage:
  harbor artifact label [flags]
  harbor artifact label [command]

Examples:
harbor artifact label add <project>/<repository>/<reference> <label name>
harbor artifact label del <project>/<repository>/<reference> <label name>


Available Commands:
  add         add label to an artifact
  delete      del label to an artifact

Flags:
  -h, --help   help for label

Global Flags:
  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
  -o, --output-format string   Output format. One of: json|yaml
  -v, --verbose                verbose output

Use "harbor artifact label [command] --help" for more information about a command.
```