### PR TITLE
Remove context switching from `harbor-cli login --name context` command

### DIFF
--- a/cmd/harbor/root/login.go
+++ b/cmd/harbor/root/login.go
@@ -78,7 +78,6 @@ func LoginCommand() *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.StringVarP(&Name, "name", "", "", "name for the set of credentials")
 	flags.StringVarP(&Username, "username", "u", "", "Username")
 	flags.StringVarP(&Password, "password", "p", "", "Password")
 	flags.BoolVar(&passwordStdin, "password-stdin", false, "Take the password from stdin")
@@ -89,21 +88,12 @@ func LoginCommand() *cobra.Command {
 // ProcessLogin applies a simplified decision logic to run login or launch an interactive view.
 func ProcessLogin(loginView login.LoginView, config *utils.HarborConfig) error {
 	// Auto-generate the name if not provided.
-	if loginView.Name == "" && loginView.Server != "" && loginView.Username != "" {
-		loginView.Name = fmt.Sprintf("%s@%s", loginView.Username, utils.SanitizeServerAddress(loginView.Server))
-	}
+	loginView.Name = fmt.Sprintf("%s@%s", loginView.Username, utils.SanitizeServerAddress(loginView.Server))
 	// If complete credentials are provided (overrides), run login using them directly.
 	if loginView.Server != "" && loginView.Username != "" && loginView.Password != "" {
 		return RunLogin(loginView)
 	}
-	// If a name is provided, try to load the matching credential from the config.
-	if loginView.Name != "" {
-		loadedLoginView, err := LoadCredentialsIntoLoginView(loginView.Name, config)
-		if err != nil {
-			return fmt.Errorf("failed to load credentials: %w", err)
-		}
-		return RunLogin(loadedLoginView)
-	}
+
 	// If nothing matches, launch the interactive view.
 	return CreateLoginView(&loginView)
 }
@@ -122,29 +112,6 @@ func CreateLoginView(loginView *login.LoginView) error {
 	login.CreateView(loginView)
 
 	return RunLogin(*loginView)
-}
-
-// LoadCredentialsIntoLoginView loads a stored credential from the config by name and returns a LoginView.
-func LoadCredentialsIntoLoginView(credentialName string, config *utils.HarborConfig) (login.LoginView, error) {
-	for _, cred := range config.Credentials {
-		if cred.Name == credentialName {
-			key, err := utils.GetEncryptionKey()
-			if err != nil {
-				return login.LoginView{}, fmt.Errorf("failed to get encryption key: %w", err)
-			}
-			decryptedPassword, err := utils.Decrypt(key, string(cred.Password))
-			if err != nil {
-				return login.LoginView{}, fmt.Errorf("failed to decrypt password: %w", err)
-			}
-			return login.LoginView{
-				Server:   cred.ServerAddress,
-				Username: cred.Username,
-				Password: decryptedPassword,
-				Name:     cred.Name,
-			}, nil
-		}
-	}
-	return login.LoginView{}, fmt.Errorf("credential with name %s not found", credentialName)
 }
 
 // RunLogin attempts to log in using the provided LoginView credentials.

--- a/doc/cli-docs/harbor-login.md
+++ b/doc/cli-docs/harbor-login.md
@@ -20,7 +20,6 @@ harbor login [server] [flags]
 
 ```sh
   -h, --help              help for login
-      --name string       name for the set of credentials
   -p, --password string   Password
       --password-stdin    Take the password from stdin
   -u, --username string   Username

--- a/doc/man-docs/man1/harbor-login.1
+++ b/doc/man-docs/man1/harbor-login.1
@@ -18,10 +18,6 @@ Authenticate with Harbor Registry.
 	help for login
 
 .PP
-\fB--name\fP=""
-	name for the set of credentials
-
-.PP
 \fB-p\fP, \fB--password\fP=""
 	Password
 

--- a/test/e2e/login_test.go
+++ b/test/e2e/login_test.go
@@ -40,7 +40,6 @@ import (
 // 			args := []string{serverAddress}
 // 			cmd.SetArgs(args)
 
-// 			assert.NoError(t, cmd.Flags().Set("name", "test"))
 // 			assert.NoError(t, cmd.Flags().Set("username", "harbor-cli"))
 // 			assert.NoError(t, cmd.Flags().Set("password", "Harbor12345"))
 
@@ -58,7 +57,6 @@ func Test_Login_Failure_WrongServer(t *testing.T) {
 	cmd := root.LoginCommand()
 	cmd.SetArgs([]string{"wrongserver"})
 
-	assert.NoError(t, cmd.Flags().Set("name", "test"))
 	assert.NoError(t, cmd.Flags().Set("username", "harbor-cli"))
 	assert.NoError(t, cmd.Flags().Set("password", "Harbor12345"))
 
@@ -74,7 +72,6 @@ func Test_Login_Failure_WrongUsername(t *testing.T) {
 	cmd := root.LoginCommand()
 	cmd.SetArgs([]string{"http://demo.goharbor.io"})
 
-	assert.NoError(t, cmd.Flags().Set("name", "test"))
 	assert.NoError(t, cmd.Flags().Set("username", "does-not-exist"))
 	assert.NoError(t, cmd.Flags().Set("password", "Harbor12345"))
 
@@ -90,7 +87,6 @@ func Test_Login_Failure_WrongPassword(t *testing.T) {
 	cmd := root.LoginCommand()
 	cmd.SetArgs([]string{"http://demo.goharbor.io"})
 
-	assert.NoError(t, cmd.Flags().Set("name", "test"))
 	assert.NoError(t, cmd.Flags().Set("username", "admin"))
 	assert.NoError(t, cmd.Flags().Set("password", "wrong"))
 


### PR DESCRIPTION
removed context switching from `harbor-cli login --name context` 

---

Fixes: #477 