### PR TITLE
add: Release to Homebrew-Tap

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	GOLANGCILINT_VERSION = "v2.1.2"
-	GO_VERSION           = "1.24.2"
+	GO_VERSION           = "1.24.1"
 	SYFT_VERSION         = "v1.22.0"
 	GORELEASER_VERSION   = "v2.8.2"
 )

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -237,9 +237,13 @@ func (m *HarborCli) Release(ctx context.Context, githubToken *dagger.Secret) {
 	goreleaser := m.goreleaserContainer().
 		WithSecretVariable("GITHUB_TOKEN", githubToken).
 		WithExec([]string{"goreleaser", "release", "--clean"})
-	_, err := goreleaser.Stderr(ctx)
+	error, err := goreleaser.Stderr(ctx)
 	if err != nil {
 		log.Printf("Error occured during release: %s", err)
+		return
+	}
+	if len(error) > 0 {
+		log.Printf("Error occured while release: %s", err)
 		return
 	}
 	log.Println("Release tasks completed successfully 🎉")
@@ -247,22 +251,14 @@ func (m *HarborCli) Release(ctx context.Context, githubToken *dagger.Secret) {
 
 // Return a container with the goreleaser binary mounted and the source directory mounted.
 func (m *HarborCli) goreleaserContainer() *dagger.Container {
-	// Export the syft binary from the syft container as a file to generate SBOM
-	syft := dag.Container().
-		From(fmt.Sprintf("anchore/syft:%s", SYFT_VERSION)).
-		WithMountedCache("/go/pkg/mod", dag.CacheVolume("syft-gomod")).
-		File("/syft")
-
 	return dag.Container().
 		From(fmt.Sprintf("goreleaser/goreleaser:%s", GORELEASER_VERSION)).
 		WithMountedCache("/go/pkg/mod", dag.CacheVolume("go-mod-"+GO_VERSION)).
 		WithEnvVariable("GOMODCACHE", "/go/pkg/mod").
 		WithMountedCache("/go/build-cache", dag.CacheVolume("go-build-"+GO_VERSION)).
 		WithEnvVariable("GOCACHE", "/go/build-cache").
-		WithFile("/bin/syft", syft).
 		WithMountedDirectory("/src", m.Source).
-		WithWorkdir("/src").
-		WithEnvVariable("TINI_SUBREAPER", "true")
+		WithWorkdir("/src")
 }
 
 // Generate CLI Documentation and return the directory containing the generated files

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -25,8 +25,8 @@ import (
 const (
 	GOLANGCILINT_VERSION = "v2.1.2"
 	GO_VERSION           = "1.24.2"
-	SYFT_VERSION         = "v1.9.0"
-	GORELEASER_VERSION   = "v2.3.2"
+	SYFT_VERSION         = "v1.22.0"
+	GORELEASER_VERSION   = "v2.8.2"
 )
 
 func New(

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -159,6 +159,7 @@ jobs:
           REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
           REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS }}
           REGISTRY_USERNAME: ${{ vars.REGISTRY_USERNAME }}
+        continue-on-error: true
 
       - name: Create Release
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
@@ -169,6 +170,7 @@ jobs:
           version: "latest"
           verb: call
           args: "release --github-token=env:GITHUB_TOKEN"
+        continue-on-error: true
 
       - name: Publish and Sign Tagged Image
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
@@ -179,3 +181,4 @@ jobs:
           REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
           REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS }}
           REGISTRY_USERNAME: ${{ vars.REGISTRY_USERNAME }}
+        continue-on-error: true

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -165,7 +165,7 @@ jobs:
         if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/'))
         uses: dagger/dagger-for-github@v7
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         with:
           version: "latest"
           verb: call

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -69,20 +69,6 @@ brews:
       owner: bupd                           # GitHub user/org who owns the tap repo
       name: homebrew-tap                    # Tap repo name (i.e., bupd/homebrew-tap)
       branch: main
-            # This might require a personal access token.
-      pull_request:
-        # Whether to enable it or not.
-        enabled: true
-
-        # Whether to open the PR as a draft or not.
-        draft: false
-        # Base can also be another repository, in which case the owner and name
-        # above will be used as HEAD, allowing cross-repository pull requests.
-        base:
-          owner: bupd
-          name: homebrew-tap
-          branch: main
-
     name: harbor-cli                        # Name of the CLI, becomes harbor-cli.rb
     commit_author:                          # Who commits to the tap repo
       name: goreleaserbot

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -66,17 +66,16 @@ release:
 # https://goreleaser.com/customization/homebrew/
 brews:
   - repository:
-      owner: bupd
-      name: homebrew-tap
-    name: harbor-cli
-    commit_author:
-      name: harbor-bot
+      owner: bupd                           # GitHub user/org who owns the tap repo
+      name: homebrew-tap                    # Tap repo name (i.e., bupd/homebrew-tap)
+    name: harbor-cli                        # Name of the CLI, becomes harbor-cli.rb
+    commit_author:                          # Who commits to the tap repo
+      name: bupd-bot
       email: noreply@goharbor.io
-    url_template: "https://{{ .Env.ARTEFACTS_FQDN }}/harbor-cli/releases/{{ .Version }}/{{ .ArtifactName }}"
     homepage: "https://goharbor.io"
-    description: "harbor is an integrated platform to orchestrate the delivery of applications"
+    description: "Harbor CLI for interacting with Harbor registry"  # Formula description
     test: |
-      system "#{bin}/harbor-cli version"
+      system "#{bin}/harbor-cli", "version"            # Formula test (after install)
 
 changelog:
   use: github

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -60,13 +60,13 @@ release:
   replace_existing_artifacts: true
   disable: false              # Ensure release publishing is enabled
   github:
-    owner: goharbor           # Your GitHub repository owner
+    owner: bupd           # Your GitHub repository owner
     name: harbor-cli          # Your GitHub repository name
 
 # https://goreleaser.com/customization/homebrew/
 brews:
   - repository:
-      owner: goharbor
+      owner: bupd
       name: homebrew-tap
     name: harbor-cli
     commit_author:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -68,10 +68,26 @@ brews:
   - repository:
       owner: bupd                           # GitHub user/org who owns the tap repo
       name: homebrew-tap                    # Tap repo name (i.e., bupd/homebrew-tap)
+      branch: main
+            # This might require a personal access token.
+      pull_request:
+        # Whether to enable it or not.
+        enabled: true
+
+        # Whether to open the PR as a draft or not.
+        draft: false
+        # Base can also be another repository, in which case the owner and name
+        # above will be used as HEAD, allowing cross-repository pull requests.
+        base:
+          owner: bupd
+          name: homebrew-tap
+          branch: main
+
     name: harbor-cli                        # Name of the CLI, becomes harbor-cli.rb
     commit_author:                          # Who commits to the tap repo
-      name: bupd-bot
-      email: noreply@goharbor.io
+      name: goreleaserbot
+      email: bot@goreleaser.com
+    commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
     homepage: "https://goharbor.io"
     description: "Harbor CLI for interacting with Harbor registry"  # Formula description
     test: |

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,6 +63,21 @@ release:
     owner: goharbor           # Your GitHub repository owner
     name: harbor-cli          # Your GitHub repository name
 
+# https://goreleaser.com/customization/homebrew/
+brews:
+  - repository:
+      owner: goharbor
+      name: homebrew-tap
+    name: harbor-cli
+    commit_author:
+      name: harbor-bot
+      email: noreply@goharbor.io
+    url_template: "https://{{ .Env.ARTEFACTS_FQDN }}/harbor-cli/releases/{{ .Version }}/{{ .ArtifactName }}"
+    homepage: "https://goharbor.io"
+    description: "harbor is an integrated platform to orchestrate the delivery of applications"
+    test: |
+      system "#{bin}/harbor-cli version"
+
 changelog:
   use: github
   filters:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/goharbor/harbor-cli
 
-go 1.24.2
+go 1.24.1
 
 require (
 	github.com/charmbracelet/bubbles v0.20.0


### PR DESCRIPTION
## Changes made:
- Fix goreleaser
- Add release to homebrew. 

## Important 
Need to add ACCESS_TOKEN to secrets in github actions environment
- The token needs to have write access to the [homebrew-tap repo](https://github.com/bupd/homebrew-tap/). otherwise this might not work.