### PR TITLE
fix: remove repeated error logging in `project list` cmd

### DIFF
--- a/pkg/utils/client.go
+++ b/pkg/utils/client.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/goharbor/go-client/pkg/harbor"
 	v2client "github.com/goharbor/go-client/pkg/sdk/v2.0/client"
-	log "github.com/sirupsen/logrus"
 )
 
 var (
@@ -43,10 +42,6 @@ func GetClient() (*v2client.HarborAPI, error) {
 		}
 
 		clientInstance, clientErr = GetClientByCredentialName(credentialName)
-		if clientErr != nil {
-			log.Errorf("failed to initialize client: %v", clientErr)
-			return
-		}
 	})
 
 	return clientInstance, clientErr


### PR DESCRIPTION
### Description:

This PR addresses the issue of duplicated error messages during client initialization in the Harbor CLI. Previously, the same error was logged internally (using `log.Errorf`) and then also returned to the CLI command, resulting in multiple redundant outputs like:

```
ERRO failed to initialize client: ...
Error: failed to get projects list: ...
```

### Changes made:
- Removed internal logging (`log.Errorf`) from `GetClient()` to prevent duplicate logs.
- Error is now propagated cleanly to the CLI layer, which can handle logging uniformly in one place.
- Improved clarity and user experience by showing each error **only once**, in a consistent format.

### Result:

Now when a command like `harbor-cli project list` fails, the output is clean and free from duplication:

```
Error: failed to get projects list: failed to decrypt password: failed to decode ciphertext: illegal base64 data at input byte 8
```
### Fix #398 