### PR TITLE
FIX: project delete --force

### DIFF
--- a/cmd/harbor/root/project/delete.go
+++ b/cmd/harbor/root/project/delete.go
@@ -82,7 +82,7 @@ func DeleteProjectCommand() *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.BoolVar(&forceDelete, "force", false, "Deletes all repositories and artifacts within the project")
+	flags.BoolVar(&forceDelete, "force", false, "Forcefully delete all repositories, artifacts, and policies in the project. Use with extreme caution—this action is irreversible.")
 	flags.StringVar(&projectID, "project-id", "", "Specify project ID instead of project name")
 
 	return cmd

--- a/pkg/api/project_handler.go
+++ b/pkg/api/project_handler.go
@@ -83,6 +83,22 @@ func DeleteProject(projectNameOrID string, forceDelete bool, useProjectID bool) 
 	if forceDelete {
 		var resp repository.ListRepositoriesOK
 
+		project, err := GetProject(projectNameOrID, useProjectID)
+		if err != nil {
+			log.Errorf("failed to get project name: %v", err)
+			return err
+		}
+		projectName := project.Payload.Name
+
+		immutables, err := ListImmutable(projectName)
+		for _, rule := range immutables.Payload {
+			err = DeleteImmutable(projectName, rule.ID)
+			if err != nil {
+				log.Errorf("failed to delete tag immutable rule: %v", err)
+				return err
+			}
+		}
+
 		resp, err = ListRepository(projectNameOrID, useProjectID)
 
 		if err != nil {


### PR DESCRIPTION
## Summary
This has been a long running issue with no fix. So I have created a fix for it. Now project delete with force deletes the immutable rules and nested repositories. and more tested.

## Changes made
- add deletion of immutable rules when using force.
- clearly indicate with message stating this should be done with caution.

Fix #310 
Fix #419 

Thanks