### PR TITLE
Add groups to root help command

### DIFF
--- a/cmd/harbor/root/cmd.go
+++ b/cmd/harbor/root/cmd.go
@@ -93,26 +93,86 @@ harbor help
 		fmt.Println(err.Error())
 	}
 
-	root.AddCommand(
-		versionCommand(),
-		LoginCommand(),
-		config.Config(),
-		HealthCommand(),
-		project.Project(),
-		registry.Registry(),
-		repository.Repository(),
-		user.User(),
-		artifact.Artifact(),
-		scanner.Scanner(),
-		tag.TagCommand(),
-		cve.CVEAllowlist(),
-		schedule.Schedule(),
-		labels.Labels(),
-		InfoCommand(),
-		webhook.Webhook(),
-		instance.Instance(),
-		quota.Quota(),
-	)
+	root.AddGroup(&cobra.Group{ID: "core", Title: "Core:"})
+	root.AddGroup(&cobra.Group{ID: "access", Title: "Access:"})
+	root.AddGroup(&cobra.Group{ID: "system", Title: "System:"})
+	root.AddGroup(&cobra.Group{ID: "utils", Title: "Utility:"})
+
+	// Core
+	cmd := InfoCommand()
+	cmd.GroupID = "core"
+	root.AddCommand(cmd)
+
+	cmd = project.Project()
+	cmd.GroupID = "core"
+	root.AddCommand(cmd)
+
+	cmd = repository.Repository()
+	cmd.GroupID = "core"
+	root.AddCommand(cmd)
+
+	cmd = artifact.Artifact()
+	cmd.GroupID = "core"
+	root.AddCommand(cmd)
+
+	cmd = tag.TagCommand()
+	cmd.GroupID = "core"
+	root.AddCommand(cmd)
+
+	cmd = labels.Labels()
+	cmd.GroupID = "core"
+	root.AddCommand(cmd)
+
+	cmd = quota.Quota()
+	cmd.GroupID = "core"
+	root.AddCommand(cmd)
+
+	cmd = cve.CVEAllowlist()
+	cmd.GroupID = "core"
+	root.AddCommand(cmd)
+
+	cmd = webhook.Webhook()
+	cmd.GroupID = "core"
+	root.AddCommand(cmd)
+
+	// Access
+	cmd = LoginCommand()
+	cmd.GroupID = "access"
+	root.AddCommand(cmd)
+
+	cmd = user.User()
+	cmd.GroupID = "access"
+	root.AddCommand(cmd)
+
+	// System
+	cmd = config.Config()
+	cmd.GroupID = "system"
+	root.AddCommand(cmd)
+
+	cmd = HealthCommand()
+	cmd.GroupID = "system"
+	root.AddCommand(cmd)
+
+	cmd = instance.Instance()
+	cmd.GroupID = "system"
+	root.AddCommand(cmd)
+
+	cmd = registry.Registry()
+	cmd.GroupID = "system"
+	root.AddCommand(cmd)
+
+	cmd = scanner.Scanner()
+	cmd.GroupID = "system"
+	root.AddCommand(cmd)
+
+	cmd = schedule.Schedule()
+	cmd.GroupID = "system"
+	root.AddCommand(cmd)
+
+	// Utils
+	cmd = versionCommand()
+	cmd.GroupID = "utils"
+	root.AddCommand(cmd)
 
 	return root
 }


### PR DESCRIPTION
Fixes: #464

Before: 
```
Official Harbor CLI

Usage:
  harbor [command]

Examples:

// Base command:
harbor

// Display help about the command:
harbor help


Available Commands:
  artifact      Manage artifacts
  completion    Generate the autocompletion script for the specified shell
  config        Manage the config of the Harbor CLI
  cve-allowlist Manage system CVE allowlist
  health        Get the health status of Harbor components
  help          Help about any command
  info          Display detailed Harbor system, statistics, and CLI environment information
  instance      Manage preheat provider instances in Harbor
  label         Manage labels in Harbor
  login         Log in to Harbor registry
  project       Manage projects and assign resources to them
  quota         Manage quotas
  registry      Manage registries
  repo          Manage repositories
  scanner       scanner commands
  schedule      Schedule jobs in Harbor
  tag           Manage tags in Harbor registry
  user          Manage users
  version       Version of Harbor CLI
  webhook       Manage webhook policies in Harbor

Flags:
  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
  -h, --help                   help for harbor
  -o, --output-format string   Output format. One of: json|yaml
  -v, --verbose                verbose output

Use "harbor [command] --help" for more information about a command.
```

After:
```
Official Harbor CLI

Usage:
  harbor [command]

Examples:

// Base command:
harbor

// Display help about the command:
harbor help


Core:
  artifact      Manage artifacts
  cve-allowlist Manage system CVE allowlist
  info          Display detailed Harbor system, statistics, and CLI environment information
  label         Manage labels in Harbor
  project       Manage projects and assign resources to them
  quota         Manage quotas
  repo          Manage repositories
  tag           Manage tags in Harbor registry
  webhook       Manage webhook policies in Harbor

Access:
  login         Log in to Harbor registry
  user          Manage users

System:
  config        Manage the config of the Harbor CLI
  health        Get the health status of Harbor components
  instance      Manage preheat provider instances in Harbor
  registry      Manage registries
  scanner       scanner commands
  schedule      Schedule jobs in Harbor

Utility:
  version       Version of Harbor CLI

Additional Commands:
  completion    Generate the autocompletion script for the specified shell
  help          Help about any command

Flags:
  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
  -h, --help                   help for harbor
  -o, --output-format string   Output format. One of: json|yaml
  -v, --verbose                verbose output

Use "harbor [command] --help" for more information about a command.
```

### Additional Considerations:
- We can also disable sorting globally if that would be better
- If we don't wanna add a title, we can still group but modify the default template of cobra to not have the title.