### PR TITLE
feat: replace random widths with standard custom widths

### DIFF
--- a/pkg/views/artifact/list/view.go
+++ b/pkg/views/artifact/list/view.go
@@ -27,11 +27,11 @@ import (
 
 var columns = []table.Column{
 	{Title: "ID", Width: tablelist.WidthXS},
-	{Title: "Artifact Digest", Width: tablelist.WidthL},
+	{Title: "Artifact Digest", Width: tablelist.WidthXL},
 	{Title: "Type", Width: tablelist.WidthS},
 	{Title: "Size", Width: tablelist.WidthS},
-	{Title: "Vulnerabilities", Width: tablelist.WidthM},
-	{Title: "Push Time", Width: tablelist.WidthM},
+	{Title: "Vulnerabilities", Width: tablelist.WidthL},
+	{Title: "Push Time", Width: tablelist.WidthL},
 }
 
 func ListArtifacts(artifacts []*models.Artifact) {

--- a/pkg/views/artifact/list/view.go
+++ b/pkg/views/artifact/list/view.go
@@ -26,12 +26,12 @@ import (
 )
 
 var columns = []table.Column{
-	{Title: "ID", Width: 6},
-	{Title: "Artifact Digest", Width: 20},
-	{Title: "Type", Width: 12},
-	{Title: "Size", Width: 12},
-	{Title: "Vulnerabilities", Width: 15},
-	{Title: "Push Time", Width: 12},
+	{Title: "ID", Width: tablelist.WidthXS},
+	{Title: "Artifact Digest", Width: tablelist.WidthL},
+	{Title: "Type", Width: tablelist.WidthS},
+	{Title: "Size", Width: tablelist.WidthS},
+	{Title: "Vulnerabilities", Width: tablelist.WidthM},
+	{Title: "Push Time", Width: tablelist.WidthM},
 }
 
 func ListArtifacts(artifacts []*models.Artifact) {

--- a/pkg/views/artifact/tags/list/view.go
+++ b/pkg/views/artifact/tags/list/view.go
@@ -25,9 +25,9 @@ import (
 )
 
 var columns = []table.Column{
-	{Title: "Name", Width: 12},
-	{Title: "Pull Time", Width: 30},
-	{Title: "Push Time", Width: 30},
+	{Title: "Name", Width: tablelist.WidthL},
+	{Title: "Pull Time", Width: tablelist.WidthL},
+	{Title: "Push Time", Width: tablelist.WidthL},
 }
 
 func ListTags(tags []*models.Tag) {

--- a/pkg/views/artifact/view/view.go
+++ b/pkg/views/artifact/view/view.go
@@ -26,12 +26,12 @@ import (
 )
 
 var columns = []table.Column{
-	{Title: "ID", Width: 6},
-	{Title: "Artifact Digest", Width: 20},
-	{Title: "Type", Width: 12},
-	{Title: "Size", Width: 12},
-	{Title: "Vulnerabilities", Width: 15},
-	{Title: "Push Time", Width: 12},
+	{Title: "ID", Width: tablelist.WidthXS},
+	{Title: "Artifact Digest", Width: tablelist.WidthL},
+	{Title: "Type", Width: tablelist.WidthS},
+	{Title: "Size", Width: tablelist.WidthS},
+	{Title: "Vulnerabilities", Width: tablelist.WidthM},
+	{Title: "Push Time", Width: tablelist.WidthM},
 }
 
 func ViewArtifact(artifact *models.Artifact) {

--- a/pkg/views/artifact/view/view.go
+++ b/pkg/views/artifact/view/view.go
@@ -27,11 +27,11 @@ import (
 
 var columns = []table.Column{
 	{Title: "ID", Width: tablelist.WidthXS},
-	{Title: "Artifact Digest", Width: tablelist.WidthL},
+	{Title: "Artifact Digest", Width: tablelist.WidthXL},
 	{Title: "Type", Width: tablelist.WidthS},
 	{Title: "Size", Width: tablelist.WidthS},
-	{Title: "Vulnerabilities", Width: tablelist.WidthM},
-	{Title: "Push Time", Width: tablelist.WidthM},
+	{Title: "Vulnerabilities", Width: tablelist.WidthL},
+	{Title: "Push Time", Width: tablelist.WidthL},
 }
 
 func ViewArtifact(artifact *models.Artifact) {

--- a/pkg/views/base/tablelist/model.go
+++ b/pkg/views/base/tablelist/model.go
@@ -21,11 +21,12 @@ import (
 )
 
 const (
-	WidthXS = 5
-	WidthS  = 10
-	WidthM  = 15
-	WidthL  = 20
-	WidthXL = 25
+	WidthXS  = 4
+	WidthS   = 8
+	WidthM   = 12
+	WidthL   = 16
+	WidthXL  = 20
+	WidthXXL = 24
 )
 
 type Model struct {

--- a/pkg/views/base/tablelist/model.go
+++ b/pkg/views/base/tablelist/model.go
@@ -20,6 +20,14 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/views"
 )
 
+const (
+	WidthXS = 5
+	WidthS  = 10
+	WidthM  = 15
+	WidthL  = 20
+	WidthXL = 25
+)
+
 type Model struct {
 	Table table.Model
 }

--- a/pkg/views/health/view.go
+++ b/pkg/views/health/view.go
@@ -25,8 +25,8 @@ import (
 )
 
 var columns = []table.Column{
-	{Title: "Component", Width: 18},
-	{Title: "Status", Width: 26},
+	{Title: "Component", Width: tablelist.WidthL},
+	{Title: "Status", Width: tablelist.WidthXL},
 }
 
 func PrintHealthStatus(status *health.GetHealthOK) {

--- a/pkg/views/health/view.go
+++ b/pkg/views/health/view.go
@@ -26,7 +26,7 @@ import (
 
 var columns = []table.Column{
 	{Title: "Component", Width: tablelist.WidthL},
-	{Title: "Status", Width: tablelist.WidthXL},
+	{Title: "Status", Width: tablelist.WidthXXL},
 }
 
 func PrintHealthStatus(status *health.GetHealthOK) {

--- a/pkg/views/label/list/view.go
+++ b/pkg/views/label/list/view.go
@@ -25,11 +25,11 @@ import (
 )
 
 var columns = []table.Column{
-	{Title: "ID", Width: 6},
-	{Title: "Name", Width: 12},
-	{Title: "Color", Width: 12},
-	{Title: "Description", Width: 18},
-	{Title: "Creation Time", Width: 24},
+	{Title: "ID", Width: tablelist.WidthXS},
+	{Title: "Name", Width: tablelist.WidthM},
+	{Title: "Color", Width: tablelist.WidthM},
+	{Title: "Description", Width: tablelist.WidthXL},
+	{Title: "Creation Time", Width: tablelist.WidthL},
 }
 
 func ListLabels(labels []*models.Label) {

--- a/pkg/views/project/list/view.go
+++ b/pkg/views/project/list/view.go
@@ -26,12 +26,12 @@ import (
 )
 
 var columns = []table.Column{
-	{Title: "ID", Width: 6},
-	{Title: "Project Name", Width: 20},
-	{Title: "Access Level", Width: 12},
-	{Title: "Type", Width: 12},
-	{Title: "Repo Count", Width: 12},
-	{Title: "Creation Time", Width: 18},
+	{Title: "ID", Width: tablelist.WidthXS},
+	{Title: "Project Name", Width: tablelist.WidthXL},
+	{Title: "Access Level", Width: tablelist.WidthM},
+	{Title: "Type", Width: tablelist.WidthM},
+	{Title: "Repo Count", Width: tablelist.WidthS},
+	{Title: "Creation Time", Width: tablelist.WidthL},
 }
 
 func ListProjects(projects []*models.Project) {

--- a/pkg/views/project/list/view.go
+++ b/pkg/views/project/list/view.go
@@ -27,9 +27,9 @@ import (
 
 var columns = []table.Column{
 	{Title: "ID", Width: tablelist.WidthXS},
-	{Title: "Project Name", Width: tablelist.WidthXL},
-	{Title: "Access Level", Width: tablelist.WidthM},
-	{Title: "Type", Width: tablelist.WidthM},
+	{Title: "Project Name", Width: tablelist.WidthXXL},
+	{Title: "Access Level", Width: tablelist.WidthL},
+	{Title: "Type", Width: tablelist.WidthL},
 	{Title: "Repo Count", Width: tablelist.WidthS},
 	{Title: "Creation Time", Width: tablelist.WidthL},
 }

--- a/pkg/views/project/logs/view.go
+++ b/pkg/views/project/logs/view.go
@@ -25,11 +25,11 @@ import (
 )
 
 var columns = []table.Column{
-	{Title: "Username", Width: 12},
-	{Title: "Resource", Width: 24},
-	{Title: "Resource Type", Width: 12},
-	{Title: "Operation", Width: 12},
-	{Title: "Timestamp", Width: 30},
+	{Title: "Username", Width: tablelist.WidthM},
+	{Title: "Resource", Width: tablelist.WidthXXL},
+	{Title: "Resource Type", Width: tablelist.WidthM},
+	{Title: "Operation", Width: tablelist.WidthM},
+	{Title: "Timestamp", Width: tablelist.WidthL * 2},
 }
 
 func LogsProject(logs []*models.AuditLog) {

--- a/pkg/views/project/view/view.go
+++ b/pkg/views/project/view/view.go
@@ -26,12 +26,12 @@ import (
 )
 
 var columns = []table.Column{
-	{Title: "Project ID", Width: 10},
-	{Title: "Project Name", Width: 12},
-	{Title: "Access Level", Width: 12},
-	{Title: "Type", Width: 12},
-	{Title: "Repo Count", Width: 12},
-	{Title: "Creation Time", Width: 15},
+	{Title: "ID", Width: tablelist.WidthXS},
+	{Title: "Project Name", Width: tablelist.WidthM},
+	{Title: "Access Level", Width: tablelist.WidthM},
+	{Title: "Type", Width: tablelist.WidthM},
+	{Title: "Repo Count", Width: tablelist.WidthM},
+	{Title: "Creation Time", Width: tablelist.WidthL},
 }
 
 func ViewProjects(project *models.Project) {

--- a/pkg/views/registry/list/view.go
+++ b/pkg/views/registry/list/view.go
@@ -25,14 +25,12 @@ import (
 )
 
 var columns = []table.Column{
-	{Title: "ID", Width: 6},
-	{Title: "Name", Width: 12},
-	{Title: "Status", Width: 12},
-	{Title: "Endpoint URL", Width: 26},
-	{Title: "Provider", Width: 12},
-	{Title: "Creation Time", Width: 24},
-	// {Title: "Verify Remote Cert", Width: 12},
-	// {Title: "Description", Width: 12},
+	{Title: "ID", Width: tablelist.WidthXS},
+	{Title: "Name", Width: tablelist.WidthM},
+	{Title: "Status", Width: tablelist.WidthM},
+	{Title: "Endpoint URL", Width: tablelist.WidthXXL},
+	{Title: "Provider", Width: tablelist.WidthM},
+	{Title: "Creation Time", Width: tablelist.WidthXXL},
 }
 
 func ListRegistry(registry []*models.Registry) {

--- a/pkg/views/registry/view/view.go
+++ b/pkg/views/registry/view/view.go
@@ -25,13 +25,13 @@ import (
 )
 
 var columns = []table.Column{
-	{Title: "ID", Width: 5},
-	{Title: "Name", Width: 10},
-	{Title: "Status", Width: 10},
-	{Title: "Endpoint URL", Width: 20},
-	{Title: "Provider", Width: 15},
-	{Title: "Creation Time", Width: 15},
-	{Title: "Description", Width: 20},
+	{Title: "ID", Width: tablelist.WidthXS},
+	{Title: "Name", Width: tablelist.WidthM},
+	{Title: "Status", Width: tablelist.WidthM},
+	{Title: "Endpoint URL", Width: tablelist.WidthL},
+	{Title: "Provider", Width: tablelist.WidthL},
+	{Title: "Creation Time", Width: tablelist.WidthL},
+	{Title: "Description", Width: tablelist.WidthXL},
 }
 
 func ViewRegistry(registry *models.Registry) {

--- a/pkg/views/repository/list/view.go
+++ b/pkg/views/repository/list/view.go
@@ -26,10 +26,10 @@ import (
 )
 
 var columns = []table.Column{
-	{Title: "Name", Width: 24},
-	{Title: "Artifacts", Width: 12},
-	{Title: "Pulls", Width: 12},
-	{Title: "Last Modified Time", Width: 30},
+	{Title: "Name", Width: tablelist.WidthXXL},
+	{Title: "Artifacts", Width: tablelist.WidthM},
+	{Title: "Pulls", Width: tablelist.WidthM},
+	{Title: "Last Modified Time", Width: tablelist.WidthL * 2},
 }
 
 func ListRepositories(repos []*models.Repository) {

--- a/pkg/views/repository/search/view.go
+++ b/pkg/views/repository/search/view.go
@@ -25,12 +25,12 @@ import (
 )
 
 var columns = []table.Column{
-	{Title: "Repository Name", Width: 30},
-	{Title: "Project Id", Width: 11},
-	{Title: "Project Name", Width: 16},
-	{Title: "Access Level", Width: 12},
-	{Title: "Artifact Count", Width: 14},
-	{Title: "Pull Count", Width: 12},
+	{Title: "Repository Name", Width: tablelist.WidthL * 2},
+	{Title: "Project Id", Width: tablelist.WidthM},
+	{Title: "Project Name", Width: tablelist.WidthL},
+	{Title: "Access Level", Width: tablelist.WidthM},
+	{Title: "Artifact Count", Width: tablelist.WidthL},
+	{Title: "Pull Count", Width: tablelist.WidthM},
 }
 
 func SearchRepositories(repos []*models.SearchRepository) {

--- a/pkg/views/repository/view/view.go
+++ b/pkg/views/repository/view/view.go
@@ -26,14 +26,14 @@ import (
 )
 
 var columns = []table.Column{
-	{Title: "Name", Width: 20},
-	{Title: "ID", Width: 10},
-	{Title: "Project ID", Width: 10},
-	{Title: "Artifacts", Width: 10},
-	{Title: "Pulls", Width: 5},
-	{Title: "Creation Time", Width: 20},
-	{Title: "Last Modified Time", Width: 20},
-	{Title: "Description", Width: 20},
+	{Title: "Name", Width: tablelist.WidthXL},
+	{Title: "ID", Width: tablelist.WidthM},
+	{Title: "Project ID", Width: tablelist.WidthM},
+	{Title: "Artifacts", Width: tablelist.WidthM},
+	{Title: "Pulls", Width: tablelist.WidthXS},
+	{Title: "Creation Time", Width: tablelist.WidthXL},
+	{Title: "Last Modified Time", Width: tablelist.WidthXL},
+	{Title: "Description", Width: tablelist.WidthXL},
 }
 
 func ViewRepository(repo *models.Repository) {

--- a/pkg/views/schedule/list/view.go
+++ b/pkg/views/schedule/list/view.go
@@ -25,10 +25,10 @@ import (
 )
 
 var columns = []table.Column{
-	{Title: "ID", Width: 6},
-	{Title: "Cron", Width: 18},
-	{Title: "Vendor Type", Width: 28},
-	{Title: "Update Time", Width: 20},
+	{Title: "ID", Width: tablelist.WidthXS},
+	{Title: "Cron", Width: tablelist.WidthL},
+	{Title: "Vendor Type", Width: tablelist.WidthXL},
+	{Title: "Update Time", Width: tablelist.WidthXL},
 }
 
 func ListSchedule(schedule []*models.ScheduleTask) {

--- a/pkg/views/user/list/view.go
+++ b/pkg/views/user/list/view.go
@@ -26,11 +26,11 @@ import (
 )
 
 var columns = []table.Column{
-	{Title: "ID", Width: 6},
-	{Title: "Name", Width: 16},
-	{Title: "Administrator", Width: 16},
-	{Title: "Email", Width: 20},
-	{Title: "Registration Time", Width: 24},
+	{Title: "ID", Width: tablelist.WidthXS},
+	{Title: "Name", Width: tablelist.WidthL},
+	{Title: "Administrator", Width: tablelist.WidthM},
+	{Title: "Email", Width: tablelist.WidthXL},
+	{Title: "Registration Time", Width: tablelist.WidthL},
 }
 
 func ListUsers(users []*models.UserResp) {

--- a/pkg/views/user/list/view.go
+++ b/pkg/views/user/list/view.go
@@ -28,8 +28,8 @@ import (
 var columns = []table.Column{
 	{Title: "ID", Width: tablelist.WidthXS},
 	{Title: "Name", Width: tablelist.WidthL},
-	{Title: "Administrator", Width: tablelist.WidthM},
-	{Title: "Email", Width: tablelist.WidthXL},
+	{Title: "Administrator", Width: tablelist.WidthL},
+	{Title: "Email", Width: tablelist.WidthXXL},
 	{Title: "Registration Time", Width: tablelist.WidthL},
 }
 


### PR DESCRIPTION
##  Add standard column widths for all tables based on screen size

### Changes Made
- Introduced support for different table column configurations based on size (`xs`, `s`, `m`, `l`, `xl`).
- Defined `sizeMap` to map size labels to specific column configurations using predefined widths: `WidthXS`, `WidthS`, `WidthM`, `WidthL`, and `WidthXL`.
- Ensured each size layout maintains readability and avoids text truncation where possible.

### Fix #397 
