### PR TITLE
Updates incorrect config mount location and adds default value for HARBOR_CLI_CONFIG in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ The Harbor CLI is designed to enhance your interaction with the Harbor container
 It is straightforward to use the Harbor CLI as a container. You can run the following command to use the Harbor CLI as a container:
 
 ```shell
-docker run -ti --rm -v $HOME/.harbor/config.yaml:/root/.harbor/config.yaml registry.goharbor.io/harbor-cli/harbor-cli --help
+docker run -ti --rm -v $HOME/.config/harbor-cli/config.yaml:/root/.config/harbor-cli/config.yaml registry.goharbor.io/harbor-cli/harbor-cli --help
 
 ```
 
 # Add the following command to create an alias and append the alias to your .zshrc or .bashrc file
 ```shell
-echo "alias harbor='docker run -ti --rm -v \$HOME/.harbor/config.yaml:/root/.harbor/config.yaml registry.goharbor.io/harbor-cli/harbor-cli'" >> ~/.zshrc
+echo "export HARBOR_CLI_CONFIG=$HOME/.config/harbor-cli/config.yaml && alias harbor='docker run -ti --rm -v \$HARBOR_CLI_CONFIG:/root/.config/harbor-cli/config.yaml registry.goharbor.io/harbor-cli/harbor-cli'" >> ~/.zshrc
 source ~/.zshrc # or restart your terminal
 ```
 


### PR DESCRIPTION
## Related Issue:
https://github.com/goharbor/harbor-cli/issues/415

## Description:
The location of the config has been incorrrectly set as `$HOME/.harbor/config.yaml` while it should be `$HOME/.config/harbor-cli/config.yaml`. Sets a default HARBOR_CLI_CONFIG in .zshrc and use it to alias harbor. This way we can keep track of updating locations of config file.