### PR TITLE
Add keyring fallback hierarchy for containerized environments

### DIFF
--- a/test/e2e/encryption_test.go
+++ b/test/e2e/encryption_test.go
@@ -84,3 +84,37 @@ func Test_EncryptionWithFileKeyring(t *testing.T) {
 		t.Fatalf("expected %s but got %s", plaintext, decrypted)
 	}
 }
+
+func Test_EncryptionWithEnvironmentKeyring(t *testing.T) {
+	// Use environment keyring for tests
+	envKeyring := utils.EnvironmentKeyring{
+		EnvVarName: "TEST_HARBOR_ENCRYPTION_KEY",
+	}
+	utils.SetKeyringProvider(&envKeyring)
+
+	// Run tests
+	err := utils.GenerateEncryptionKey()
+	if err != nil {
+		t.Fatalf("failed to generate encryption key: %v", err)
+	}
+
+	key, err := utils.GetEncryptionKey()
+	if err != nil {
+		t.Fatalf("failed to get encryption key: %v", err)
+	}
+
+	plaintext := "my-secret"
+	encrypted, err := utils.Encrypt(key, []byte(plaintext))
+	if err != nil {
+		t.Fatalf("failed to encrypt: %v", err)
+	}
+
+	decrypted, err := utils.Decrypt(key, encrypted)
+	if err != nil {
+		t.Fatalf("failed to decrypt: %v", err)
+	}
+
+	if decrypted != plaintext {
+		t.Fatalf("expected %s but got %s", plaintext, decrypted)
+	}
+}


### PR DESCRIPTION
**Fixes** #386

# Problem
Harbor CLI fails to run in container environments due to missing system keyring services.
# Solution
This PR implements a hierarchical keyring fallback system that prioritizes:

1. Environment variables (HARBOR_ENCRYPTION_KEY) - ideal for containers/Kubernetes
2. System keyring - best for desktop environments
3. File-based storage - fallback when neither of the above is available

# Implementation details
- Added EnvironmentKeyring for containerized environments
- Added validation of encryption key sizes with clear error messages
- Improved debug and info logging for keyring selection

# Usage examples

## Docker container with environment key:
```bash
# Generate a secure AES-256 key
docker run --rm -e HARBOR_ENCRYPTION_KEY=$(openssl rand -base64 32) \
  goharbor/harbor-cli login https://demo.goharbor.io -u username -p password
```

## Kubernetes usage:
```yaml
# secrets.yaml
apiVersion: v1
kind: Secret
metadata:
  name: harbor-cli-secrets
type: Opaque
data:
  HARBOR_ENCRYPTION_KEY: "<base64-encoded-key>"

# deployment.yaml
spec:
  containers:
  - name: harbor-cli
    image: goharbor/harbor-cli
    envFrom:
    - secretRef:
        name: harbor-cli-secrets
```

# Testing
Added comprehensive tests for keyring providers: Test_EncryptionWithEnvironmentKeyring

# Documentation updates:
Where do they go? Into the main README.md?