### PR TITLE
Improve Server Input Sanitization and Credential Name Generation

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -74,3 +74,8 @@ func SanitizeServerAddress(server string) string {
 	server = re.ReplaceAllString(server, "-")
 	return server
 }
+
+func DefaultCredentialName(username, server string) string {
+	sanitized := SanitizeServerAddress(server)
+	return fmt.Sprintf("%s@%s", username, sanitized)
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -16,7 +16,6 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
-	"regexp"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -68,11 +67,25 @@ func ParseProjectRepoReference(projectRepoReference string) (string, string, str
 }
 
 func SanitizeServerAddress(server string) string {
-	re := regexp.MustCompile(`^https?://`)
-	server = re.ReplaceAllString(server, "")
-	re = regexp.MustCompile(`[^a-zA-Z0-9]`)
-	server = re.ReplaceAllString(server, "-")
-	return server
+	server = strings.TrimPrefix(server, "https://")
+	server = strings.TrimPrefix(server, "http://")
+
+	var sb strings.Builder
+	prevDash := false
+	for _, r := range server {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			sb.WriteRune(r)
+			prevDash = false
+		} else if !prevDash {
+			sb.WriteRune('-')
+			prevDash = true
+		}
+	}
+
+	sanitized := sb.String()
+	sanitized = strings.Trim(sanitized, "-")
+
+	return sanitized
 }
 
 func DefaultCredentialName(username, server string) string {

--- a/pkg/views/login/create.go
+++ b/pkg/views/login/create.go
@@ -15,8 +15,6 @@ package login
 
 import (
 	"errors"
-	"fmt"
-	"net/url"
 	"strings"
 
 	"github.com/charmbracelet/huh"
@@ -34,6 +32,8 @@ type LoginView struct {
 
 func CreateView(loginView *LoginView) {
 	theme := huh.ThemeCharm()
+	sanitizedServer := utils.FormatURL(loginView.Server)
+	loginView.Server = *sanitizedServer
 
 	err := huh.NewForm(
 		huh.NewGroup(
@@ -42,16 +42,8 @@ func CreateView(loginView *LoginView) {
 				Description("Server address eg. demo.goharbor.io").
 				Value(&loginView.Server).
 				Validate(func(str string) error {
-					if strings.TrimSpace(str) == "" {
-						return errors.New("server cannot be empty or only spaces")
-					}
-					formattedUrl := utils.FormatUrl(str)
-					if _, err := url.ParseRequestURI(formattedUrl); err != nil {
-						return errors.New("please enter the correct server format")
-					}
-					return nil
-				}),
-			huh.NewInput().
+					return utils.ValidateURL(str)
+				}), huh.NewInput().
 				Title("User Name").
 				Value(&loginView.Username).
 				Validate(func(str string) error {
@@ -81,17 +73,16 @@ func CreateView(loginView *LoginView) {
 				Value(&loginView.Name).
 				Description("Name of credential to be stored in the harbor config file.").
 				PlaceholderFunc(func() string {
-					return fmt.Sprintf("%s@%s", loginView.Username, utils.SanitizeServerAddress(loginView.Server))
+					return utils.DefaultCredentialName(loginView.Username, loginView.Server)
 				}, &loginView).
 				SuggestionsFunc(func() []string {
 					return []string{
-						fmt.Sprintf("%s@%s", loginView.Username, utils.SanitizeServerAddress(loginView.Server)),
+						utils.DefaultCredentialName(loginView.Username, loginView.Server),
 					}
 				}, &loginView).
 				Validate(func(str string) error {
-					if str == "" {
-						loginView.Name = fmt.Sprintf("%s@%s", loginView.Username, utils.SanitizeServerAddress(loginView.Server))
-						return nil
+					if strings.TrimSpace(str) == "" {
+						loginView.Name = utils.DefaultCredentialName(loginView.Username, loginView.Server)
 					}
 					return nil
 				}),


### PR DESCRIPTION
## Changes Introduced

- **Updated `SanitizeServerAddress`** function to improve robustness and ensure only meaningful characters are retained.
- **Trimmed and validated `Server` field** within the `CreateView` flow to avoid trailing or leading slashes, and ensure valid server URLs.
- **Optimized credential name generation** logic:
  - Introduced `defaultCredentialName(username, server string)` to generate consistent and reusable credential names.
  - Applied this consistently in placeholder, suggestion, and validation logic for the `Name` field.
- Removed redundant formatting and string sanitization calls.

## Why This Change?

- To ensure **clean and consistent credential naming** across different user inputs.
- Prevent issues caused by **trailing slashes** or malformed server addresses.
- Centralize and **reuse sanitization and formatting logic** for easier maintenance.

## Affected Areas

- Login flow (`CreateView`)
- Credential name input placeholder and suggestion
- `SanitizeServerAddress` utility

## Example Before/After

| Input `Server`        | Before Credential Name     | After Credential Name        |
|----------------------|----------------------------|------------------------------|
| `https://demo.io/`   | `user@demo-io-`            | `user@demo-io`               |
| `http://example.com` | `user@example-com`         | `user@example-com` (no change) |
| `demo.goharbor.io/`  | `user@demo-goharbor-io-`   | `user@demo-goharbor-io`      |

## Fix #269 
