### PR TITLE
feat: Add `label` sub-cmd in `artifact` cmd

### DIFF
--- a/cmd/harbor/root/artifact/cmd.go
+++ b/cmd/harbor/root/artifact/cmd.go
@@ -14,6 +14,7 @@
 package artifact
 
 import (
+	"github.com/goharbor/harbor-cli/cmd/harbor/root/artifact/label"
 	"github.com/spf13/cobra"
 )
 
@@ -31,6 +32,7 @@ func Artifact() *cobra.Command {
 		DeleteArtifactCommand(),
 		ScanArtifactCommand(),
 		ArtifactTagsCmd(),
+		label.LabelsArtifactCommmand(),
 	)
 
 	return cmd

--- a/cmd/harbor/root/artifact/delete.go
+++ b/cmd/harbor/root/artifact/delete.go
@@ -14,6 +14,8 @@
 package artifact
 
 import (
+	"fmt"
+
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
@@ -26,17 +28,13 @@ func DeleteArtifactCommand() *cobra.Command {
 		Use:   "delete",
 		Short: "delete an artifact",
 		Args:  cobra.MaximumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			var projectName, repoName, reference string
 			if len(args) > 0 {
-				projectName, repoName, reference, parseError := utils.ParseProjectRepoReference(args[0])
-				if parseError != nil {
-					log.Errorf("failed to parse project/repo/reference: %v", parseError)
-				}
-				err = api.DeleteArtifact(projectName, repoName, reference)
+				projectName, repoName, reference, err = utils.ParseProjectRepoReference(args[0])
 				if err != nil {
-					log.Errorf("failed to delete an artifact: %v", err)
+					return fmt.Errorf("failed to parse project/repo/reference: %v", err)
 				}
 			} else {
 				projectName, err = prompt.GetProjectNameFromUser()
@@ -48,8 +46,9 @@ func DeleteArtifactCommand() *cobra.Command {
 			}
 			err = api.DeleteArtifact(projectName, repoName, reference)
 			if err != nil {
-				log.Errorf("failed to delete an artifact: %v", err)
+				return fmt.Errorf("failed to delete an artifact: %v", utils.ParseHarborErrorMsg(err))
 			}
+			return nil
 		},
 	}
 

--- a/cmd/harbor/root/artifact/label/add.go
+++ b/cmd/harbor/root/artifact/label/add.go
@@ -1,0 +1,92 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package label
+
+import (
+	"fmt"
+
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/prompt"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+// AddLabelArtifactCommmand adds a label to an artifact
+func AddLabelArtifactCommmand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add",
+		Short: "Attach a label to an artifact in a Harbor project repository",
+		Long: `Attach an existing label to a specific artifact identified by <project>/<repository>:<reference>.
+You can specify the artifact and label directly as arguments, or interactively select them if arguments are omitted.
+
+Examples:
+  # Add a label to an artifact using project/repo:reference and label name
+  harbor artifact label add myproject/myrepo@sha256:abcdef1234567890 dev
+
+  # Prompt-based label selection for an artifact
+  harbor artifact label add library/nginx:1.21
+
+  # Fully interactive mode (prompt for everything)
+  harbor artifact label add
+`,
+		Args: cobra.MaximumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var (
+				projectName, repoName, reference string
+				labelName                        string
+				labelID                          int64
+				err                              error
+			)
+
+			if len(args) >= 1 {
+				projectName, repoName, reference, err = utils.ParseProjectRepoReference(args[0])
+				if err != nil {
+					return fmt.Errorf("failed to parse project/repo/reference: %v", err)
+				}
+			} else {
+				projectName, err = prompt.GetProjectNameFromUser()
+				if err != nil {
+					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
+				}
+				repoName = prompt.GetRepoNameFromUser(projectName)
+				reference = prompt.GetReferenceFromUser(repoName, projectName)
+			}
+
+			if len(args) == 2 {
+				labelName = args[1]
+				labelID, err = api.GetLabelIdByName(labelName)
+				if err != nil {
+					return fmt.Errorf("failed to get label id: %v", utils.ParseHarborErrorMsg(err))
+				}
+			} else {
+				labels, err := api.ListLabel()
+				if err != nil {
+					return fmt.Errorf("failed to list labels: %v", utils.ParseHarborErrorMsg(err))
+				}
+				labelID = prompt.GetLabelIdFromUser(labels.Payload)
+			}
+
+			label := api.GetLabel(labelID)
+
+			if _, err := api.AddLabelArtifact(projectName, repoName, reference, label); err != nil {
+				return fmt.Errorf("failed to add label to artifact: %v", utils.ParseHarborErrorMsg(err))
+			}
+
+			fmt.Printf("Label '%s' added to artifact %s/%s@%s\n", label.Name, projectName, repoName, reference)
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cmd/harbor/root/artifact/label/cmd.go
+++ b/cmd/harbor/root/artifact/label/cmd.go
@@ -1,0 +1,39 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package label
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+// LabelsArtifactCommmand compound command to label artifacts
+func LabelsArtifactCommmand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "label",
+		Short: "label command for artifacts",
+		Long:  `label command for artifact`,
+		Example: `harbor artifact label add <project>/<repository>/<reference> <label name>
+harbor artifact label del <project>/<repository>/<reference> <label name>
+		`,
+		Run: func(cmd *cobra.Command, args []string) {
+			log.Error("Please use label command with subcommand add or del")
+			log.Errorf("Example: %s", cmd.Example)
+		},
+	}
+	cmd.AddCommand(AddLabelArtifactCommmand())
+	cmd.AddCommand(DelLabelArtifactCommmand())
+	cmd.AddCommand(ListLabelArtifactCommmand())
+	return cmd
+}

--- a/cmd/harbor/root/artifact/label/delete.go
+++ b/cmd/harbor/root/artifact/label/delete.go
@@ -1,0 +1,97 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package label
+
+import (
+	"fmt"
+
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/prompt"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+// DelLabelArtifactCommmand deletes a label from an artifact
+func DelLabelArtifactCommmand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "delete",
+		Aliases: []string{"del"},
+		Short:   "Detach a label from an artifact in a Harbor project repository",
+		Long: `Remove an existing label from a specific artifact identified by <project>/<repository>:<reference>.
+You can provide the artifact and label name as arguments, or choose them interactively if not specified.
+
+Examples:
+  # Remove a label by specifying artifact and label name
+  harbor artifact label delete library/nginx:latest stable
+
+  # Prompt-based label selection for a specific artifact
+  harbor artifact label del library/nginx:1.21
+
+  # Fully interactive mode (prompt for project, repo, reference, and label)
+  harbor artifact label delete
+
+  # Remove a label from an artifact identified by digest
+  harbor artifact label del myproject/myrepo@sha256:abcdef1234567890 qa-label`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var (
+				projectName, repoName, reference string
+				labelID                          int64
+				err                              error
+			)
+
+			if len(args) >= 1 {
+				projectName, repoName, reference, err = utils.ParseProjectRepoReference(args[0])
+				if err != nil {
+					return fmt.Errorf("failed to parse project/repo/reference: %v", err)
+				}
+			} else {
+				projectName, err = prompt.GetProjectNameFromUser()
+				if err != nil {
+					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
+				}
+				repoName = prompt.GetRepoNameFromUser(projectName)
+				reference = prompt.GetReferenceFromUser(repoName, projectName)
+			}
+
+			if len(args) == 2 {
+				labelName := args[1]
+				labelID, err = api.GetLabelIdByName(labelName)
+				if err != nil {
+					return fmt.Errorf("failed to get label id: %v", utils.ParseHarborErrorMsg(err))
+				}
+			} else {
+				artifact, err := api.ViewArtifact(projectName, repoName, reference, true)
+				if err != nil || artifact == nil {
+					return fmt.Errorf("failed to get artifact info: %v", utils.ParseHarborErrorMsg(err))
+				}
+
+				labels := artifact.Payload.Labels
+				if len(labels) == 0 {
+					fmt.Printf("No labels found for artifact %s/%s@%s\n", projectName, repoName, reference)
+					return nil
+				}
+				labelID = prompt.GetLabelIdFromUser(labels)
+			}
+
+			if _, err := api.RemoveLabelArtifact(projectName, repoName, reference, labelID); err != nil {
+				return fmt.Errorf("failed to remove label from artifact: %v", utils.ParseHarborErrorMsg(err))
+			}
+
+			fmt.Println("Label removed successfully")
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cmd/harbor/root/artifact/label/list.go
+++ b/cmd/harbor/root/artifact/label/list.go
@@ -1,0 +1,102 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package label
+
+import (
+	"fmt"
+
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/artifact"
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/prompt"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/goharbor/harbor-cli/pkg/views/label/list"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// DelLabelArtifactCommmand delete label command to artifact
+func ListLabelArtifactCommmand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "Display labels attached to a specific artifact",
+		Long: `This command lists all labels currently associated with a specific artifact in a Harbor project repository.
+You can provide the artifact reference in the format <project>/<repository>:<reference> (where reference is either a tag or a digest).
+If the reference is not provided as an argument, the command will prompt you to select the project, repository, and artifact.
+
+Supports output formatting such as JSON or YAML using the --output (-o) flag.`,
+		Example: `  # List labels for a tagged artifact
+  harbor artifact label list library/nginx:latest
+
+  # List labels for an artifact by digest
+  harbor artifact label list myproject/myrepo@sha256:abc123...
+
+  # Prompt-based interactive selection of artifact
+  harbor artifact label list
+
+  # Output in JSON format
+  harbor artifact label list library/nginx:1.21 -o json`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+			var projectName, repoName, reference string
+			var artifact *artifact.GetArtifactOK
+			getLabel := true
+			if len(args) > 0 {
+				projectName, repoName, reference, err = utils.ParseProjectRepoReference(args[0])
+				if err != nil {
+					return fmt.Errorf("failed to parse project/repo/reference: %v", err)
+				}
+			} else {
+				projectName, err = prompt.GetProjectNameFromUser()
+				if err != nil {
+					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
+				}
+				repoName = prompt.GetRepoNameFromUser(projectName)
+				reference = prompt.GetReferenceFromUser(repoName, projectName)
+			}
+
+			if reference == "" {
+				if len(args) > 0 {
+					log.Errorf("Invalid artifact reference format: %s", args[0])
+				} else {
+					log.Error("Invalid artifact reference format: no arguments provided")
+				}
+			}
+
+			artifact, err = api.ViewArtifact(projectName, repoName, reference, getLabel)
+
+			if err != nil || artifact == nil {
+				return fmt.Errorf("failed to get info of an artifact: %v", utils.ParseHarborErrorMsg(err))
+			}
+			labelList := artifact.Payload.Labels
+			if len(labelList) == 0 {
+				fmt.Printf("No labels found for artifact %s/%s@%s", projectName, repoName, reference)
+				return nil
+			}
+			formatFlag := viper.GetString("output-format")
+			if formatFlag != "" {
+				err = utils.PrintFormat(labelList, formatFlag)
+				if err != nil {
+					return err
+				}
+			} else {
+				list.ListLabels(labelList)
+			}
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cmd/harbor/root/artifact/scan.go
+++ b/cmd/harbor/root/artifact/scan.go
@@ -14,6 +14,8 @@
 package artifact
 
 import (
+	"fmt"
+
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
@@ -44,32 +46,28 @@ func StartScanArtifactCommand() *cobra.Command {
 		Short:   "Start a scan of an artifact",
 		Long:    `Start a scan of an artifact in Harbor Repository`,
 		Example: `harbor artifact scan start <project>/<repository>/<reference>`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			var projectName, repoName, reference string
 
 			if len(args) > 0 {
-				projectName, repoName, reference, parseError := utils.ParseProjectRepoReference(args[0])
-				if parseError != nil {
-					log.Errorf("failed to parse project/repo/reference: %v", parseError)
-					return
-				}
-				err = api.StartScanArtifact(projectName, repoName, reference)
+				projectName, repoName, reference, err = utils.ParseProjectRepoReference(args[0])
 				if err != nil {
-					log.Errorf("failed to start scan of artifact: %v", err)
+					return fmt.Errorf("failed to parse project/repo/reference: %v", err)
 				}
 			} else {
 				projectName, err = prompt.GetProjectNameFromUser()
 				if err != nil {
-					log.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
+					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
 				}
 				repoName = prompt.GetRepoNameFromUser(projectName)
 				reference = prompt.GetReferenceFromUser(repoName, projectName)
 			}
 			err = api.StartScanArtifact(projectName, repoName, reference)
 			if err != nil {
-				log.Errorf("failed to start scan of artifact: %v", err)
+				return fmt.Errorf("failed to start scan of artifact: %v", err)
 			}
+			return nil
 		},
 	}
 	return cmd
@@ -86,14 +84,9 @@ func StopScanArtifactCommand() *cobra.Command {
 			var projectName, repoName, reference string
 
 			if len(args) > 0 {
-				projectName, repoName, reference, parseError := utils.ParseProjectRepoReference(args[0])
-				if parseError != nil {
-					log.Errorf("failed to parse project/repo/reference: %v", parseError)
-					return
-				}
-				err = api.StopScanArtifact(projectName, repoName, reference)
+				projectName, repoName, reference, err = utils.ParseProjectRepoReference(args[0])
 				if err != nil {
-					log.Errorf("failed to stop scan of artifact: %v", err)
+					log.Errorf("failed to parse project/repo/reference: %v", err)
 				}
 			} else {
 				var projectName string

--- a/cmd/harbor/root/artifact/tags.go
+++ b/cmd/harbor/root/artifact/tags.go
@@ -48,27 +48,24 @@ func CreateTagsCmd() *cobra.Command {
 		Example: `harbor artifact tags create <project>/<repository>/<reference> <tag>`,
 		Run: func(cmd *cobra.Command, args []string) {
 			var err error
-
+			var projectName, repoName, reference string
+			var tagName string
 			if len(args) > 0 {
-				projectName, repoName, reference, parseError := utils.ParseProjectRepoReference(args[0])
-				if parseError != nil {
-					log.Errorf("failed to parse project/repo/reference: %v", parseError)
-					return
+				projectName, repoName, reference, err = utils.ParseProjectRepoReference(args[0])
+				if err != nil {
+					log.Errorf("failed to parse project/repo/reference: %v", err)
 				}
-				tag := args[1]
-				err = api.CreateTag(projectName, repoName, reference, tag)
+				tagName = args[1]
 			} else {
-				var tagName string
-				var projectName string
 				projectName, err = prompt.GetProjectNameFromUser()
 				if err != nil {
 					log.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
 				}
-				repoName := prompt.GetRepoNameFromUser(projectName)
-				reference := prompt.GetReferenceFromUser(repoName, projectName)
+				repoName = prompt.GetRepoNameFromUser(projectName)
+				reference = prompt.GetReferenceFromUser(repoName, projectName)
 				create.CreateTagView(&tagName)
-				err = api.CreateTag(projectName, repoName, reference, tagName)
 			}
+			err = api.CreateTag(projectName, repoName, reference, tagName)
 			if err != nil {
 				log.Errorf("failed to create tag: %v", err)
 			}
@@ -84,15 +81,14 @@ func ListTagsCmd() *cobra.Command {
 		Short:   "List tags of an artifact",
 		Example: `harbor artifact tags list <project>/<repository>/<reference>`,
 		Run: func(cmd *cobra.Command, args []string) {
-			var err, parseError error
+			var err error
 			var tags *artifact.ListTagsOK
 			var projectName, repoName, reference string
 
 			if len(args) > 0 {
-				projectName, repoName, reference, parseError = utils.ParseProjectRepoReference(args[0])
-				if parseError != nil {
-					log.Errorf("failed to parse project/repo/reference: %v", parseError)
-					return
+				projectName, repoName, reference, err = utils.ParseProjectRepoReference(args[0])
+				if err != nil {
+					log.Errorf("failed to parse project/repo/reference: %v", err)
 				}
 			} else {
 				projectName, err = prompt.GetProjectNameFromUser()
@@ -133,26 +129,24 @@ func DeleteTagsCmd() *cobra.Command {
 		Example: `harbor artifact tags delete <project>/<repository>/<reference> <tag>`,
 		Run: func(cmd *cobra.Command, args []string) {
 			var err error
-
+			var projectName, repoName, reference string
+			var tagName string
 			if len(args) > 0 {
-				projectName, repoName, reference, parseError := utils.ParseProjectRepoReference(args[0])
-				if parseError != nil {
-					log.Errorf("failed to parse project/repo/reference: %v", parseError)
-					return
+				projectName, repoName, reference, err = utils.ParseProjectRepoReference(args[0])
+				if err != nil {
+					log.Errorf("failed to parse project/repo/reference: %v", err)
 				}
-				tag := args[1]
-				err = api.DeleteTag(projectName, repoName, reference, tag)
+				tagName = args[1]
 			} else {
-				var projectName string
 				projectName, err = prompt.GetProjectNameFromUser()
 				if err != nil {
 					log.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
 				}
-				repoName := prompt.GetRepoNameFromUser(projectName)
-				reference := prompt.GetReferenceFromUser(repoName, projectName)
-				tag := prompt.GetTagFromUser(repoName, projectName, reference)
-				err = api.DeleteTag(projectName, repoName, reference, tag)
+				repoName = prompt.GetRepoNameFromUser(projectName)
+				reference = prompt.GetReferenceFromUser(repoName, projectName)
+				tagName = prompt.GetTagFromUser(repoName, projectName, reference)
 			}
+			err = api.DeleteTag(projectName, repoName, reference, tagName)
 			if err != nil {
 				log.Errorf("failed to delete tag: %v", err)
 			}

--- a/cmd/harbor/root/artifact/view.go
+++ b/cmd/harbor/root/artifact/view.go
@@ -31,15 +31,14 @@ func ViewArtifactCommmand() *cobra.Command {
 		Long:    `Get information of an artifact`,
 		Example: `harbor artifact view <project>/<repository>:<tag> OR harbor artifact view <project>/<repository>@<digest>`,
 		Run: func(cmd *cobra.Command, args []string) {
-			var err, parseError error
+			var err error
 			var projectName, repoName, reference string
 			var artifact *artifact.GetArtifactOK
 
 			if len(args) > 0 {
-				projectName, repoName, reference, parseError = utils.ParseProjectRepoReference(args[0])
-				if parseError != nil {
-					log.Errorf("failed to parse project/repo/reference: %v", parseError)
-					return
+				projectName, repoName, reference, err = utils.ParseProjectRepoReference(args[0])
+				if err != nil {
+					log.Errorf("failed to parse project/repo/reference: %v", err)
 				}
 			} else {
 				projectName, err = prompt.GetProjectNameFromUser()
@@ -59,7 +58,7 @@ func ViewArtifactCommmand() *cobra.Command {
 				}
 			}
 
-			artifact, err = api.ViewArtifact(projectName, repoName, reference)
+			artifact, err = api.ViewArtifact(projectName, repoName, reference, false)
 
 			if err != nil {
 				log.Errorf("failed to get info of an artifact: %v", err)

--- a/cmd/harbor/root/labels/update.go
+++ b/cmd/harbor/root/labels/update.go
@@ -40,7 +40,12 @@ func UpdateLableCommand() *cobra.Command {
 			if len(args) > 0 {
 				labelId, err = api.GetLabelIdByName(args[0])
 			} else {
-				labelId = prompt.GetLabelIdFromUser(updateflags)
+				labelList, err := api.ListLabel(updateflags)
+				if err != nil {
+					log.Errorf("failed to get label list: %v", err)
+					return
+				}
+				labelId = prompt.GetLabelIdFromUser(labelList.Payload)
 			}
 			if err != nil {
 				log.Errorf("failed to parse label id: %v", err)

--- a/cmd/harbor/root/repository/delete.go
+++ b/cmd/harbor/root/repository/delete.go
@@ -32,14 +32,10 @@ func RepoDeleteCmd() *cobra.Command {
 			var projectName string
 			var repoName string
 			if len(args) > 0 {
-				projectName, repoName, parseError := utils.ParseProjectRepo(args[0])
-				if parseError != nil {
-					log.Errorf("failed to parse project/repo: %v", parseError)
-					return
-				}
-				err = api.RepoDelete(projectName, repoName, false)
+				projectName, repoName, err = utils.ParseProjectRepo(args[0])
 				if err != nil {
-					log.Errorf("failed to delete repository: %v", err)
+					log.Errorf("failed to parse project/repo: %v", err)
+					return
 				}
 			} else {
 				projectName, err = prompt.GetProjectNameFromUser()

--- a/doc/cli-docs/harbor-artifact-label-add.md
+++ b/doc/cli-docs/harbor-artifact-label-add.md
@@ -1,0 +1,48 @@
+---
+title: harbor artifact label add
+weight: 95
+---
+## harbor artifact label add
+
+### Description
+
+##### Attach a label to an artifact in a Harbor project repository
+
+### Synopsis
+
+Attach an existing label to a specific artifact identified by <project>/<repository>:<reference>.
+You can specify the artifact and label directly as arguments, or interactively select them if arguments are omitted.
+
+Examples:
+  # Add a label to an artifact using project/repo:reference and label name
+  harbor artifact label add myproject/myrepo@sha256:abcdef1234567890 dev
+
+  # Prompt-based label selection for an artifact
+  harbor artifact label add library/nginx:1.21
+
+  # Fully interactive mode (prompt for everything)
+  harbor artifact label add
+
+
+```sh
+harbor artifact label add [flags]
+```
+
+### Options
+
+```sh
+  -h, --help   help for add
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor artifact label](harbor-artifact-label.md)	 - label command for artifacts
+

--- a/doc/cli-docs/harbor-artifact-label-delete.md
+++ b/doc/cli-docs/harbor-artifact-label-delete.md
@@ -1,0 +1,50 @@
+---
+title: harbor artifact label delete
+weight: 90
+---
+## harbor artifact label delete
+
+### Description
+
+##### Detach a label from an artifact in a Harbor project repository
+
+### Synopsis
+
+Remove an existing label from a specific artifact identified by <project>/<repository>:<reference>.
+You can provide the artifact and label name as arguments, or choose them interactively if not specified.
+
+Examples:
+  # Remove a label by specifying artifact and label name
+  harbor artifact label delete library/nginx:latest stable
+
+  # Prompt-based label selection for a specific artifact
+  harbor artifact label del library/nginx:1.21
+
+  # Fully interactive mode (prompt for project, repo, reference, and label)
+  harbor artifact label delete
+
+  # Remove a label from an artifact identified by digest
+  harbor artifact label del myproject/myrepo@sha256:abcdef1234567890 qa-label
+
+```sh
+harbor artifact label delete [flags]
+```
+
+### Options
+
+```sh
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor artifact label](harbor-artifact-label.md)	 - label command for artifacts
+

--- a/doc/cli-docs/harbor-artifact-label-list.md
+++ b/doc/cli-docs/harbor-artifact-label-list.md
@@ -1,0 +1,56 @@
+---
+title: harbor artifact label list
+weight: 30
+---
+## harbor artifact label list
+
+### Description
+
+##### Display labels attached to a specific artifact
+
+### Synopsis
+
+This command lists all labels currently associated with a specific artifact in a Harbor project repository.
+You can provide the artifact reference in the format <project>/<repository>:<reference> (where reference is either a tag or a digest).
+If the reference is not provided as an argument, the command will prompt you to select the project, repository, and artifact.
+
+Supports output formatting such as JSON or YAML using the --output (-o) flag.
+
+```sh
+harbor artifact label list [flags]
+```
+
+### Examples
+
+```sh
+  # List labels for a tagged artifact
+  harbor artifact label list library/nginx:latest
+
+  # List labels for an artifact by digest
+  harbor artifact label list myproject/myrepo@sha256:abc123...
+
+  # Prompt-based interactive selection of artifact
+  harbor artifact label list
+
+  # Output in JSON format
+  harbor artifact label list library/nginx:1.21 -o json
+```
+
+### Options
+
+```sh
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor artifact label](harbor-artifact-label.md)	 - label command for artifacts
+

--- a/doc/cli-docs/harbor-artifact-label.md
+++ b/doc/cli-docs/harbor-artifact-label.md
@@ -1,0 +1,47 @@
+---
+title: harbor artifact label
+weight: 70
+---
+## harbor artifact label
+
+### Description
+
+##### label command for artifacts
+
+### Synopsis
+
+label command for artifact
+
+```sh
+harbor artifact label [flags]
+```
+
+### Examples
+
+```sh
+harbor artifact label add <project>/<repository>/<reference> <label name>
+harbor artifact label del <project>/<repository>/<reference> <label name>
+		
+```
+
+### Options
+
+```sh
+  -h, --help   help for label
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor artifact](harbor-artifact.md)	 - Manage artifacts
+* [harbor artifact label add](harbor-artifact-label-add.md)	 - Attach a label to an artifact in a Harbor project repository
+* [harbor artifact label delete](harbor-artifact-label-delete.md)	 - Detach a label from an artifact in a Harbor project repository
+* [harbor artifact label list](harbor-artifact-label-list.md)	 - Display labels attached to a specific artifact
+

--- a/doc/cli-docs/harbor-artifact.md
+++ b/doc/cli-docs/harbor-artifact.md
@@ -36,6 +36,7 @@ Manage artifacts in Harbor Repository
 
 * [harbor](harbor.md)	 - Official Harbor CLI
 * [harbor artifact delete](harbor-artifact-delete.md)	 - delete an artifact
+* [harbor artifact label](harbor-artifact-label.md)	 - label command for artifacts
 * [harbor artifact list](harbor-artifact-list.md)	 - List container artifacts (images, charts, etc.) in a Harbor repository with metadata
 * [harbor artifact scan](harbor-artifact-scan.md)	 - Scan an artifact
 * [harbor artifact tags](harbor-artifact-tags.md)	 - Manage tags of an artifact

--- a/doc/man-docs/man1/harbor-artifact-label-add.1
+++ b/doc/man-docs/man1/harbor-artifact-label-add.1
@@ -1,0 +1,49 @@
+.nh
+.TH "HARBOR" "1"  "Harbor Community" "Harbor User Manuals"
+
+.SH NAME
+harbor-artifact-label-add - Attach a label to an artifact in a Harbor project repository
+
+
+.SH SYNOPSIS
+\fBharbor artifact label add [flags]\fP
+
+
+.SH DESCRIPTION
+Attach an existing label to a specific artifact identified by /:\&.
+You can specify the artifact and label directly as arguments, or interactively select them if arguments are omitted.
+
+.PP
+Examples:
+  # Add a label to an artifact using project/repo:reference and label name
+  harbor artifact label add myproject/myrepo@sha256:abcdef1234567890 dev
+
+.PP
+# Prompt-based label selection for an artifact
+  harbor artifact label add library/nginx:1.21
+
+.PP
+# Fully interactive mode (prompt for everything)
+  harbor artifact label add
+
+
+.SH OPTIONS
+\fB-h\fP, \fB--help\fP[=false]
+	help for add
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+\fB-c\fP, \fB--config\fP=""
+	config file (default is $HOME/.config/harbor-cli/config.yaml)
+
+.PP
+\fB-o\fP, \fB--output-format\fP=""
+	Output format. One of: json|yaml
+
+.PP
+\fB-v\fP, \fB--verbose\fP[=false]
+	verbose output
+
+
+.SH SEE ALSO
+\fBharbor-artifact-label(1)\fP

--- a/doc/man-docs/man1/harbor-artifact-label-delete.1
+++ b/doc/man-docs/man1/harbor-artifact-label-delete.1
@@ -1,0 +1,53 @@
+.nh
+.TH "HARBOR" "1"  "Harbor Community" "Harbor User Manuals"
+
+.SH NAME
+harbor-artifact-label-delete - Detach a label from an artifact in a Harbor project repository
+
+
+.SH SYNOPSIS
+\fBharbor artifact label delete [flags]\fP
+
+
+.SH DESCRIPTION
+Remove an existing label from a specific artifact identified by /:\&.
+You can provide the artifact and label name as arguments, or choose them interactively if not specified.
+
+.PP
+Examples:
+  # Remove a label by specifying artifact and label name
+  harbor artifact label delete library/nginx:latest stable
+
+.PP
+# Prompt-based label selection for a specific artifact
+  harbor artifact label del library/nginx:1.21
+
+.PP
+# Fully interactive mode (prompt for project, repo, reference, and label)
+  harbor artifact label delete
+
+.PP
+# Remove a label from an artifact identified by digest
+  harbor artifact label del myproject/myrepo@sha256:abcdef1234567890 qa-label
+
+
+.SH OPTIONS
+\fB-h\fP, \fB--help\fP[=false]
+	help for delete
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+\fB-c\fP, \fB--config\fP=""
+	config file (default is $HOME/.config/harbor-cli/config.yaml)
+
+.PP
+\fB-o\fP, \fB--output-format\fP=""
+	Output format. One of: json|yaml
+
+.PP
+\fB-v\fP, \fB--verbose\fP[=false]
+	verbose output
+
+
+.SH SEE ALSO
+\fBharbor-artifact-label(1)\fP

--- a/doc/man-docs/man1/harbor-artifact-label-list.1
+++ b/doc/man-docs/man1/harbor-artifact-label-list.1
@@ -1,0 +1,56 @@
+.nh
+.TH "HARBOR" "1"  "Harbor Community" "Harbor User Manuals"
+
+.SH NAME
+harbor-artifact-label-list - Display labels attached to a specific artifact
+
+
+.SH SYNOPSIS
+\fBharbor artifact label list [flags]\fP
+
+
+.SH DESCRIPTION
+This command lists all labels currently associated with a specific artifact in a Harbor project repository.
+You can provide the artifact reference in the format /: (where reference is either a tag or a digest).
+If the reference is not provided as an argument, the command will prompt you to select the project, repository, and artifact.
+
+.PP
+Supports output formatting such as JSON or YAML using the --output (-o) flag.
+
+
+.SH OPTIONS
+\fB-h\fP, \fB--help\fP[=false]
+	help for list
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+\fB-c\fP, \fB--config\fP=""
+	config file (default is $HOME/.config/harbor-cli/config.yaml)
+
+.PP
+\fB-o\fP, \fB--output-format\fP=""
+	Output format. One of: json|yaml
+
+.PP
+\fB-v\fP, \fB--verbose\fP[=false]
+	verbose output
+
+
+.SH EXAMPLE
+.EX
+  # List labels for a tagged artifact
+  harbor artifact label list library/nginx:latest
+
+  # List labels for an artifact by digest
+  harbor artifact label list myproject/myrepo@sha256:abc123...
+
+  # Prompt-based interactive selection of artifact
+  harbor artifact label list
+
+  # Output in JSON format
+  harbor artifact label list library/nginx:1.21 -o json
+.EE
+
+
+.SH SEE ALSO
+\fBharbor-artifact-label(1)\fP

--- a/doc/man-docs/man1/harbor-artifact-label.1
+++ b/doc/man-docs/man1/harbor-artifact-label.1
@@ -2,20 +2,20 @@
 .TH "HARBOR" "1"  "Harbor Community" "Harbor User Manuals"
 
 .SH NAME
-harbor-artifact - Manage artifacts
+harbor-artifact-label - label command for artifacts
 
 
 .SH SYNOPSIS
-\fBharbor artifact [flags]\fP
+\fBharbor artifact label [flags]\fP
 
 
 .SH DESCRIPTION
-Manage artifacts in Harbor Repository
+label command for artifact
 
 
 .SH OPTIONS
 \fB-h\fP, \fB--help\fP[=false]
-	help for artifact
+	help for label
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
@@ -33,9 +33,11 @@ Manage artifacts in Harbor Repository
 
 .SH EXAMPLE
 .EX
-  harbor artifact list
+harbor artifact label add <project>/<repository>/<reference> <label name>
+harbor artifact label del <project>/<repository>/<reference> <label name>
+		
 .EE
 
 
 .SH SEE ALSO
-\fBharbor(1)\fP, \fBharbor-artifact-delete(1)\fP, \fBharbor-artifact-label(1)\fP, \fBharbor-artifact-list(1)\fP, \fBharbor-artifact-scan(1)\fP, \fBharbor-artifact-tags(1)\fP, \fBharbor-artifact-view(1)\fP
+\fBharbor-artifact(1)\fP, \fBharbor-artifact-label-add(1)\fP, \fBharbor-artifact-label-delete(1)\fP, \fBharbor-artifact-label-list(1)\fP

--- a/pkg/api/artifact_handler.go
+++ b/pkg/api/artifact_handler.go
@@ -43,7 +43,7 @@ func DeleteArtifact(projectName, repoName, reference string) error {
 }
 
 // InfoArtifact retrieves information about a specific artifact.
-func ViewArtifact(projectName, repoName, reference string) (*artifact.GetArtifactOK, error) {
+func ViewArtifact(projectName, repoName, reference string, withLabels bool) (*artifact.GetArtifactOK, error) {
 	ctx, client, err := utils.ContextWithClient()
 	var response = &artifact.GetArtifactOK{}
 	if err != nil {
@@ -54,6 +54,7 @@ func ViewArtifact(projectName, repoName, reference string) (*artifact.GetArtifac
 		ProjectName:    projectName,
 		RepositoryName: repoName,
 		Reference:      reference,
+		WithLabel:      &withLabels,
 	})
 
 	if err != nil {
@@ -194,4 +195,50 @@ func CreateTag(projectName, repoName, reference, tagName string) error {
 	}
 	log.Infof("Tag created successfully: %s/%s@%s:%s", projectName, repoName, reference, tagName)
 	return nil
+}
+
+// AddLabelArtifact put label on a specific artifact.
+func AddLabelArtifact(projectName, repoName, reference string, label *models.Label) (*artifact.AddLabelOK, error) {
+	ctx, client, err := utils.ContextWithClient()
+	var response = &artifact.AddLabelOK{}
+	if err != nil {
+		return response, err
+	}
+
+	response, err = client.Artifact.AddLabel(ctx, &artifact.AddLabelParams{
+		ProjectName:    projectName,
+		RepositoryName: repoName,
+		Reference:      reference,
+		Label:          label,
+	})
+
+	if err != nil {
+		log.Errorf("Failed to set label on artifact: %v", err)
+		return response, err
+	}
+
+	return response, nil
+}
+
+// LabelArtifact delete a label from a specific artifact.
+func RemoveLabelArtifact(projectName, repoName, reference string, labelID int64) (*artifact.RemoveLabelOK, error) {
+	ctx, client, err := utils.ContextWithClient()
+	var response = &artifact.RemoveLabelOK{}
+	if err != nil {
+		return response, err
+	}
+
+	response, err = client.Artifact.RemoveLabel(ctx, &artifact.RemoveLabelParams{
+		ProjectName:    projectName,
+		RepositoryName: repoName,
+		Reference:      reference,
+		LabelID:        labelID,
+	})
+
+	if err != nil {
+		log.Errorf("Failed to remove label on artifact: %v", err)
+		return response, err
+	}
+
+	return response, nil
 }

--- a/pkg/api/label_handler.go
+++ b/pkg/api/label_handler.go
@@ -133,5 +133,5 @@ func GetLabelIdByName(labelName string) (int64, error) {
 		}
 	}
 
-	return 0, err
+	return 0, fmt.Errorf("label %s not found", labelName)
 }

--- a/pkg/api/project_handler.go
+++ b/pkg/api/project_handler.go
@@ -111,12 +111,12 @@ func DeleteProject(projectNameOrID string, forceDelete bool, useProjectID bool) 
 		}
 
 		for _, repo := range resp.Payload {
-			_, repoName, parseError := utils.ParseProjectRepo(repo.Name)
-			if parseError != nil {
-				log.Errorf("failed to parse project/repo: %v", parseError)
-				return parseError
+			_, repoName, err := utils.ParseProjectRepo(repo.Name)
+			if err != nil {
+				log.Errorf("failed to parse project/repo: %v", err)
+				return err
 			}
-			err = RepoDelete(projectName, repoName, useProjectID)
+			err = RepoDelete(projectNameOrID, repoName, useProjectID)
 
 			if err != nil {
 				log.Errorf("failed to delete repository: %v", err)

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -192,11 +192,10 @@ func GetWebhookFromUser(projectName string) (models.WebhookPolicy, error) {
 	return res.webhook, res.err
 }
 
-func GetLabelIdFromUser(opts api.ListFlags) int64 {
+func GetLabelIdFromUser(labelList []*models.Label) int64 {
 	labelId := make(chan int64)
 	go func() {
-		response, _ := api.ListLabel(opts)
-		lview.LabelList(response.Payload, labelId)
+		lview.LabelList(labelList, labelId)
 	}()
 
 	return <-labelId

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -87,7 +87,7 @@ func ParseProjectRepoReference(projectRepoReference string) (project, repo, refe
 	project = projectRepoParts[0]
 	repo = projectRepoParts[1]
 
-	return project, repo, ref, nil
+	return project, repo, ref, err
 }
 
 func SanitizeServerAddress(server string) string {


### PR DESCRIPTION
## Description
This PR introduces a new `label` subcommand under `artifact` in `harbor-cli`. It provides functionality to manage labels attached to artifacts within a Harbor project repository.

### Commands Added

* `harbor artifact label add <project>/<repository>:<reference> <label name>`
  → Attach a label to a specific artifact.

* `harbor artifact label del <project>/<repository>:<reference> <label name>`
  → Detach a label from a specific artifact.

* `harbor artifact label list <project>/<repository>:<reference>`
  → List all labels attached to a specific artifact.

If arguments are not provided, each command supports interactive selection for project, repository, reference, and label name.
As shown in the image below, where no argument is there in each command, the args have been chosen interactively. 
![image](https://github.com/user-attachments/assets/015ee2ae-dbfa-4970-aabc-7d8acd6adff5)

### Notes

* Minor refactors in shared utility functions to support this feature.
* A few unrelated files were touched to resolve resulting lint errors post-refactor.
