### PR TITLE
feat: Remove month from autogenerated man-docs

### DIFF
--- a/doc/man-docs/man_doc.go
+++ b/doc/man-docs/man_doc.go
@@ -80,7 +80,7 @@ func cleanManPages(docDir string) error {
 					re := regexp.MustCompile(`"[^"]*"`)
 					matches := re.FindAllString(line, -1)
 					if len(matches) >= 5 {
-						matches[2] = `` 
+						matches[2] = ``
 						lines[i] = ".TH " + strings.Join(matches, " ")
 					}
 				}


### PR DESCRIPTION
## Description
This PR modifies the ManDoc function to remove the auto-generated date (e.g., "Apr 2025") from the .TH header line in the man pages generated by the Harbor CLI. The date field is automatically added by Cobra's doc.GenManTree function, even when not explicitly specified in the doc.GenManHeader. To address this, a post-processing step has been added to clean up the .TH line and ensure the date field is empty.

### Approach
- Introduced a regex-based approach to identify and modify the .TH header line in the generated man pages.
- The third quoted field (date) in .TH is removed to ensure no date is included

### Why This Change Is Needed
- The auto-generated date in the .TH header can lead to non-deterministic builds, as the date changes based on when the documentation is generated.
- Removing the date ensures consistency across builds and makes it easier to track changes in documentation without unnecessary diffs caused by date updates.