### PR TITLE
fix: return proper error when a directory exists instead of config file

### DIFF
--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -171,6 +171,10 @@ func EnsureConfigFileExists(harborConfigPath string) error {
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}
 
+	if fileInfo, err := os.Stat(harborConfigPath); err == nil && fileInfo.IsDir() {
+		return fmt.Errorf("a directory exists with the same name as the config file: %s", harborConfigPath)
+	}
+
 	// Create config file if it doesn't exist
 	if _, err := os.Stat(harborConfigPath); os.IsNotExist(err) {
 		if err := CreateConfigFile(harborConfigPath); err != nil {

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -172,7 +172,7 @@ func EnsureConfigFileExists(harborConfigPath string) error {
 	}
 
 	if fileInfo, err := os.Stat(harborConfigPath); err == nil && fileInfo.IsDir() {
-		return fmt.Errorf("a directory exists with the same name as the config file: %s", harborConfigPath)
+		return fmt.Errorf("expected a file but found a directory at path: %s", harborConfigPath)
 	}
 
 	// Create config file if it doesn't exist

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -171,7 +171,12 @@ func EnsureConfigFileExists(harborConfigPath string) error {
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}
 
-	if fileInfo, err := os.Stat(harborConfigPath); err == nil && fileInfo.IsDir() {
+	if fileInfo, err := os.Stat(harborConfigPath); err != nil {
+		// No need to throw error if config file does not exist
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("error while checking config file: %w", err)
+		}  
+	} else if fileInfo.IsDir() {
 		return fmt.Errorf("expected a file but found a directory at path: %s", harborConfigPath)
 	}
 


### PR DESCRIPTION
fixed #264 

a clear error message is logged : 

![image](https://github.com/user-attachments/assets/8153f56d-ccf0-45df-b96a-e800c9cd9263)
