### PR TITLE
Adds login with trailing slash

### DIFF
--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -49,11 +49,9 @@ func FormatUrl(url string) string {
 		// If not, prepend "https://"
 		url = "https://" + url
 	}
-	// Check if URL ends with trailing "/". If so remove it
-	suffix := "/"
-	if strings.HasSuffix(url, suffix) {
-		url = url[:len(url)-len(suffix)]
-	}
+
+	// Remove all trailing slashes from the URL
+	url = strings.TrimRight(url, "/")
 	return url
 }
 

--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -49,6 +49,11 @@ func FormatUrl(url string) string {
 		// If not, prepend "https://"
 		url = "https://" + url
 	}
+	// Check if URL ends with trailing "/". If so remove it
+	suffix := "/"
+	if strings.HasSuffix(url, suffix) {
+		url = url[:len(url)-len(suffix)]
+	}
 	return url
 }
 


### PR DESCRIPTION
## Related Issue: 
https://github.com/goharbor/harbor-cli/issues/297
## Description: 
Adds feature to login using URLs with leading slash. The inbuilt harbor modules don't seem to work the same if the URL has a leading slash. A simple workaround is to remove any trailing slashes from the URL before any further processing