### PR TITLE
Fix: Preserve Table Alignment While Adding Status Colors

### DIFF
--- a/cmd/harbor/root/health.go
+++ b/cmd/harbor/root/health.go
@@ -41,7 +41,6 @@ func HealthCommand() *cobra.Command {
 					return err
 				}
 			} else {
-
 				health.PrintHealthStatus(status)
 			}
 			return nil

--- a/cmd/harbor/root/health.go
+++ b/cmd/harbor/root/health.go
@@ -15,8 +15,10 @@ package root
 
 import (
 	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/health"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func HealthCommand() *cobra.Command {
@@ -32,7 +34,16 @@ func HealthCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			health.PrintHealthStatus(status)
+			FormatFlag := viper.GetString("output-format")
+			if FormatFlag != "" {
+				err = utils.PrintFormat(status, FormatFlag)
+				if err != nil {
+					return err
+				}
+			} else {
+
+				health.PrintHealthStatus(status)
+			}
 			return nil
 		},
 		Example: `  # Get the health status of Harbor components`,

--- a/pkg/views/health/view.go
+++ b/pkg/views/health/view.go
@@ -31,7 +31,7 @@ var columns = []table.Column{
 
 func PrintHealthStatus(status *health.GetHealthOK) {
 	var rows []table.Row
-	fmt.Printf("Harbor Health Status:: %s\n", styleStatus(status.Payload.Status))
+	fmt.Printf("Harbor Health Status: %s\n", styleStatus(status.Payload.Status))
 	for _, component := range status.Payload.Components {
 		rows = append(rows, table.Row{
 			component.Name,
@@ -48,8 +48,12 @@ func PrintHealthStatus(status *health.GetHealthOK) {
 }
 
 func styleStatus(status string) string {
+	var colored string
+
 	if status == "healthy" {
-		return views.GreenStyle.Render(status)
+		colored = views.GreenANSI + status + views.ResetANSI
+	} else {
+		colored = views.RedANSI + status + views.ResetANSI
 	}
-	return views.RedStyle.Render(status)
+	return colored
 }

--- a/pkg/views/styles.go
+++ b/pkg/views/styles.go
@@ -30,3 +30,9 @@ var (
 
 var BaseStyle = lipgloss.NewStyle().
 	BorderStyle(lipgloss.NormalBorder()).Padding(0, 1)
+
+const (
+	GreenANSI = "\033[32m"
+	RedANSI   = "\033[31m"
+	ResetANSI = "\033[0m"
+)


### PR DESCRIPTION
### Description
This PR fixes a display alignment issue in the `health` command output of `harbor-cli`.

#### Issue
Previously, using `lipgloss` styles (e.g., `views.GreenStyle` and `views.RedStyle`) for coloring status values in the health report led to **misaligned columns** in the TUI table rendered by `bubbles/table`. This happened because `lipgloss.Render()` adds ANSI color codes, which aren't accounted for during table width calculations.

#### Solution
Replaced `lipgloss` styles with **raw ANSI escape codes** (`\033[32m` for green and `\033[31m` for red), ensuring consistent alignment and correct color rendering **without affecting column layout**.

#### Output (after fix)
![image](https://github.com/user-attachments/assets/4f27044b-55c1-4a6e-9ef9-1482fd490696)

(Status text now appears green or red based on health and is properly aligned.)

#### Why This Works Better
Raw ANSI sequences preserve correct width handling by avoiding extra padding or styling behavior introduced by external libraries. This keeps the `bubbletea` table aligned while still enabling color-coded statuses.

#### Fix #429 