### PR TITLE
feat: Enhance `user list` cmd to fetch all users by default via paginated API calls

### DIFF
--- a/cmd/harbor/root/labels/list.go
+++ b/cmd/harbor/root/labels/list.go
@@ -47,6 +47,10 @@ func ListLabelCommand() *cobra.Command {
 					log.Error(err)
 				}
 			} else {
+				if len(label.Payload) == 0 {
+					log.Info("No labels found")
+					return nil
+				}
 				list.ListLabels(label.Payload)
 			}
 			return nil

--- a/cmd/harbor/root/labels/list.go
+++ b/cmd/harbor/root/labels/list.go
@@ -40,17 +40,17 @@ func ListLabelCommand() *cobra.Command {
 			if err != nil {
 				log.Fatalf("failed to get label list: %v", err)
 			}
-			FormatFlag := viper.GetString("output-format")
-			if FormatFlag != "" {
-				err = utils.PrintFormat(label, FormatFlag)
+			if len(label.Payload) == 0 {
+				log.Info("No labels found")
+				return nil
+			}
+			formatFlag := viper.GetString("output-format")
+			if formatFlag != "" {
+				err = utils.PrintFormat(label, formatFlag)
 				if err != nil {
 					log.Error(err)
 				}
 			} else {
-				if len(label.Payload) == 0 {
-					log.Info("No labels found")
-					return nil
-				}
 				list.ListLabels(label.Payload)
 			}
 			return nil

--- a/cmd/harbor/root/project/list.go
+++ b/cmd/harbor/root/project/list.go
@@ -21,6 +21,7 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	list "github.com/goharbor/harbor-cli/pkg/views/project/list"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -58,9 +59,13 @@ func ListProjectCommand() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to get projects list: %v", err)
 			}
-			FormatFlag := viper.GetString("output-format")
-			if FormatFlag != "" {
-				err = utils.PrintFormat(allProjects, FormatFlag)
+			if len(allProjects) == 0 {
+				log.Info("No projects found")
+				return nil
+			}
+			formatFlag := viper.GetString("output-format")
+			if formatFlag != "" {
+				err = utils.PrintFormat(allProjects, formatFlag)
 				if err != nil {
 					return err
 				}

--- a/cmd/harbor/root/registry/list.go
+++ b/cmd/harbor/root/registry/list.go
@@ -41,9 +41,13 @@ func ListRegistryCommand() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to get projects list: %v", err)
 			}
-			FormatFlag := viper.GetString("output-format")
-			if FormatFlag != "" {
-				err = utils.PrintFormat(registry, FormatFlag)
+			if len(registry.Payload) == 0 {
+				log.Info("No registries found")
+				return nil
+			}
+			formatFlag := viper.GetString("output-format")
+			if formatFlag != "" {
+				err = utils.PrintFormat(registry, formatFlag)
 				if err != nil {
 					log.Error(err)
 				}

--- a/cmd/harbor/root/repository/list.go
+++ b/cmd/harbor/root/repository/list.go
@@ -53,7 +53,10 @@ func ListRepositoryCommand() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to list repositories: %v", err)
 			}
-
+			if len(repos.Payload) == 0 {
+				log.Info("No repositories found")
+				return nil
+			}
 			FormatFlag := viper.GetString("output-format")
 			if FormatFlag != "" {
 				err = utils.PrintFormat(repos, FormatFlag)
@@ -61,10 +64,6 @@ func ListRepositoryCommand() *cobra.Command {
 					log.Error(err)
 				}
 			} else {
-				if len(repos.Payload) == 0 {
-					log.Info("No repositories found")
-					return nil
-				}
 				list.ListRepositories(repos.Payload)
 			}
 			return nil

--- a/cmd/harbor/root/repository/list.go
+++ b/cmd/harbor/root/repository/list.go
@@ -61,6 +61,10 @@ func ListRepositoryCommand() *cobra.Command {
 					log.Error(err)
 				}
 			} else {
+				if len(repos.Payload) == 0 {
+					log.Info("No repositories found")
+					return nil
+				}
 				list.ListRepositories(repos.Payload)
 			}
 			return nil

--- a/cmd/harbor/root/user/list.go
+++ b/cmd/harbor/root/user/list.go
@@ -1,21 +1,9 @@
-// Copyright Project Harbor Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 package user
 
 import (
 	"fmt"
 
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/user/list"
@@ -26,10 +14,11 @@ import (
 
 func UserListCmd() *cobra.Command {
 	var opts api.ListFlags
+	var allUsers []*models.UserResp // assuming api.User is the response type
 
 	cmd := &cobra.Command{
 		Use:     "list",
-		Short:   "list users",
+		Short:   "List users",
 		Args:    cobra.ExactArgs(0),
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -37,22 +26,45 @@ func UserListCmd() *cobra.Command {
 				return fmt.Errorf("page size should be less than or equal to 100")
 			}
 
-			response, err := api.ListUsers(opts)
-			if err != nil {
-				if isUnauthorizedError(err) {
-					return fmt.Errorf("Permission denied: Admin privileges are required to execute this command.")
-				} else {
+			if opts.PageSize == 0 {
+				opts.PageSize = 100
+				opts.Page = 1
+
+				for {
+					response, err := api.ListUsers(opts)
+					if err != nil {
+						if isUnauthorizedError(err) {
+							return fmt.Errorf("Permission denied: Admin privileges are required to execute this command.")
+						}
+						return fmt.Errorf("failed to list users: %v", err)
+					}
+
+					allUsers = append(allUsers, response.Payload...)
+
+					if len(response.Payload) < int(opts.PageSize) {
+						break
+					}
+					opts.Page++
+				}
+			} else {
+				response, err := api.ListUsers(opts)
+				if err != nil {
+					if isUnauthorizedError(err) {
+						return fmt.Errorf("Permission denied: Admin privileges are required to execute this command.")
+					}
 					return fmt.Errorf("failed to list users: %v", err)
 				}
+				allUsers = response.Payload
 			}
+
 			FormatFlag := viper.GetString("output-format")
 			if FormatFlag != "" {
-				err = utils.PrintFormat(response, FormatFlag)
+				err := utils.PrintFormat(allUsers, FormatFlag)
 				if err != nil {
 					log.Error(err)
 				}
 			} else {
-				list.ListUsers(response.Payload)
+				list.ListUsers(allUsers)
 			}
 			return nil
 		},
@@ -60,7 +72,7 @@ func UserListCmd() *cobra.Command {
 
 	flags := cmd.Flags()
 	flags.Int64VarP(&opts.Page, "page", "p", 1, "Page number")
-	flags.Int64VarP(&opts.PageSize, "page-size", "n", 10, "Size of per page")
+	flags.Int64VarP(&opts.PageSize, "page-size", "n", 0, "Size of per page (0 to fetch all)")
 	flags.StringVarP(&opts.Q, "query", "q", "", "Query string to query resources")
 	flags.StringVarP(&opts.Sort, "sort", "s", "", "Sort the resource list in ascending or descending order")
 

--- a/cmd/harbor/root/user/list.go
+++ b/cmd/harbor/root/user/list.go
@@ -14,7 +14,7 @@ import (
 
 func UserListCmd() *cobra.Command {
 	var opts api.ListFlags
-	var allUsers []*models.UserResp // assuming api.User is the response type
+	var allUsers []*models.UserResp
 
 	cmd := &cobra.Command{
 		Use:     "list",

--- a/cmd/harbor/root/user/list.go
+++ b/cmd/harbor/root/user/list.go
@@ -69,10 +69,13 @@ func UserListCmd() *cobra.Command {
 				}
 				allUsers = response.Payload
 			}
-
-			FormatFlag := viper.GetString("output-format")
-			if FormatFlag != "" {
-				err := utils.PrintFormat(allUsers, FormatFlag)
+			if len(allUsers) == 0 {
+				log.Info("No users found")
+				return nil
+			}
+			formatFlag := viper.GetString("output-format")
+			if formatFlag != "" {
+				err := utils.PrintFormat(allUsers, formatFlag)
 				if err != nil {
 					log.Error(err)
 				}

--- a/cmd/harbor/root/user/list.go
+++ b/cmd/harbor/root/user/list.go
@@ -1,3 +1,16 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package user
 
 import (


### PR DESCRIPTION
## Description:

This PR updates the `user list` command in the Harbor CLI to support listing **all users** when no `--page-size` is specified (i.e., set to `0`). It mirrors the behavior of the `project list` command.

## 🛠️ Key Changes:

- Added support for repeated paginated API calls when `--page-size` is `0`, with a default of `page-size=100`.
- Ensures consistent behavior with other commands like `project list`.
- Introduced a check in relevant list views to **avoid printing empty tables**.
  - If no entries are found, a clean message like `"No users found`` is printed instead. This is done for all list commands.

## Behavior:

| CLI Input                         | Result                            |
|----------------------------------|-----------------------------------|
| `harbor user list`               | Fetches **all users**             |
| `harbor user list -n 20`         | Fetches **20 users** (1 page)     |
| `harbor user list -n 100 -p 2`   | Fetches page 2 with 100 users     |


