### PR TITLE
Fix: Version in "harbor version" command

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,6 +11,7 @@ builds:
     - CGO_ENABLED=0
   ldflags:
     - -w -s -X github.com/goharbor/harbor-cli/cmd/harbor/internal/version.GitCommit={{.FullCommit}}
+    - -X github.com/goharbor/harbor-cli/cmd/harbor/internal/version.Version={{.Tag}}
   goos:
     - linux
     - windows


### PR DESCRIPTION
For the moment the version of the CLI displayed in "harbor version" is wrong:

```
$ harbor version
Version:      0.1.0
Go version:
Git commit:   651cfb4090e8b0d396c1faa902e404c7bdc5e66a
Built:
OS/Arch:      darwin/arm64
```

This PR fix #400 