### PR TITLE
adds replication command

### DIFF
--- a/cmd/harbor/root/cmd.go
+++ b/cmd/harbor/root/cmd.go
@@ -15,7 +15,13 @@ package root
 
 import (
 	"fmt"
+	"github.com/goharbor/harbor-cli/cmd/harbor/root/replication"
+)
+<<<<<<< HEAD
 	"io"
+=======
+	"github.com/goharbor/harbor-cli/cmd/harbor/root/replication"
+>>>>>>> 062384a (adds replication command)
 	"time"
 
 	"github.com/goharbor/harbor-cli/cmd/harbor/root/artifact"
@@ -132,6 +138,10 @@ harbor help
 	root.AddCommand(cmd)
 
 	cmd = webhook.Webhook()
+	cmd.GroupID = "core"
+	root.AddCommand(cmd)
+
+	cmd = replication.Replication()
 	cmd.GroupID = "core"
 	root.AddCommand(cmd)
 

--- a/cmd/harbor/root/cmd.go
+++ b/cmd/harbor/root/cmd.go
@@ -15,14 +15,10 @@ package root
 
 import (
 	"fmt"
-	"github.com/goharbor/harbor-cli/cmd/harbor/root/replication"
-)
-<<<<<<< HEAD
 	"io"
-=======
-	"github.com/goharbor/harbor-cli/cmd/harbor/root/replication"
->>>>>>> 062384a (adds replication command)
 	"time"
+
+	"github.com/goharbor/harbor-cli/cmd/harbor/root/replication"
 
 	"github.com/goharbor/harbor-cli/cmd/harbor/root/artifact"
 	"github.com/goharbor/harbor-cli/cmd/harbor/root/config"

--- a/cmd/harbor/root/replication/cmd.go
+++ b/cmd/harbor/root/replication/cmd.go
@@ -22,10 +22,12 @@ func Replication() *cobra.Command {
 	var replicationCmd = &cobra.Command{
 		Use:     "replication",
 		Aliases: []string{"repl"},
-		Short:   "",
-		Long:    ``,
+		Short:   "Manage replication policies",
+		Long:    `Manage Replication policies.`,
 	}
-	replicationCmd.AddCommand()
+	replicationCmd.AddCommand(
+		ListReplicationCommand(),
+	)
 
 	return replicationCmd
 }

--- a/cmd/harbor/root/replication/cmd.go
+++ b/cmd/harbor/root/replication/cmd.go
@@ -28,6 +28,7 @@ func Replication() *cobra.Command {
 	}
 	replicationCmd.AddCommand(
 		ListReplicationCommand(),
+		DeleteReplicationCommand(),
 	)
 
 	return replicationCmd

--- a/cmd/harbor/root/replication/cmd.go
+++ b/cmd/harbor/root/replication/cmd.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package replication
 
 import (

--- a/cmd/harbor/root/replication/delete.go
+++ b/cmd/harbor/root/replication/delete.go
@@ -1,0 +1,36 @@
+package replication
+
+import (
+	"fmt"
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/spf13/cobra"
+	"strconv"
+)
+
+func DeleteReplicationCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "delete",
+		Aliases: []string{"repl"},
+		Short:   "delete replication policies",
+		Long:    `delete replication policies`,
+		Args:    cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			replicationPolicyID, err := strconv.Atoi(args[0])
+			if err != nil {
+				fmt.Println("invalid project id: ", utils.ParseHarborErrorMsg(err))
+				return
+			}
+
+			err = api.DeleteReplication(replicationPolicyID)
+			if err != nil {
+				fmt.Printf("failed to delete replication policy %d: %v\n", replicationPolicyID, utils.ParseHarborErrorMsg(err))
+				return
+			} else {
+				fmt.Printf("deleted replication policy %d\n", replicationPolicyID)
+			}
+		},
+	}
+
+	return cmd
+}

--- a/cmd/harbor/root/replication/list.go
+++ b/cmd/harbor/root/replication/list.go
@@ -15,10 +15,9 @@
 package replication
 
 import (
-	"fmt"
-
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/goharbor/harbor-cli/pkg/views/replication/list"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -43,8 +42,7 @@ func ListReplicationCommand() *cobra.Command {
 				utils.PrintPayloadInJSONFormat(replication)
 				return
 			} else {
-				// TODO: Add view in pkg/views/replication/list/view.go
-				fmt.Println(replication)
+				list.ListReplicationPolicies(replication.Payload)
 			}
 		},
 	}

--- a/cmd/harbor/root/replication/list.go
+++ b/cmd/harbor/root/replication/list.go
@@ -1,0 +1,58 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package replication
+
+import (
+	"fmt"
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func ListReplicationCommand() *cobra.Command {
+	var opts api.ListFlags
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"repl"},
+		Short:   "list replication policies",
+		Long:    `list replication policies`,
+		Run: func(cmd *cobra.Command, args []string) {
+			replication, err := api.ListReplication(opts)
+
+			if err != nil {
+				logrus.Fatalf("failed to get replications list: %v", err)
+			}
+			FormatFlag := viper.GetString("output-format")
+			if FormatFlag != "" {
+				utils.PrintPayloadInJSONFormat(replication)
+				return
+			} else {
+				// TODO: Add view in pkg/views/replication/list/view.go
+				fmt.Println(replication)
+			}
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.Int64VarP(&opts.Page, "page", "", 1, "Page number")
+	flags.Int64VarP(&opts.PageSize, "page-size", "", 10, "Size of per page")
+	flags.StringVarP(&opts.Q, "query", "q", "", "Query string to query resources")
+	flags.StringVarP(&opts.Sort, "sort", "", "", "Sort the resource list in ascending or descending order")
+
+	return cmd
+}

--- a/cmd/harbor/root/replication/list.go
+++ b/cmd/harbor/root/replication/list.go
@@ -16,6 +16,7 @@ package replication
 
 import (
 	"fmt"
+
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/sirupsen/logrus"

--- a/pkg/api/replication_handler.go
+++ b/pkg/api/replication_handler.go
@@ -12,3 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 package api
+
+import (
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/replication"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+)
+
+func ListReplication(opts ...ListFlags) (replication.ListReplicationPoliciesOK, error) {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return replication.ListReplicationPoliciesOK{}, err
+	}
+	var listFlags ListFlags
+	if len(opts) > 0 {
+		listFlags = opts[0]
+	}
+	response, err := client.Replication.ListReplicationPolicies(ctx, &replication.ListReplicationPoliciesParams{Page: &listFlags.Page, PageSize: &listFlags.PageSize, Q: &listFlags.Q, Sort: &listFlags.Sort})
+	if err != nil {
+		return replication.ListReplicationPoliciesOK{}, err
+	}
+	return *response, nil
+}

--- a/pkg/api/replication_handler.go
+++ b/pkg/api/replication_handler.go
@@ -33,3 +33,18 @@ func ListReplication(opts ...ListFlags) (replication.ListReplicationPoliciesOK, 
 	}
 	return *response, nil
 }
+
+func DeleteReplication(projectId int) error {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Replication.DeleteReplicationPolicy(ctx, &replication.DeleteReplicationPolicyParams{ID: int64(projectId)})
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/views/base/tablelist/model.go
+++ b/pkg/views/base/tablelist/model.go
@@ -27,6 +27,7 @@ const (
 	WidthL   = 16
 	WidthXL  = 20
 	WidthXXL = 24
+	Width3XL = 30
 )
 
 type Model struct {

--- a/pkg/views/replication/list/view.go
+++ b/pkg/views/replication/list/view.go
@@ -1,0 +1,1 @@
+package list

--- a/pkg/views/replication/list/view.go
+++ b/pkg/views/replication/list/view.go
@@ -27,8 +27,9 @@ import (
 
 var columns = []table.Column{
 	{Title: "ID", Width: tablelist.WidthXL},
-	{Title: "Name", Width: tablelist.WidthXL},
-	{Title: "Registry URL", Width: tablelist.WidthXXL},
+	{Title: "Name", Width: tablelist.Width3XL},
+	{Title: "Destination Registry URL", Width: tablelist.Width3XL},
+	{Title: "Source Registry URL", Width: tablelist.Width3XL},
 }
 
 func ListReplicationPolicies(replicationPolicy []*models.ReplicationPolicy) {
@@ -36,12 +37,14 @@ func ListReplicationPolicies(replicationPolicy []*models.ReplicationPolicy) {
 	for _, rp := range replicationPolicy {
 		id := rp.ID
 		name := rp.Name
-		url := rp.DestRegistry.URL
+		sourceUrl := rp.SrcRegistry.URL
+		destUrl := rp.DestRegistry.URL
 
 		rows = append(rows, table.Row{
 			strconv.FormatInt(id, 10),
 			name,
-			url,
+			destUrl,
+			sourceUrl,
 		})
 	}
 

--- a/pkg/views/replication/list/view.go
+++ b/pkg/views/replication/list/view.go
@@ -13,3 +13,42 @@
 // limitations under the License.
 
 package list
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/views/base/tablelist"
+)
+
+var columns = []table.Column{
+	{Title: "ID", Width: tablelist.WidthXL},
+	{Title: "Name", Width: tablelist.WidthXL},
+	{Title: "Registry URL", Width: tablelist.WidthXXL},
+}
+
+func ListReplicationPolicies(replicationPolicy []*models.ReplicationPolicy) {
+	var rows []table.Row
+	for _, rp := range replicationPolicy {
+		id := rp.ID
+		name := rp.Name
+		url := rp.DestRegistry.URL
+
+		rows = append(rows, table.Row{
+			strconv.FormatInt(id, 10),
+			name,
+			url,
+		})
+	}
+
+	m := tablelist.NewModel(columns, rows, len(rows))
+
+	if _, err := tea.NewProgram(m).Run(); err != nil {
+		fmt.Println("Error running program:", err)
+		os.Exit(1)
+	}
+}

--- a/pkg/views/replication/list/view.go
+++ b/pkg/views/replication/list/view.go
@@ -1,1 +1,15 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package list


### PR DESCRIPTION
## Related issue:
https://github.com/goharbor/harbor-cli/issues/102
## Changes made:
Adds the `replication` command for managing replication policies in harbor. Continuing from: https://github.com/goharbor/harbor-cli/pull/103. Adds the following subcommands:
+ [x] list
+ [ ] create
+ [x] delete
+ [ ] start
+ [ ] stop