### PR TITLE
Improve user message in proxy cache project creation without adding registry-id

### DIFF
--- a/cmd/harbor/root/project/create.go
+++ b/cmd/harbor/root/project/create.go
@@ -40,7 +40,7 @@ func CreateProjectCommand() *cobra.Command {
 			if len(args) > 0 {
 				opts.ProjectName = args[0]
 
-				if(opts.ProxyCache && opts.RegistryID == "") {
+				if opts.ProxyCache && opts.RegistryID == "" {
 					log.Errorf("Use the --registry-id flag with a registry ID")
 				} else {
 					err = api.CreateProject(opts)

--- a/cmd/harbor/root/project/create.go
+++ b/cmd/harbor/root/project/create.go
@@ -39,7 +39,14 @@ func CreateProjectCommand() *cobra.Command {
 			}
 			if len(args) > 0 {
 				opts.ProjectName = args[0]
-				err = api.CreateProject(opts)
+
+				if(opts.ProxyCache && opts.RegistryID == "") {
+					log.Errorf("Use the --registry-id flag with a registry ID")
+				} else {
+					err = api.CreateProject(opts)
+				}
+
+				//err = api.CreateProject(opts)
 			} else {
 				err = createProjectView(createView)
 			}

--- a/cmd/harbor/root/project/create.go
+++ b/cmd/harbor/root/project/create.go
@@ -45,8 +45,6 @@ func CreateProjectCommand() *cobra.Command {
 				} else {
 					err = api.CreateProject(opts)
 				}
-
-				//err = api.CreateProject(opts)
 			} else {
 				err = createProjectView(createView)
 			}


### PR DESCRIPTION
I think it is better to display a clear error message when an user don't specify registry-id for a proxy cache project creation.

Fix #394 

Tested with the PR:

```
$ ./harbor-cli project create docker-hub --proxy-cache
ERRO Use the --registry-id flag with a registry ID
```