### PR TITLE
Add FileKeyring as fallback for secure key storage

### DIFF
--- a/test/e2e/encryption_test.go
+++ b/test/e2e/encryption_test.go
@@ -50,3 +50,37 @@ func Test_EncryptionWithMockKeyring(t *testing.T) {
 		t.Fatalf("expected %s but got %s", plaintext, decrypted)
 	}
 }
+
+func Test_EncryptionWithFileKeyring(t *testing.T) {
+	// Use file keyring for tests
+	fileKeyring := utils.FileKeyring{
+		BaseDir: t.TempDir(),
+	}
+	utils.SetKeyringProvider(&fileKeyring)
+
+	// Run tests
+	err := utils.GenerateEncryptionKey()
+	if err != nil {
+		t.Fatalf("failed to generate encryption key: %v", err)
+	}
+
+	key, err := utils.GetEncryptionKey()
+	if err != nil {
+		t.Fatalf("failed to get encryption key: %v", err)
+	}
+
+	plaintext := "my-secret"
+	encrypted, err := utils.Encrypt(key, []byte(plaintext))
+	if err != nil {
+		t.Fatalf("failed to encrypt: %v", err)
+	}
+
+	decrypted, err := utils.Decrypt(key, encrypted)
+	if err != nil {
+		t.Fatalf("failed to decrypt: %v", err)
+	}
+
+	if decrypted != plaintext {
+		t.Fatalf("expected %s but got %s", plaintext, decrypted)
+	}
+}


### PR DESCRIPTION
## Add FileKeyring as fallback for secure key storage

**Fixes** #384

### Problem
In containerized environments (e.g. harbor-cli containers), system keyring providers are often unavailable, making it impossible to securely store encryption keys.

### Solution
Implement a `FileKeyring` type that serves as a fallback mechanism when no system keyring is detected. The encryption private key is now stored in an encrypted file within the user's home directory (`~/.harbor/keyring` by default).

### Key Implementation Details
- **Automatic Fallback**: System keyring remains first priority, FileKeyring used as secondary option
- **Secure Storage**:
  - Strict `600` file permissions
- **Container-Friendly**: Works without DBus/Keychain access
- **New `init` Function**: Centralized provider selection logic

### Security Considerations
- Open to security hardening suggestions

### Testing
1. Validated in Docker container (Golang:1.22)
2. Manual verification of fallback behavior

### Preview
<img width="736" alt="Screenshot 2025-04-09 at 22 02 59" src="https://github.com/user-attachments/assets/e5e343b0-40fd-460e-a841-9693fa134b41" />
