### PR TITLE
Add Documentation for usage of dagger

### DIFF
--- a/.dagger/README.md
+++ b/.dagger/README.md
@@ -1,12 +1,13 @@
 # 🛠️ Harbor CLI Dagger Pipeline
 
-This repository uses [Dagger](https://dagger.io) to define a portable, CI/CD pipeline for building, linting, and publishing the [Harbor CLI](https://github.com/goharbor/harbor-cli). This README will help beginners understand how to use Dagger in local and CI workflows.
+We use [Dagger](https://dagger.io) to define a CI/CD pipeline for building, linting, and publishing the [Harbor CLI](https://github.com/goharbor/harbor-cli). 
+This README will help beginners understand how to use Dagger in local development and CI workflows.
 
 ## Prerequisites
 
 Before you start, ensure you have the following:
 
-1. Dagger: Install the latest version of Dagger. You can check the official documentation for installation steps: [Dagger Installation Guide](https://docs.dagger.io/quickstart/cli).
+1. Dagger: Install the latest version of Dagger. You can check the official documentation for installation steps: [Dagger Installation Guide](https://docs.dagger.io/install).
 
 ## Dagger Setup and Development Mode
 
@@ -81,6 +82,6 @@ const (
 
 ## 📚 References
 
-- [Dagger Go SDK Docs](https://docs.dagger.io/sdk/go)
+- [Dagger Go SDK Docs](https://pkg.go.dev/dagger.io/dagger)
 - [golangci-lint](https://golangci-lint.run/)
 - [Goreleaser](https://goreleaser.com/)

--- a/.dagger/README.md
+++ b/.dagger/README.md
@@ -1,0 +1,86 @@
+# 🛠️ Harbor CLI Dagger Pipeline
+
+This repository uses [Dagger](https://dagger.io) to define a portable, CI/CD pipeline for building, linting, and publishing the [Harbor CLI](https://github.com/goharbor/harbor-cli). This README will help beginners understand how to use Dagger in local and CI workflows.
+
+## Prerequisites
+
+Before you start, ensure you have the following:
+
+1. Dagger: Install the latest version of Dagger. You can check the official documentation for installation steps: [Dagger Installation Guide](https://docs.dagger.io/quickstart/cli).
+
+## Dagger Setup and Development Mode
+
+### Run Dagger Develop
+
+```bash
+dagger develop
+```
+
+This command will generate the necessary files and configuration for building and running Dagger.
+
+
+## 📦 Dagger Functions Explained
+
+### 🔧 `BuildDev(platform)`
+
+Builds a development binary for your target platform.
+
+```bash
+dagger call build-dev --platform="linux/amd64" export --path=bin/harbor-dev
+```
+
+### 🧼 `LintReport()`
+
+Runs `golangci-lint` on your code and saves the report to a file.
+
+```bash
+dagger call lint-report export --path=./LintReport.json
+```
+
+### 🚀 `PublishImage(registry, imageTags)`
+
+Builds and publishes the Harbor CLI image to the given container registry with proper OCI metadata labels.
+
+Before running the command you have to export you registry password
+
+```shell
+export REGPASS=Harbor12345
+```
+
+```bash
+dagger call publish-image \
+  --registry=demo.goharbor.io \
+  --registry-username=harbor-cli \
+  --registry-password=env:REGPASS \
+  --imageTags=v0.1.0,latest
+```
+
+---
+
+## ⚙️ Configuration Constants
+
+Dagger uses these constant versions (you can modify them as needed):
+
+```go
+const (
+  GO_VERSION           = "1.24.2"
+  GOLANGCILINT_VERSION = "v2.1.2"
+  SYFT_VERSION         = "v1.9.0"
+  GORELEASER_VERSION   = "v2.3.2"
+)
+```
+
+---
+
+## 💡 Tips for Beginners
+
+- Every container step is **reproducible** you can build locally or in GitHub Actions without changes.
+- Use Dagger to cache Go builds and lint output, speeding up re-runs.
+
+---
+
+## 📚 References
+
+- [Dagger Go SDK Docs](https://docs.dagger.io/sdk/go)
+- [golangci-lint](https://golangci-lint.run/)
+- [Goreleaser](https://goreleaser.com/)


### PR DESCRIPTION
## Description

Fixes #194

Currently we lack how to use dagger in harbor-cli. and adding this will be helpful for beginners to understand on how to interact with dagger. to lint, build and publish images for harbor-cli via dagger.

Thanks.