### PR TITLE
Refactor: Centralized Harbor Error Parsing for all commands

### DIFF
--- a/cmd/harbor/root/artifact/delete.go
+++ b/cmd/harbor/root/artifact/delete.go
@@ -14,10 +14,11 @@
 package artifact
 
 import (
+	"fmt"
+
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -26,22 +27,22 @@ func DeleteArtifactCommand() *cobra.Command {
 		Use:   "delete",
 		Short: "delete an artifact",
 		Args:  cobra.MaximumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-
+			var projectName, repoName, reference string
 			if len(args) > 0 {
-				projectName, repoName, reference := utils.ParseProjectRepoReference(args[0])
-				err = api.DeleteArtifact(projectName, repoName, reference)
+				projectName, repoName, reference = utils.ParseProjectRepoReference(args[0])
 			} else {
-				projectName := prompt.GetProjectNameFromUser()
-				repoName := prompt.GetRepoNameFromUser(projectName)
-				reference := prompt.GetReferenceFromUser(repoName, projectName)
-				err = api.DeleteArtifact(projectName, repoName, reference)
+				projectName = prompt.GetProjectNameFromUser()
+				repoName = prompt.GetRepoNameFromUser(projectName)
+				reference = prompt.GetReferenceFromUser(repoName, projectName)
 			}
 
+			err = api.DeleteArtifact(projectName, repoName, reference)
 			if err != nil {
-				log.Errorf("failed to delete an artifact: %v", err)
+				return fmt.Errorf("failed to delete an artifact: %v", utils.ParseHarborError(err))
 			}
+			return nil
 		},
 	}
 

--- a/cmd/harbor/root/artifact/list.go
+++ b/cmd/harbor/root/artifact/list.go
@@ -46,11 +46,9 @@ func ListArtifactCommand() *cobra.Command {
 				projectName = prompt.GetProjectNameFromUser()
 				repoName = prompt.GetRepoNameFromUser(projectName)
 			}
-
 			artifacts, err = api.ListArtifact(projectName, repoName, opts)
-
 			if err != nil {
-				return fmt.Errorf("failed to list artifacts: %v", err)
+				return fmt.Errorf("failed to list artifacts: %v", utils.ParseHarborError(err))
 			}
 
 			FormatFlag := viper.GetString("output-format")

--- a/cmd/harbor/root/artifact/scan.go
+++ b/cmd/harbor/root/artifact/scan.go
@@ -14,10 +14,11 @@
 package artifact
 
 import (
+	"fmt"
+
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -44,21 +45,21 @@ func StartScanArtifactCommand() *cobra.Command {
 		Short:   "Start a scan of an artifact",
 		Long:    `Start a scan of an artifact in Harbor Repository`,
 		Example: `harbor artifact scan start <project>/<repository>/<reference>`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-
+			var projectName, repoName, reference string
 			if len(args) > 0 {
-				projectName, repoName, reference := utils.ParseProjectRepoReference(args[0])
-				err = api.StartScanArtifact(projectName, repoName, reference)
+				projectName, repoName, reference = utils.ParseProjectRepoReference(args[0])
 			} else {
-				projectName := prompt.GetProjectNameFromUser()
-				repoName := prompt.GetRepoNameFromUser(projectName)
-				reference := prompt.GetReferenceFromUser(repoName, projectName)
-				err = api.StartScanArtifact(projectName, repoName, reference)
+				projectName = prompt.GetProjectNameFromUser()
+				repoName = prompt.GetRepoNameFromUser(projectName)
+				reference = prompt.GetReferenceFromUser(repoName, projectName)
 			}
+			err = api.StartScanArtifact(projectName, repoName, reference)
 			if err != nil {
-				log.Errorf("failed to start scan of artifact: %v", err)
+				return fmt.Errorf("failed to start scan of artifact: %v", utils.ParseHarborError(err))
 			}
+			return nil
 		},
 	}
 	return cmd
@@ -70,21 +71,21 @@ func StopScanArtifactCommand() *cobra.Command {
 		Short:   "Stop a scan of an artifact",
 		Long:    `Stop a scan of an artifact in Harbor Repository`,
 		Example: `harbor artifact scan stop <project>/<repository>/<reference>`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-
+			var projectName, repoName, reference string
 			if len(args) > 0 {
-				projectName, repoName, reference := utils.ParseProjectRepoReference(args[0])
-				err = api.StopScanArtifact(projectName, repoName, reference)
+				projectName, repoName, reference = utils.ParseProjectRepoReference(args[0])
 			} else {
-				projectName := prompt.GetProjectNameFromUser()
-				repoName := prompt.GetRepoNameFromUser(projectName)
-				reference := prompt.GetReferenceFromUser(repoName, projectName)
-				err = api.StopScanArtifact(projectName, repoName, reference)
+				projectName = prompt.GetProjectNameFromUser()
+				repoName = prompt.GetRepoNameFromUser(projectName)
+				reference = prompt.GetReferenceFromUser(repoName, projectName)
 			}
+			err = api.StopScanArtifact(projectName, repoName, reference)
 			if err != nil {
-				log.Errorf("failed to stop scan of artifact: %v", err)
+				return fmt.Errorf("failed to stop scan of artifact: %v", err)
 			}
+			return nil
 		},
 	}
 	return cmd

--- a/cmd/harbor/root/artifact/tags.go
+++ b/cmd/harbor/root/artifact/tags.go
@@ -14,13 +14,14 @@
 package artifact
 
 import (
+	"fmt"
+
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/artifact"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/artifact/tags/create"
 	"github.com/goharbor/harbor-cli/pkg/views/artifact/tags/list"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -46,24 +47,25 @@ func CreateTagsCmd() *cobra.Command {
 		Use:     "create",
 		Short:   "Create a tag of an artifact",
 		Example: `harbor artifact tags create <project>/<repository>/<reference> <tag>`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-
+			var projectName, repoName, reference, tagName string
 			if len(args) > 0 {
-				projectName, repoName, reference := utils.ParseProjectRepoReference(args[0])
-				tag := args[1]
-				err = api.CreateTag(projectName, repoName, reference, tag)
+				projectName, repoName, reference = utils.ParseProjectRepoReference(args[0])
+				tagName = args[1]
 			} else {
 				var tagName string
-				projectName := prompt.GetProjectNameFromUser()
-				repoName := prompt.GetRepoNameFromUser(projectName)
-				reference := prompt.GetReferenceFromUser(repoName, projectName)
+				projectName = prompt.GetProjectNameFromUser()
+				repoName = prompt.GetRepoNameFromUser(projectName)
+				reference = prompt.GetReferenceFromUser(repoName, projectName)
 				create.CreateTagView(&tagName)
-				err = api.CreateTag(projectName, repoName, reference, tagName)
 			}
+
+			err = api.CreateTag(projectName, repoName, reference, tagName)
 			if err != nil {
-				log.Errorf("failed to create tag: %v", err)
+				return fmt.Errorf("failed to create tag: %v", utils.ParseHarborError(err))
 			}
+			return nil
 		},
 	}
 
@@ -75,7 +77,7 @@ func ListTagsCmd() *cobra.Command {
 		Use:     "list",
 		Short:   "List tags of an artifact",
 		Example: `harbor artifact tags list <project>/<repository>/<reference>`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			var tags *artifact.ListTagsOK
 			var projectName, repoName, reference string
@@ -91,20 +93,19 @@ func ListTagsCmd() *cobra.Command {
 			tags, err = api.ListTags(projectName, repoName, reference)
 
 			if err != nil {
-				log.Errorf("failed to list tags: %v", err)
-				return
+				return fmt.Errorf("failed to list tags: %v", utils.ParseHarborError(err))
 			}
 
 			FormatFlag := viper.GetString("output-format")
 			if FormatFlag != "" {
 				err = utils.PrintFormat(tags, FormatFlag)
 				if err != nil {
-					log.Error(err)
-					return
+					return err
 				}
 			} else {
 				list.ListTags(tags.Payload)
 			}
+			return nil
 		},
 	}
 
@@ -116,23 +117,23 @@ func DeleteTagsCmd() *cobra.Command {
 		Use:     "delete",
 		Short:   "Delete a tag of an artifact",
 		Example: `harbor artifact tags delete <project>/<repository>/<reference> <tag>`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-
+			var projectName, repoName, reference, tag string
 			if len(args) > 0 {
-				projectName, repoName, reference := utils.ParseProjectRepoReference(args[0])
-				tag := args[1]
-				err = api.DeleteTag(projectName, repoName, reference, tag)
+				projectName, repoName, reference = utils.ParseProjectRepoReference(args[0])
+				tag = args[1]
 			} else {
-				projectName := prompt.GetProjectNameFromUser()
-				repoName := prompt.GetRepoNameFromUser(projectName)
-				reference := prompt.GetReferenceFromUser(repoName, projectName)
-				tag := prompt.GetTagFromUser(repoName, projectName, reference)
-				err = api.DeleteTag(projectName, repoName, reference, tag)
+				projectName = prompt.GetProjectNameFromUser()
+				repoName = prompt.GetRepoNameFromUser(projectName)
+				reference = prompt.GetReferenceFromUser(repoName, projectName)
+				tag = prompt.GetTagFromUser(repoName, projectName, reference)
 			}
+			err = api.DeleteTag(projectName, repoName, reference, tag)
 			if err != nil {
-				log.Errorf("failed to delete tag: %v", err)
+				return fmt.Errorf("failed to delete tag: %v", utils.ParseHarborError(err))
 			}
+			return nil
 		},
 	}
 

--- a/cmd/harbor/root/artifact/view.go
+++ b/cmd/harbor/root/artifact/view.go
@@ -14,12 +14,13 @@
 package artifact
 
 import (
+	"fmt"
+
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/artifact"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/artifact/view"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -30,7 +31,7 @@ func ViewArtifactCommmand() *cobra.Command {
 		Short:   "Get information of an artifact",
 		Long:    `Get information of an artifact`,
 		Example: `harbor artifact view <project>/<repository>/<reference>`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			var projectName, repoName, reference string
 			var artifact *artifact.GetArtifactOK
@@ -44,22 +45,20 @@ func ViewArtifactCommmand() *cobra.Command {
 			}
 
 			artifact, err = api.ViewArtifact(projectName, repoName, reference)
-
 			if err != nil {
-				log.Errorf("failed to get info of an artifact: %v", err)
-				return
+				return fmt.Errorf("failed to get info of an artifact: %v", utils.ParseHarborError(err))
 			}
 
 			FormatFlag := viper.GetString("output-format")
 			if FormatFlag != "" {
 				err = utils.PrintFormat(artifact, FormatFlag)
 				if err != nil {
-					log.Error(err)
-					return
+					return err
 				}
 			} else {
 				view.ViewArtifact(artifact.Payload)
 			}
+			return nil
 		},
 	}
 

--- a/cmd/harbor/root/health.go
+++ b/cmd/harbor/root/health.go
@@ -29,11 +29,11 @@ func HealthCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := api.Ping()
 			if err != nil {
-				return fmt.Errorf(utils.ParseHarborError(err))
+				return fmt.Errorf("%s", utils.ParseHarborError(err))
 			}
 			status, err := api.GetHealth()
 			if err != nil {
-				return fmt.Errorf(utils.ParseHarborError(err))
+				return fmt.Errorf("%s", utils.ParseHarborError(err))
 			}
 			health.PrintHealthStatus(status)
 			return nil

--- a/cmd/harbor/root/health.go
+++ b/cmd/harbor/root/health.go
@@ -14,7 +14,10 @@
 package root
 
 import (
+	"fmt"
+
 	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/health"
 	"github.com/spf13/cobra"
 )
@@ -26,11 +29,11 @@ func HealthCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := api.Ping()
 			if err != nil {
-				return err
+				return fmt.Errorf(utils.ParseHarborError(err))
 			}
 			status, err := api.GetHealth()
 			if err != nil {
-				return err
+				return fmt.Errorf(utils.ParseHarborError(err))
 			}
 			health.PrintHealthStatus(status)
 			return nil

--- a/cmd/harbor/root/info.go
+++ b/cmd/harbor/root/info.go
@@ -55,14 +55,14 @@ func InfoCommand() *cobra.Command {
 
 			userInfo, err := client.User.GetCurrentUserInfo(ctx, &user.GetCurrentUserInfoParams{})
 			if err != nil {
-				return fmt.Errorf("failed to get current user info: %v", err)
+				return fmt.Errorf("failed to get current user info: %v", utils.ParseHarborError(err))
 			}
 
 			isSysAdmin := userInfo.Payload.SysadminFlag
 
 			sysInfo, err := client.Systeminfo.GetSystemInfo(ctx, &systeminfo.GetSystemInfoParams{})
 			if err != nil {
-				return fmt.Errorf("failed to get system info: %v", err)
+				return fmt.Errorf("failed to get system info: %v", utils.ParseHarborError(err))
 			}
 			harborVersion := sysInfo.Payload.HarborVersion
 

--- a/cmd/harbor/root/labels/create.go
+++ b/cmd/harbor/root/labels/create.go
@@ -14,9 +14,11 @@
 package labels
 
 import (
+	"fmt"
+
 	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/label/create"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -29,7 +31,7 @@ func CreateLabelCommand() *cobra.Command {
 		Long:    "create label in harbor",
 		Example: "harbor label create",
 		Args:    cobra.ExactArgs(0),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			createView := &create.CreateView{
 				Name:        opts.Name,
@@ -44,8 +46,9 @@ func CreateLabelCommand() *cobra.Command {
 			}
 
 			if err != nil {
-				log.Errorf("failed to create label: %v", err)
+				return fmt.Errorf("failed to create label: %v", utils.ParseHarborError(err))
 			}
+			return nil
 		},
 	}
 

--- a/cmd/harbor/root/labels/delete.go
+++ b/cmd/harbor/root/labels/delete.go
@@ -14,10 +14,12 @@
 package labels
 
 import (
+	"fmt"
+
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
-	log "github.com/sirupsen/logrus"
+	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -28,22 +30,24 @@ func DeleteLabelCommand() *cobra.Command {
 		Short:   "delete label",
 		Example: "harbor label delete [labelname]",
 		Args:    cobra.MaximumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			deleteView := &api.ListFlags{
 				Scope: opts.Scope,
 			}
+			var labelId int64
 
 			if len(args) > 0 {
-				labelId, _ := api.GetLabelIdByName(args[0])
-				err = api.DeleteLabel(labelId)
+				labelId, _ = api.GetLabelIdByName(args[0])
 			} else {
-				labelId := prompt.GetLabelIdFromUser(*deleteView)
-				err = api.DeleteLabel(labelId)
+				labelId = prompt.GetLabelIdFromUser(*deleteView)
 			}
+
+			err = api.DeleteLabel(labelId)
 			if err != nil {
-				log.Errorf("failed to delete label: %v", err)
+				return fmt.Errorf("failed to delete label: %v", utils.ParseHarborError(err))
 			}
+			return nil
 		},
 	}
 	flags := cmd.Flags()

--- a/cmd/harbor/root/labels/list.go
+++ b/cmd/harbor/root/labels/list.go
@@ -38,7 +38,7 @@ func ListLabelCommand() *cobra.Command {
 
 			label, err := api.ListLabel(opts)
 			if err != nil {
-				log.Fatalf("failed to get label list: %v", err)
+				return fmt.Errorf("failed to get label list: %v", utils.ParseHarborError(err))
 			}
 			if len(label.Payload) == 0 {
 				log.Info("No labels found")
@@ -48,7 +48,7 @@ func ListLabelCommand() *cobra.Command {
 			if formatFlag != "" {
 				err = utils.PrintFormat(label, formatFlag)
 				if err != nil {
-					log.Error(err)
+					return err
 				}
 			} else {
 				list.ListLabels(label.Payload)

--- a/cmd/harbor/root/labels/update.go
+++ b/cmd/harbor/root/labels/update.go
@@ -48,8 +48,8 @@ func UpdateLableCommand() *cobra.Command {
 				return fmt.Errorf("failed to parse label id: %v", err)
 			}
 
-			existingLabel := api.GetLabel(labelId)
-			if existingLabel == nil {
+			existingLabel, err := api.GetLabel(labelId)
+			if err != nil {
 				return fmt.Errorf("error in getting label %s", utils.ParseHarborError(err))
 			}
 			updateView := &models.Label{

--- a/cmd/harbor/root/labels/update.go
+++ b/cmd/harbor/root/labels/update.go
@@ -14,11 +14,13 @@
 package labels
 
 import (
+	"fmt"
+
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
+	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/label/update"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -30,7 +32,7 @@ func UpdateLableCommand() *cobra.Command {
 		Short:   "update label",
 		Example: "harbor label update [labelname]",
 		Args:    cobra.MaximumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			var labelId int64
 			updateflags := api.ListFlags{
@@ -43,13 +45,12 @@ func UpdateLableCommand() *cobra.Command {
 				labelId = prompt.GetLabelIdFromUser(updateflags)
 			}
 			if err != nil {
-				log.Errorf("failed to parse label id: %v", err)
+				return fmt.Errorf("failed to parse label id: %v", err)
 			}
 
 			existingLabel := api.GetLabel(labelId)
 			if existingLabel == nil {
-				log.Errorf("label is not found")
-				return
+				return fmt.Errorf("error in getting label %s", utils.ParseHarborError(err))
 			}
 			updateView := &models.Label{
 				Name:        existingLabel.Name,
@@ -75,8 +76,9 @@ func UpdateLableCommand() *cobra.Command {
 			update.UpdateLabelView(updateView)
 			err = api.UpdateLabel(updateView, labelId)
 			if err != nil {
-				log.Errorf("failed to update label: %v", err)
+				return fmt.Errorf("failed to update label: %v", utils.ParseHarborError(err))
 			}
+			return nil
 		},
 	}
 	flags := cmd.Flags()

--- a/cmd/harbor/root/login.go
+++ b/cmd/harbor/root/login.go
@@ -160,7 +160,7 @@ func RunLogin(opts login.LoginView) error {
 	ctx := context.Background()
 	_, err := client.User.GetCurrentUserInfo(ctx, &user.GetCurrentUserInfoParams{})
 	if err != nil {
-		return fmt.Errorf("login failed, please check your credentials: %s", err)
+		return fmt.Errorf("login failed, please check your credentials and server address, one of them is incorrect")
 	}
 	if err := utils.GenerateEncryptionKey(); err != nil {
 		fmt.Println("Encryption key already exists or could not be created:", err)
@@ -168,7 +168,6 @@ func RunLogin(opts login.LoginView) error {
 
 	key, err := utils.GetEncryptionKey()
 	if err != nil {
-		fmt.Println("Error getting encryption key:", err)
 		return fmt.Errorf("failed to get encryption key: %s", err)
 	}
 

--- a/cmd/harbor/root/project/create.go
+++ b/cmd/harbor/root/project/create.go
@@ -14,9 +14,11 @@
 package project
 
 import (
+	"fmt"
+
 	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/project/create"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -28,7 +30,7 @@ func CreateProjectCommand() *cobra.Command {
 		Use:   "create [project name]",
 		Short: "create project",
 		Args:  cobra.MaximumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			createView := &create.CreateView{
 				ProjectName:  opts.ProjectName,
@@ -45,8 +47,9 @@ func CreateProjectCommand() *cobra.Command {
 			}
 
 			if err != nil {
-				log.Errorf("failed to create project: %v", err)
+				return fmt.Errorf("failed to create project: %v", utils.ParseHarborError(err))
 			}
+			return nil
 		},
 	}
 

--- a/cmd/harbor/root/project/delete.go
+++ b/cmd/harbor/root/project/delete.go
@@ -45,7 +45,7 @@ func DeleteProjectCommand() *cobra.Command {
 					go func(projectName string) {
 						defer wg.Done()
 						if err := api.DeleteProject(projectName, forceDelete); err != nil {
-							errChan <- err
+							errChan <- fmt.Errorf("%s", utils.ParseHarborError(err))
 						}
 					}(arg)
 				}

--- a/cmd/harbor/root/project/delete.go
+++ b/cmd/harbor/root/project/delete.go
@@ -14,10 +14,12 @@
 package project
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
+	"github.com/goharbor/harbor-cli/pkg/utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -30,7 +32,7 @@ func DeleteProjectCommand() *cobra.Command {
 		Short:   "delete project by name or id",
 		Example: `  harbor project delete [projectname]`,
 		Args:    cobra.MinimumNArgs(0),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var wg sync.WaitGroup
 			errChan := make(
 				chan error,
@@ -51,7 +53,7 @@ func DeleteProjectCommand() *cobra.Command {
 				projectName := prompt.GetProjectNameFromUser()
 				err := api.DeleteProject(projectName, forceDelete)
 				if err != nil {
-					log.Errorf("failed to delete project: %v", err)
+					log.Errorf("failed to delete project: %v", utils.ParseHarborError(err))
 				}
 			}
 
@@ -71,8 +73,9 @@ func DeleteProjectCommand() *cobra.Command {
 				}
 			}
 			if finalErr != nil {
-				log.Errorf("failed to delete some projects: %v", finalErr)
+				return fmt.Errorf("failed to delete some projects: %v", finalErr)
 			}
+			return nil
 		},
 	}
 

--- a/cmd/harbor/root/project/list.go
+++ b/cmd/harbor/root/project/list.go
@@ -57,7 +57,7 @@ func ListProjectCommand() *cobra.Command {
 
 			allProjects, err = fetchProjects(listFunc, opts)
 			if err != nil {
-				return fmt.Errorf("failed to get projects list: %v", err)
+				return fmt.Errorf("failed to get projects list: %v", utils.ParseHarborError(err))
 			}
 			if len(allProjects) == 0 {
 				log.Info("No projects found")
@@ -72,7 +72,6 @@ func ListProjectCommand() *cobra.Command {
 			} else {
 				list.ListProjects(allProjects)
 			}
-
 			return nil
 		},
 	}

--- a/cmd/harbor/root/project/logs.go
+++ b/cmd/harbor/root/project/logs.go
@@ -14,12 +14,13 @@
 package project
 
 import (
+	"fmt"
+
 	proj "github.com/goharbor/go-client/pkg/sdk/v2.0/client/project"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	auditLog "github.com/goharbor/harbor-cli/pkg/views/project/logs"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -32,30 +33,30 @@ func LogsProjectCommmand() *cobra.Command {
 		Use:   "logs",
 		Short: "get project logs",
 		Args:  cobra.MaximumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			var resp *proj.GetLogsOK
+			var projectName string
 			if len(args) > 0 {
-				resp, err = api.LogsProject(args[0])
+				projectName = args[0]
 			} else {
-				projectName := prompt.GetProjectNameFromUser()
-				resp, err = api.LogsProject(projectName)
+				projectName = prompt.GetProjectNameFromUser()
 			}
-
+			resp, err = api.LogsProject(projectName)
 			if err != nil {
-				log.Fatalf("failed to get project logs: %v", err)
-				return
+				return fmt.Errorf("failed to get project logs: %v", err)
 			}
 
 			FormatFlag := viper.GetString("output-format")
 			if FormatFlag != "" {
 				err = utils.PrintFormat(resp, FormatFlag)
 				if err != nil {
-					log.Error(err)
+					return err
 				}
 			} else {
 				auditLog.LogsProject(resp.Payload)
 			}
+			return nil
 		},
 	}
 

--- a/cmd/harbor/root/project/search.go
+++ b/cmd/harbor/root/project/search.go
@@ -14,10 +14,11 @@
 package project
 
 import (
+	"fmt"
+
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/project/list"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -27,21 +28,22 @@ func SearchProjectCommand() *cobra.Command {
 		Use:   "search",
 		Short: "search project based on their names",
 		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			projects, err := api.SearchProject(args[0])
 			if err != nil {
-				log.Fatalf("failed to get projects: %v", err)
+				return fmt.Errorf("failed to get projects: %v", utils.ParseHarborError(err))
 			}
 
 			FormatFlag := viper.GetString("output-format")
 			if FormatFlag != "" {
 				err = utils.PrintFormat(projects, FormatFlag)
 				if err != nil {
-					log.Error(err)
+					return err
 				}
 			} else {
 				list.SearchProjects(projects.Payload.Project)
 			}
+			return nil
 		},
 	}
 	return cmd

--- a/cmd/harbor/root/project/view.go
+++ b/cmd/harbor/root/project/view.go
@@ -14,12 +14,13 @@
 package project
 
 import (
+	"fmt"
+
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/project"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/project/view"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -30,7 +31,7 @@ func ViewCommand() *cobra.Command {
 		Use:   "view [NAME|ID]",
 		Short: "get project by name or id",
 		Args:  cobra.MaximumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			var projectName string
 			var project *project.GetProjectOK
@@ -43,20 +44,19 @@ func ViewCommand() *cobra.Command {
 
 			project, err = api.GetProject(projectName)
 			if err != nil {
-				log.Errorf("failed to get project: %v", err)
-				return
+				return fmt.Errorf("failed to get project: %v", utils.ParseHarborError(err))
 			}
 
 			FormatFlag := viper.GetString("output-format")
 			if FormatFlag != "" {
 				err = utils.PrintFormat(project, FormatFlag)
 				if err != nil {
-					log.Error(err)
-					return
+					return err
 				}
 			} else {
 				view.ViewProjects(project.Payload)
 			}
+			return nil
 		},
 	}
 

--- a/cmd/harbor/root/registry/create.go
+++ b/cmd/harbor/root/registry/create.go
@@ -14,9 +14,11 @@
 package registry
 
 import (
+	"fmt"
+
 	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/registry/create"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -28,7 +30,7 @@ func CreateRegistryCommand() *cobra.Command {
 		Short:   "create registry",
 		Example: "harbor registry create",
 		Args:    cobra.ExactArgs(0),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			createView := &api.CreateRegView{
 				Name:        opts.Name,
@@ -50,8 +52,9 @@ func CreateRegistryCommand() *cobra.Command {
 			}
 
 			if err != nil {
-				log.Errorf("failed to create registry: %v", err)
+				return fmt.Errorf("failed to create registry: %v", utils.ParseHarborError(err))
 			}
+			return nil
 		},
 	}
 

--- a/cmd/harbor/root/registry/delete.go
+++ b/cmd/harbor/root/registry/delete.go
@@ -40,7 +40,7 @@ func DeleteRegistryCommand() *cobra.Command {
 					go func(registryID int64) {
 						defer wg.Done()
 						if err := api.DeleteRegistry(registryID); err != nil {
-							errChan <- fmt.Errorf(utils.ParseHarborError(err))
+							errChan <- fmt.Errorf("%s", utils.ParseHarborError(err))
 						}
 					}(registryID)
 				}

--- a/cmd/harbor/root/registry/list.go
+++ b/cmd/harbor/root/registry/list.go
@@ -37,9 +37,8 @@ func ListRegistryCommand() *cobra.Command {
 				return fmt.Errorf("page size should be less than or equal to 100")
 			}
 			registry, err := api.ListRegistries(opts)
-
 			if err != nil {
-				return fmt.Errorf("failed to get projects list: %v", err)
+				return fmt.Errorf("failed to get projects list: %v", utils.ParseHarborError(err))
 			}
 			if len(registry.Payload) == 0 {
 				log.Info("No registries found")

--- a/cmd/harbor/root/registry/update.go
+++ b/cmd/harbor/root/registry/update.go
@@ -14,11 +14,13 @@
 package registry
 
 import (
+	"fmt"
+
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
+	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/registry/update"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -31,26 +33,24 @@ func UpdateRegistryCommand() *cobra.Command {
 		Use:   "update [registry_name]",
 		Short: "update registry",
 		Args:  cobra.MaximumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			var registryId int64
 
 			if len(args) > 0 {
 				registryId, err = api.GetRegistryIdByName(args[0])
 				if err != nil {
-					log.Errorf("failed to get registry id: %v", err)
-					return
+					return fmt.Errorf("failed to get registry id: %v", utils.ParseHarborError(err))
 				}
 			} else {
 				registryId = prompt.GetRegistryNameFromUser()
 			}
 
-			existingRegistry := api.GetRegistryResponse(registryId)
-			if existingRegistry == nil {
-				log.Errorf("registry is not found")
-				return
-			}
+			existingRegistry, err := api.GetRegistryResponse(registryId)
+			if err != nil {
+				return fmt.Errorf("failed to get registry: %v", utils.ParseHarborError(err))
 
+			}
 			updateView := &models.Registry{
 				Name:        existingRegistry.Name,
 				Type:        existingRegistry.Type,
@@ -93,9 +93,9 @@ func UpdateRegistryCommand() *cobra.Command {
 			update.UpdateRegistryView(updateView)
 			err = api.UpdateRegistry(updateView, registryId)
 			if err != nil {
-				log.Errorf("failed to update registry: %v", err)
-				return
+				return fmt.Errorf("failed to update registry: %v", utils.ParseHarborError(err))
 			}
+			return nil
 		},
 	}
 

--- a/cmd/harbor/root/registry/update.go
+++ b/cmd/harbor/root/registry/update.go
@@ -49,7 +49,6 @@ func UpdateRegistryCommand() *cobra.Command {
 			existingRegistry, err := api.GetRegistryResponse(registryId)
 			if err != nil {
 				return fmt.Errorf("failed to get registry: %v", utils.ParseHarborError(err))
-
 			}
 			updateView := &models.Registry{
 				Name:        existingRegistry.Name,

--- a/cmd/harbor/root/registry/view.go
+++ b/cmd/harbor/root/registry/view.go
@@ -14,6 +14,8 @@
 package registry
 
 import (
+	"fmt"
+
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/registry"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
@@ -30,7 +32,7 @@ func ViewRegistryCommand() *cobra.Command {
 		Short:   "get registry information",
 		Example: "harbor registry view [registryName]",
 		Args:    cobra.MaximumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			var registryId int64
 			var registry *registry.GetRegistryOK
@@ -38,8 +40,7 @@ func ViewRegistryCommand() *cobra.Command {
 			if len(args) > 0 {
 				registryId, err = api.GetRegistryIdByName(args[0])
 				if err != nil {
-					log.Errorf("failed to get registry name by id: %v", err)
-					return
+					return fmt.Errorf("failed to get registry id: %v", utils.ParseHarborError(err))
 				}
 			} else {
 				registryId = prompt.GetRegistryNameFromUser()
@@ -47,8 +48,7 @@ func ViewRegistryCommand() *cobra.Command {
 
 			registry, err = api.ViewRegistry(registryId)
 			if err != nil {
-				log.Errorf("failed to get registry info: %v", err)
-				return
+				return fmt.Errorf("failed to get registry info: %v", utils.ParseHarborError(err))
 			}
 
 			FormatFlag := viper.GetString("output-format")
@@ -60,6 +60,7 @@ func ViewRegistryCommand() *cobra.Command {
 			} else {
 				view.ViewRegistry(registry.Payload)
 			}
+			return nil
 		},
 	}
 

--- a/cmd/harbor/root/repository/delete.go
+++ b/cmd/harbor/root/repository/delete.go
@@ -14,10 +14,11 @@
 package repository
 
 import (
+	"fmt"
+
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -27,19 +28,20 @@ func RepoDeleteCmd() *cobra.Command {
 		Short:   "Delete a repository",
 		Example: `  harbor repository delete [project_name]/[repository_name]`,
 		Long:    `Delete a repository within a project in Harbor`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
+			var projectName, repoName string
 			if len(args) > 0 {
-				projectName, repoName := utils.ParseProjectRepo(args[0])
-				err = api.RepoDelete(projectName, repoName)
+				projectName, repoName = utils.ParseProjectRepo(args[0])
 			} else {
-				projectName := prompt.GetProjectNameFromUser()
-				repoName := prompt.GetRepoNameFromUser(projectName)
-				err = api.RepoDelete(projectName, repoName)
+				projectName = prompt.GetProjectNameFromUser()
+				repoName = prompt.GetRepoNameFromUser(projectName)
 			}
+			err = api.RepoDelete(projectName, repoName)
 			if err != nil {
-				log.Errorf("failed to delete repository: %v", err)
+				return fmt.Errorf("failed to delete repository: %v", utils.ParseHarborError(err))
 			}
+			return nil
 		},
 	}
 	return cmd

--- a/cmd/harbor/root/repository/list.go
+++ b/cmd/harbor/root/repository/list.go
@@ -51,7 +51,7 @@ func ListRepositoryCommand() *cobra.Command {
 
 			repos, err = api.ListRepository(projectName)
 			if err != nil {
-				return fmt.Errorf("failed to list repositories: %v", err)
+				return fmt.Errorf("failed to list repositories: %v", utils.ParseHarborError(err))
 			}
 			if len(repos.Payload) == 0 {
 				log.Info("No repositories found")

--- a/cmd/harbor/root/repository/search.go
+++ b/cmd/harbor/root/repository/search.go
@@ -30,7 +30,7 @@ func SearchRepoCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			repo, err := api.SearchRepository(args[0])
 			if err != nil {
-				log.Fatalf("failed to get repositories: %v", err)
+				log.Fatalf("failed to get repositories: %v", utils.ParseHarborError(err))
 				return
 			}
 

--- a/cmd/harbor/root/repository/view.go
+++ b/cmd/harbor/root/repository/view.go
@@ -45,7 +45,7 @@ func RepoViewCmd() *cobra.Command {
 			repo, err = api.RepoView(projectName, repoName)
 
 			if err != nil {
-				log.Errorf("failed to get repository information: %v", err)
+				log.Errorf("failed to get repository information: %v", utils.ParseHarborError(err))
 				return
 			}
 

--- a/cmd/harbor/root/schedule/list.go
+++ b/cmd/harbor/root/schedule/list.go
@@ -37,7 +37,7 @@ func ListScheduleCommand() *cobra.Command {
 			schedule, err := api.ListSchedule(opts)
 
 			if err != nil {
-				return fmt.Errorf("failed to get schedule list: %v", err)
+				return fmt.Errorf("failed to get schedule list: %v", utils.ParseHarborError(err))
 			}
 
 			FormatFlag := viper.GetString("output-format")

--- a/cmd/harbor/root/user/create.go
+++ b/cmd/harbor/root/user/create.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/utils"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/goharbor/harbor-cli/pkg/views/user/create"
@@ -52,7 +53,7 @@ func UserCreateCmd() *cobra.Command {
 				if isUnauthorizedError(err) {
 					log.Error("Permission denied: Admin privileges are required to execute this command.")
 				} else {
-					log.Errorf("failed to create user: %v", err)
+					log.Errorf("failed to create user: %v", utils.ParseHarborError(err))
 				}
 			}
 		},

--- a/cmd/harbor/root/user/delete.go
+++ b/cmd/harbor/root/user/delete.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
+	"github.com/goharbor/harbor-cli/pkg/utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -61,7 +62,7 @@ func UserDeleteCmd() *cobra.Command {
 					if isUnauthorizedError(err) {
 						log.Error("Permission denied: Admin privileges are required to execute this command.")
 					} else {
-						log.Errorf("failed to delete user: %v", err)
+						log.Errorf("failed to delete user: %v", utils.ParseHarborError(err))
 					}
 				}
 			} else {
@@ -71,7 +72,7 @@ func UserDeleteCmd() *cobra.Command {
 					if isUnauthorizedError(err) {
 						log.Error("Permission denied: Admin privileges are required to execute this command.")
 					} else {
-						log.Errorf("failed to delete user: %v", err)
+						log.Errorf("failed to delete user: %v", utils.ParseHarborError(err))
 					}
 				}
 			}

--- a/cmd/harbor/root/user/delete.go
+++ b/cmd/harbor/root/user/delete.go
@@ -14,6 +14,7 @@
 package user
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
@@ -46,7 +47,7 @@ func UserDeleteCmd() *cobra.Command {
 					go func(userID int64) {
 						defer wg.Done()
 						if err := api.DeleteUser(userID); err != nil {
-							errChan <- err
+							errChan <- fmt.Errorf("%s", utils.ParseHarborError(err))
 						}
 					}(userID)
 				}
@@ -62,7 +63,7 @@ func UserDeleteCmd() *cobra.Command {
 					if isUnauthorizedError(err) {
 						log.Error("Permission denied: Admin privileges are required to execute this command.")
 					} else {
-						log.Errorf("failed to delete user: %v", utils.ParseHarborError(err))
+						log.Errorf("failed to delete some users: %v", err)
 					}
 				}
 			} else {

--- a/cmd/harbor/root/user/elevate.go
+++ b/cmd/harbor/root/user/elevate.go
@@ -16,6 +16,7 @@ package user
 import (
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
+	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -33,7 +34,7 @@ func ElevateUserCmd() *cobra.Command {
 			if len(args) > 0 {
 				userId, err = api.GetUsersIdByName(args[0])
 				if err != nil {
-					log.Errorf("failed to get user id for '%s': %v", args[0], err)
+					log.Errorf("failed to get user id for '%s': %v", args[0], utils.ParseHarborError(err))
 					return
 				}
 			} else {
@@ -53,7 +54,7 @@ func ElevateUserCmd() *cobra.Command {
 			if isUnauthorizedError(err) {
 				log.Error("Permission denied: Admin privileges are required to execute this command.")
 			} else {
-				log.Errorf("failed to elevate user: %v", err)
+				log.Errorf("failed to elevate user: %v", utils.ParseHarborError(err))
 			}
 		},
 	}

--- a/cmd/harbor/root/user/list.go
+++ b/cmd/harbor/root/user/list.go
@@ -49,7 +49,7 @@ func UserListCmd() *cobra.Command {
 						if isUnauthorizedError(err) {
 							return fmt.Errorf("Permission denied: Admin privileges are required to execute this command.")
 						}
-						return fmt.Errorf("failed to list users: %v", err)
+						return fmt.Errorf("failed to list users: %v", utils.ParseHarborError(err))
 					}
 
 					allUsers = append(allUsers, response.Payload...)
@@ -65,7 +65,7 @@ func UserListCmd() *cobra.Command {
 					if isUnauthorizedError(err) {
 						return fmt.Errorf("Permission denied: Admin privileges are required to execute this command.")
 					}
-					return fmt.Errorf("failed to list users: %v", err)
+					return fmt.Errorf("failed to list users: %v", utils.ParseHarborError(err))
 				}
 				allUsers = response.Payload
 			}

--- a/pkg/api/label_handler.go
+++ b/pkg/api/label_handler.go
@@ -106,17 +106,17 @@ func UpdateLabel(updateView *models.Label, Labelid int64) error {
 	return nil
 }
 
-func GetLabel(labelid int64) *models.Label {
+func GetLabel(labelid int64) (*models.Label, error) {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	response, err := client.Label.GetLabelByID(ctx, &label.GetLabelByIDParams{LabelID: labelid})
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
-	return response.GetPayload()
+	return response.GetPayload(), nil
 }
 
 func GetLabelIdByName(labelName string) (int64, error) {

--- a/pkg/api/registry_handler.go
+++ b/pkg/api/registry_handler.go
@@ -113,20 +113,20 @@ func ViewRegistry(registryId int64) (*registry.GetRegistryOK, error) {
 	return response, nil
 }
 
-func GetRegistryResponse(registryId int64) *models.Registry {
+func GetRegistryResponse(registryId int64) (*models.Registry, error) {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	response, err := client.Registry.GetRegistry(ctx, &registry.GetRegistryParams{ID: registryId})
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	if response.Payload.ID == 0 {
-		return nil
+		return nil, err
 	}
 
-	return response.GetPayload()
+	return response.GetPayload(), nil
 }
 
 func UpdateRegistry(updateView *models.Registry, projectID int64) error {

--- a/pkg/api/user_handler.go
+++ b/pkg/api/user_handler.go
@@ -14,6 +14,8 @@
 package api
 
 import (
+	"fmt"
+
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/user"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/utils"
@@ -116,5 +118,5 @@ func GetUsersIdByName(userName string) (int64, error) {
 		}
 	}
 
-	return 0, err
+	return -1, fmt.Errorf("User %s not found", userName)
 }

--- a/pkg/utils/error.go
+++ b/pkg/utils/error.go
@@ -1,14 +1,39 @@
-// Copyright Project Harbor Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+type HarborErrorPayload struct {
+	Errors []struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+func ParseHarborError(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	val := reflect.ValueOf(err)
+	if val.Kind() == reflect.Ptr {
+		val = val.Elem()
+	}
+	field := val.FieldByName("Payload")
+	if field.IsValid() {
+		payload := field.Interface()
+		jsonBytes, jsonErr := json.Marshal(payload)
+		if jsonErr == nil {
+			var harborErr HarborErrorPayload
+			if unmarshalErr := json.Unmarshal(jsonBytes, &harborErr); unmarshalErr == nil {
+				if len(harborErr.Errors) > 0 {
+					return fmt.Sprintf("%s field", harborErr.Errors[0].Message)
+				}
+			}
+		}
+	}
+	return fmt.Sprintf("Error: %s", err.Error())
+}

--- a/pkg/utils/error.go
+++ b/pkg/utils/error.go
@@ -1,3 +1,16 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package utils
 
 import (

--- a/pkg/utils/error.go
+++ b/pkg/utils/error.go
@@ -43,7 +43,7 @@ func ParseHarborError(err error) string {
 			var harborErr HarborErrorPayload
 			if unmarshalErr := json.Unmarshal(jsonBytes, &harborErr); unmarshalErr == nil {
 				if len(harborErr.Errors) > 0 {
-					return fmt.Sprintf("%s field", harborErr.Errors[0].Message)
+					return harborErr.Errors[0].Message
 				}
 			}
 		}


### PR DESCRIPTION
## Overview
This PR introduces a cleaner, more reliable, and consistent approach to error handling across the Harbor CLI. It standardizes parsing and reporting API errors, making the CLI more user-friendly and developer-maintainable.

### Key Changes

- **Added `ParseHarborError` utility**  
  - Centralized error parsing logic using reflection to extract the `Payload` from Harbor API responses.  
  - Produces clean and readable error messages for users (e.g.,  
    - `"user not found field"`  
    - `"permission denied field"`)

- **Replaced `Run` with `RunE` across commands**  
  - Enables direct error returns from command handlers.  
  - Ensures all errors are parsed through the new `ParseHarborError` function for consistent logging.

- **Code cleanup and simplification**  
  - Removed redundant lines and unused logs.  
  - Improved flow readability and reduced clutter in error blocks.
  
### Motivation
- Prior CLI behavior often exposed raw Go structs or verbose pointers in error logs.
- This refactor ensures a consistent and user-friendly experience across all commands.
- Simplifies future debugging and maintenance.

### Error Output Before vs After

**Before**:
```
Error: login failed: login failed, please check your credentials: [GET /users/current][401] getCurrentUserInfoUnauthorized  &{Errors:[0x14000158240]}
```
```
rizul@rizu:~/OSS/harbor-cli$ ./bin/harbor-cli user delete 1123
ERRO failed to delete user: [DELETE /users/{user_id}][404] deleteUserNotFound  &{Errors:[0xc00045a1a0]} 
```

**After**:
```
./bin/harbor-cli login demo.goharbor.io -u harbor-cli -p Harbor1234
Error: login failed: login failed, please check your credentials and server address, one of them is incorrect
```

```
rizul@rizu:~/OSS/harbor-cli$ ./bin/harbor-cli user delete 1123
ERRO failed to get user id for '1123': User 1123 not found 
```

### Related Issues
Fix #393 
Fix #316 
Fix #253 
Fix #262 