### PR TITLE
WIP: Finalizing Robots Account cli command

### DIFF
--- a/cmd/harbor/root/project/cmd.go
+++ b/cmd/harbor/root/project/cmd.go
@@ -33,6 +33,7 @@ func Project() *cobra.Command {
 		LogsProjectCommmand(),
 		config.ProjectConfigCommand(),
 		SearchProjectCommand(),
+		Robot(),
 	)
 
 	return cmd

--- a/cmd/harbor/root/project/robot.go
+++ b/cmd/harbor/root/project/robot.go
@@ -13,6 +13,8 @@ func Robot() *cobra.Command {
 	}
 	cmd.AddCommand(
 		robot.ListRobotCommand(),
+    robot.DeleteCommand(),
+    robot.ViewCommand(),
 	)
 
 	return cmd

--- a/cmd/harbor/root/project/robot.go
+++ b/cmd/harbor/root/project/robot.go
@@ -17,6 +17,7 @@ func Robot() *cobra.Command {
 		robot.ViewRobotCommand(),
 		robot.CreateRobotCommand(),
 		robot.UpdateRobotCommand(),
+		robot.RefreshSecretCommand(),
 	)
 
 	return cmd

--- a/cmd/harbor/root/project/robot.go
+++ b/cmd/harbor/root/project/robot.go
@@ -15,6 +15,7 @@ func Robot() *cobra.Command {
 		robot.ListRobotCommand(),
     robot.DeleteCommand(),
     robot.ViewCommand(),
+    robot.CreateRobot(),
 	)
 
 	return cmd

--- a/cmd/harbor/root/project/robot.go
+++ b/cmd/harbor/root/project/robot.go
@@ -9,7 +9,7 @@ func Robot() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "robot",
 		Short:   "Manage robot accounts",
-		Example: `  harbor robot list`,
+		Example: `  harbor project robot list`,
 	}
 	cmd.AddCommand(
 		robot.ListRobotCommand(),

--- a/cmd/harbor/root/project/robot.go
+++ b/cmd/harbor/root/project/robot.go
@@ -13,9 +13,10 @@ func Robot() *cobra.Command {
 	}
 	cmd.AddCommand(
 		robot.ListRobotCommand(),
-    robot.DeleteCommand(),
-    robot.ViewCommand(),
-    robot.CreateRobot(),
+		robot.DeleteRobotCommand(),
+		robot.ViewRobotCommand(),
+		robot.CreateRobotCommand(),
+		robot.UpdateRobotCommand(),
 	)
 
 	return cmd

--- a/cmd/harbor/root/project/robot.go
+++ b/cmd/harbor/root/project/robot.go
@@ -1,0 +1,19 @@
+package project
+
+import (
+	"github.com/goharbor/harbor-cli/cmd/harbor/root/project/robot"
+	"github.com/spf13/cobra"
+)
+
+func Robot() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "robot",
+		Short:   "Manage robot accounts",
+		Example: `  harbor robot list`,
+	}
+	cmd.AddCommand(
+		robot.ListRobotCommand(),
+	)
+
+	return cmd
+}

--- a/cmd/harbor/root/project/robot.go
+++ b/cmd/harbor/root/project/robot.go
@@ -1,3 +1,16 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package project
 
 import (

--- a/cmd/harbor/root/project/robot/create.go
+++ b/cmd/harbor/root/project/robot/create.go
@@ -1,6 +1,7 @@
 package robot
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/atotto/clipboard"
@@ -15,7 +16,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-// to-do add json file as input and getting json file as output from input.
 func CreateRobotCommand() *cobra.Command {
 	var (
 		opts        create.CreateView
@@ -92,12 +92,16 @@ func CreateRobotCommand() *cobra.Command {
 
 			FormatFlag := viper.GetString("output-format")
 			if FormatFlag != "" {
-				utils.PrintPayloadInJSONFormat(response.Payload)
+				name := response.Payload.Name
+				res, _ := api.GetRobot(response.Payload.ID)
+				utils.SavePayloadJSON(name, res.Payload)
 				return
 			}
 
-			create.CreateRobotSecretView(response.Payload)
+			name, secret := response.Payload.Name, response.Payload.Secret
+			create.CreateRobotSecretView(name, secret)
 			err = clipboard.WriteAll(response.Payload.Secret)
+			fmt.Println("secret copied to clipboard.")
 		},
 	}
 	flags := cmd.Flags()

--- a/cmd/harbor/root/project/robot/create.go
+++ b/cmd/harbor/root/project/robot/create.go
@@ -2,7 +2,6 @@ package robot
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/atotto/clipboard"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
@@ -26,11 +25,9 @@ func CreateRobotCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "create robot",
-		Args:  cobra.MaximumNArgs(1),
+		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			var err error
-			kind := "project"
-			opts.Level = kind
 
 			if opts.ProjectName == "" {
 				opts.ProjectName, err = prompt.GetProjectNameFromUser()
@@ -38,16 +35,9 @@ func CreateRobotCommand() *cobra.Command {
 					logrus.Fatalf("%v", utils.ParseHarborErrorMsg(err))
 				}
 				if opts.ProjectName == "" {
-					os.Exit(1)
+					log.Fatalf("Project Name Cannot be empty")
 				}
 			}
-
-			// to-do handle permission as json submission
-			perm := &create.RobotPermission{
-				Kind:      kind,
-				Namespace: projectName,
-			}
-			opts.Permissions = []*create.RobotPermission{perm}
 
 			if len(args) == 0 {
 				if opts.Name == "" || opts.Duration == 0 {
@@ -79,15 +69,14 @@ func CreateRobotCommand() *cobra.Command {
 				}
 				// convert []models.permission to []*model.Access
 				perm := &create.RobotPermission{
-					Kind:      kind,
 					Namespace: projectName,
 					Access:    accesses,
 				}
 				opts.Permissions = []*create.RobotPermission{perm}
 			}
-			response, err := api.CreateRobot(opts)
+			response, err := api.CreateRobot(opts, "project")
 			if err != nil {
-				log.Errorf("failed to create robot: %v", err)
+				log.Fatalf("failed to create robot: %v", err)
 			}
 
 			FormatFlag := viper.GetString("output-format")

--- a/cmd/harbor/root/project/robot/create.go
+++ b/cmd/harbor/root/project/robot/create.go
@@ -18,7 +18,6 @@ import (
 func CreateRobotCommand() *cobra.Command {
 	var (
 		opts        create.CreateView
-		projectName string
 		all         bool
 	)
 
@@ -69,7 +68,7 @@ func CreateRobotCommand() *cobra.Command {
 				}
 				// convert []models.permission to []*model.Access
 				perm := &create.RobotPermission{
-					Namespace: projectName,
+					Namespace: opts.ProjectName,
 					Access:    accesses,
 				}
 				opts.Permissions = []*create.RobotPermission{perm}

--- a/cmd/harbor/root/project/robot/create.go
+++ b/cmd/harbor/root/project/robot/create.go
@@ -1,3 +1,16 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package robot
 
 import (
@@ -17,8 +30,8 @@ import (
 
 func CreateRobotCommand() *cobra.Command {
 	var (
-		opts        create.CreateView
-		all         bool
+		opts create.CreateView
+		all  bool
 	)
 
 	cmd := &cobra.Command{
@@ -42,7 +55,8 @@ func CreateRobotCommand() *cobra.Command {
 				if opts.Name == "" || opts.Duration == 0 {
 					create.CreateRobotView(&opts)
 				}
-				permissions := []models.Permission{}
+
+				var permissions []models.Permission
 
 				if all {
 					perms, _ := api.GetPermissions()
@@ -89,6 +103,10 @@ func CreateRobotCommand() *cobra.Command {
 			name, secret := response.Payload.Name, response.Payload.Secret
 			create.CreateRobotSecretView(name, secret)
 			err = clipboard.WriteAll(response.Payload.Secret)
+			if err != nil {
+				log.Errorf("failed to write to clipboard")
+				return
+			}
 			fmt.Println("secret copied to clipboard.")
 		},
 	}

--- a/cmd/harbor/root/project/robot/create.go
+++ b/cmd/harbor/root/project/robot/create.go
@@ -1,0 +1,117 @@
+package robot
+
+import (
+	"os"
+
+	"github.com/atotto/clipboard"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/prompt"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/goharbor/harbor-cli/pkg/views/robot/create"
+	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// CreateProjectCommand creates a new `harbor create project` command
+func CreateRobot() *cobra.Command {
+	var (
+		opts        create.CreateView
+		projectName string
+		all         bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "create robot",
+		Args:  cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			var err error
+			kind := "project"
+			opts.Level = kind
+
+			if opts.ProjectName == "" {
+				opts.ProjectName, err = prompt.GetProjectNameFromUser()
+				if err != nil {
+					logrus.Fatalf("%v", utils.ParseHarborErrorMsg(err))
+				}
+				if opts.ProjectName == "" {
+					os.Exit(1)
+				}
+			}
+
+			// to-do handle permission as json submission
+			perm := &create.RobotPermission{
+				Kind:      kind,
+				Namespace: projectName,
+			}
+			opts.Permissions = []*create.RobotPermission{perm}
+
+			if len(args) == 0 {
+				if opts.Name == "" || opts.Duration == 0 {
+					create.CreateRobotView(&opts)
+				}
+				permissions := []models.Permission{}
+
+				if all {
+					perms, _ := api.GetPermissions()
+					permission := perms.Payload.Project
+
+					choices := []models.Permission{}
+					for _, perm := range permission {
+						choices = append(choices, *perm)
+					}
+					permissions = choices
+				} else {
+					permissions = prompt.GetRobotPermissionsFromUser()
+				}
+
+				// []Permission to []*Access
+				var accesses []*models.Access
+				for _, perm := range permissions {
+					access := &models.Access{
+						Action:   perm.Action,
+						Resource: perm.Resource,
+					}
+					accesses = append(accesses, access)
+				}
+				// convert []models.permission to []*model.Access
+				perm := &create.RobotPermission{
+					Kind:      kind,
+					Namespace: projectName,
+					Access:    accesses,
+				}
+				opts.Permissions = []*create.RobotPermission{perm}
+			}
+			response, err := api.CreateRobot(opts)
+			if err != nil {
+				log.Errorf("failed to create robot: %v", err)
+			}
+
+			FormatFlag := viper.GetString("output-format")
+			if FormatFlag != "" {
+				utils.PrintPayloadInJSONFormat(response.Payload)
+				return
+			}
+
+			create.CreateRobotSecretView(response.Payload)
+			err = clipboard.WriteAll(response.Payload.Secret)
+		},
+	}
+	flags := cmd.Flags()
+	flags.BoolVarP(
+		&all,
+		"all-permission",
+		"a",
+		false,
+		"Select all permissions for the robot account",
+	)
+	flags.StringVarP(&opts.ProjectName, "project", "", "", "set project name")
+	flags.StringVarP(&opts.Name, "name", "", "", "name of the robot account")
+	flags.StringVarP(&opts.Description, "description", "", "", "description of the robot account")
+	flags.Int64VarP(&opts.Duration, "duration", "", 0, "set expiration of robot account in days")
+
+	return cmd
+}

--- a/cmd/harbor/root/project/robot/create.go
+++ b/cmd/harbor/root/project/robot/create.go
@@ -15,8 +15,8 @@ import (
 	"github.com/spf13/viper"
 )
 
-// CreateProjectCommand creates a new `harbor create project` command
-func CreateRobot() *cobra.Command {
+// to-do add json file as input and getting json file as output from input.
+func CreateRobotCommand() *cobra.Command {
 	var (
 		opts        create.CreateView
 		projectName string

--- a/cmd/harbor/root/project/robot/delete.go
+++ b/cmd/harbor/root/project/robot/delete.go
@@ -4,27 +4,35 @@ import (
 	"strconv"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/prompt"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/spf13/cobra"
 )
 
-// to-do improve DeleteRobotCommand and multi delete
+// to-do improve DeleteRobotCommand and multi select & delete
 func DeleteRobotCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete [robotID]",
 		Short: "delete robot by id",
 		Args:  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			var (
+				robotID int64
+				err     error
+			)
 			if len(args) == 1 {
-				robotID, err := strconv.ParseInt(args[0], 10, 64)
+				robotID, err = strconv.ParseInt(args[0], 10, 64)
 				if err != nil {
-					log.Errorf("failed to parse robot ID: %v", err)
+					log.Fatalf("failed to parse robot ID: %v", err)
 				}
-				err = api.DeleteRobot(robotID)
-				if err != nil {
-					log.Errorf("failed to Delete robots")
-				}
+			} else {
+				projectID := prompt.GetProjectIDFromUser()
+				robotID = prompt.GetRobotIDFromUser(projectID)
+			}
+			err = api.DeleteRobot(robotID)
+			if err != nil {
+				log.Fatalf("failed to Delete robots")
 			}
 		},
 	}

--- a/cmd/harbor/root/project/robot/delete.go
+++ b/cmd/harbor/root/project/robot/delete.go
@@ -1,0 +1,33 @@
+package robot
+
+import (
+	"strconv"
+
+	"github.com/goharbor/harbor-cli/pkg/api"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/spf13/cobra"
+)
+
+// NewGetRegistryCommand creates a new `harbor get registry` command
+func DeleteCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete [robotID]",
+		Short: "delete robot by id",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) == 1 {
+				robotID, err := strconv.ParseInt(args[0], 10, 64)
+				if err != nil {
+					log.Errorf("failed to parse robot ID: %v", err)
+				}
+				err = api.DeleteRobot(robotID)
+				if err != nil {
+					log.Errorf("failed to Delete robots")
+				}
+			}
+		},
+	}
+
+	return cmd
+}

--- a/cmd/harbor/root/project/robot/delete.go
+++ b/cmd/harbor/root/project/robot/delete.go
@@ -9,12 +9,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewGetRegistryCommand creates a new `harbor get registry` command
-func DeleteCommand() *cobra.Command {
+// to-do improve DeleteRobotCommand and multi delete
+func DeleteRobotCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete [robotID]",
 		Short: "delete robot by id",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) == 1 {
 				robotID, err := strconv.ParseInt(args[0], 10, 64)

--- a/cmd/harbor/root/project/robot/delete.go
+++ b/cmd/harbor/root/project/robot/delete.go
@@ -1,3 +1,16 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package robot
 
 import (

--- a/cmd/harbor/root/project/robot/list.go
+++ b/cmd/harbor/root/project/robot/list.go
@@ -13,11 +13,11 @@ import (
 	"github.com/spf13/viper"
 )
 
-// ListRobotCommand creates a new `harbor robot list` command
+// ListRobotCommand creates a new `harbor project robot list` command
 func ListRobotCommand() *cobra.Command {
 	var (
-		query     string
-		opts      api.ListFlags
+		query string
+		opts  api.ListFlags
 	)
 
 	projectQString := constants.ProjectQString
@@ -29,7 +29,7 @@ func ListRobotCommand() *cobra.Command {
 			if len(args) > 0 {
 				opts.Q = projectQString + args[0]
 			} else {
-        projectID := prompt.GetProjectIDFromUser()
+				projectID := prompt.GetProjectIDFromUser()
 				opts.Q = projectQString + strconv.FormatInt(projectID, 10)
 			}
 

--- a/cmd/harbor/root/project/robot/list.go
+++ b/cmd/harbor/root/project/robot/list.go
@@ -15,10 +15,7 @@ import (
 
 // ListRobotCommand creates a new `harbor project robot list` command
 func ListRobotCommand() *cobra.Command {
-	var (
-		query string
-		opts  api.ListFlags
-	)
+	var opts api.ListFlags
 
 	projectQString := constants.ProjectQString
 	cmd := &cobra.Command{
@@ -28,6 +25,8 @@ func ListRobotCommand() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) > 0 {
 				opts.Q = projectQString + args[0]
+			} else if opts.Q != "" {
+				opts.Q = projectQString + opts.Q
 			} else {
 				projectID := prompt.GetProjectIDFromUser()
 				opts.Q = projectQString + strconv.FormatInt(projectID, 10)
@@ -51,7 +50,7 @@ func ListRobotCommand() *cobra.Command {
 	flags := cmd.Flags()
 	flags.Int64VarP(&opts.Page, "page", "", 1, "Page number")
 	flags.Int64VarP(&opts.PageSize, "page-size", "", 10, "Size of per page")
-	flags.StringVarP(&query, "query", "q", "", "Query string to query resources")
+	flags.StringVarP(&opts.Q, "query", "q", "", "Query string to query resources")
 	flags.StringVarP(
 		&opts.Sort,
 		"sort",

--- a/cmd/harbor/root/project/robot/list.go
+++ b/cmd/harbor/root/project/robot/list.go
@@ -1,0 +1,64 @@
+package robot
+
+import (
+	"log"
+	"strconv"
+
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/constants"
+	"github.com/goharbor/harbor-cli/pkg/prompt"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/goharbor/harbor-cli/pkg/views/robot/list"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// ListRobotCommand creates a new `harbor robot list` command
+func ListRobotCommand() *cobra.Command {
+	var (
+		query     string
+		opts      api.ListFlags
+	)
+
+	projectQString := constants.ProjectQString
+	cmd := &cobra.Command{
+		Use:   "list [projectID]",
+		Short: "list robot",
+		Args:  cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) > 0 {
+				opts.Q = projectQString + args[0]
+			} else {
+        projectID := prompt.GetProjectIDFromUser()
+				opts.Q = projectQString + strconv.FormatInt(projectID, 10)
+			}
+
+			robots, err := api.ListRobot(opts)
+			if err != nil {
+				log.Fatalf("failed to get robots list: %v", err)
+			}
+
+			FormatFlag := viper.GetString("output-format")
+			if FormatFlag != "" {
+				utils.PrintPayloadInJSONFormat(robots)
+				return
+			}
+
+			list.ListRobots(robots.Payload)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.Int64VarP(&opts.Page, "page", "", 1, "Page number")
+	flags.Int64VarP(&opts.PageSize, "page-size", "", 10, "Size of per page")
+	flags.StringVarP(&query, "query", "q", "", "Query string to query resources")
+	flags.StringVarP(
+		&opts.Sort,
+		"sort",
+		"",
+		"",
+		"Sort the resource list in ascending or descending order",
+	)
+
+	return cmd
+}

--- a/cmd/harbor/root/project/robot/list.go
+++ b/cmd/harbor/root/project/robot/list.go
@@ -1,3 +1,16 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package robot
 
 import (

--- a/cmd/harbor/root/project/robot/refresh.go
+++ b/cmd/harbor/root/project/robot/refresh.go
@@ -1,0 +1,84 @@
+package robot
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/atotto/clipboard"
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/prompt"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/goharbor/harbor-cli/pkg/views/robot/create"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/spf13/cobra"
+)
+
+// handle robot view with interactive like in list command.
+func RefreshSecretCommand() *cobra.Command {
+	var (
+		robotID     int64
+		secret      string
+		secretStdin bool
+	)
+	cmd := &cobra.Command{
+		Use:   "refresh [robotID]",
+		Short: "refresh robot secret by id",
+		Args:  cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			var err error
+			if len(args) == 1 {
+				robotID, err = strconv.ParseInt(args[0], 10, 64)
+				if err != nil {
+					log.Errorf("failed to parse robot ID: %v", err)
+				}
+			} else {
+				projectID := prompt.GetProjectIDFromUser()
+				robotID = prompt.GetRobotIDFromUser(projectID)
+			}
+
+			if secret != "" {
+				utils.ValidatePassword(secret)
+			}
+			if secretStdin {
+				secret = getSecret()
+			}
+
+			response, err := api.RefreshSecret(secret, robotID)
+			if err != nil {
+				log.Errorf("failed to refresh robot secret.")
+				os.Exit(1)
+			}
+
+			log.Info("Secret updated successfully.")
+
+			secret = response.Payload.Secret
+			create.CreateRobotSecretView("", secret)
+
+			err = clipboard.WriteAll(response.Payload.Secret)
+			fmt.Println("secret copied to clipboard.")
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&secret, "secret", "", "", "secret")
+	flags.BoolVarP(&secretStdin, "secret-stdin", "", false, "Take the robot secret from stdin")
+
+	return cmd
+}
+
+// getSecret from commandline
+func getSecret() string {
+	secret, err := utils.GetSecretStdin("Enter your secret: ")
+	if err != nil {
+		log.Errorf("Error reading secret: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := utils.ValidatePassword(secret); err != nil {
+		log.Errorf("Invalid secret: %v\n", err)
+		os.Exit(1)
+	}
+	return secret
+}

--- a/cmd/harbor/root/project/robot/refresh.go
+++ b/cmd/harbor/root/project/robot/refresh.go
@@ -1,3 +1,16 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package robot
 
 import (

--- a/cmd/harbor/root/project/robot/update.go
+++ b/cmd/harbor/root/project/robot/update.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// to-do complete UpdateRobotCommand
 func UpdateRobotCommand() *cobra.Command {
 	var (
 		robotID int64
@@ -29,7 +28,7 @@ func UpdateRobotCommand() *cobra.Command {
 			if len(args) == 1 {
 				robotID, err = strconv.ParseInt(args[0], 10, 64)
 				if err != nil {
-					log.Errorf("failed to parse robot ID: %v", err)
+					log.Fatalf("failed to parse robot ID: %v", err)
 				}
 
 			} else {
@@ -38,6 +37,10 @@ func UpdateRobotCommand() *cobra.Command {
 			}
 
 			robot, err := api.GetRobot(robotID)
+			if err != nil {
+				log.Fatalf("failed to get robot: %v", err)
+			}
+
 			bot := robot.Payload
 
 			opts = update.UpdateView{
@@ -87,7 +90,7 @@ func UpdateRobotCommand() *cobra.Command {
 
 			err = updateRobotView(&opts)
 			if err != nil {
-				log.Errorf("failed to Update robot")
+        log.Fatalf("failed to Update robot: %v", err)
 			}
 		},
 	}

--- a/cmd/harbor/root/project/robot/update.go
+++ b/cmd/harbor/root/project/robot/update.go
@@ -1,0 +1,117 @@
+package robot
+
+import (
+	"strconv"
+
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/prompt"
+	"github.com/goharbor/harbor-cli/pkg/views/robot/update"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/spf13/cobra"
+)
+
+// to-do complete UpdateRobotCommand
+func UpdateRobotCommand() *cobra.Command {
+	var (
+		robotID int64
+		opts    update.UpdateView
+		all     bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "update [robotID]",
+		Short: "update robot by id",
+		Args:  cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			var err error
+			if len(args) == 1 {
+				robotID, err = strconv.ParseInt(args[0], 10, 64)
+				if err != nil {
+					log.Errorf("failed to parse robot ID: %v", err)
+				}
+
+			} else {
+				projectID := prompt.GetProjectIDFromUser()
+				robotID = prompt.GetRobotIDFromUser(projectID)
+			}
+
+			robot, err := api.GetRobot(robotID)
+			bot := robot.Payload
+
+			opts = update.UpdateView{
+				CreationTime: bot.CreationTime,
+				Description:  bot.Description,
+				Disable:      bot.Disable,
+				Duration:     bot.Duration,
+				Editable:     bot.Editable,
+				ID:           bot.ID,
+				Level:        bot.Level,
+				Name:         bot.Name,
+				Secret:       bot.Secret,
+			}
+
+			// declare empty permissions to hold permissions
+			permissions := []models.Permission{}
+
+			if all {
+				perms, _ := api.GetPermissions()
+				permission := perms.Payload.Project
+
+				choices := []models.Permission{}
+				for _, perm := range permission {
+					choices = append(choices, *perm)
+				}
+				permissions = choices
+			} else {
+				permissions = prompt.GetRobotPermissionsFromUser()
+			}
+
+			// []Permission to []*Access
+			var accesses []*models.Access
+			for _, perm := range permissions {
+				access := &models.Access{
+					Action:   perm.Action,
+					Resource: perm.Resource,
+				}
+				accesses = append(accesses, access)
+			}
+			// convert []models.permission to []*model.Access
+			perm := &update.RobotPermission{
+				Kind:      bot.Permissions[0].Kind,
+				Namespace: bot.Permissions[0].Namespace,
+				Access:    accesses,
+			}
+			opts.Permissions = []*update.RobotPermission{perm}
+
+			err = updateRobotView(&opts)
+			if err != nil {
+				log.Errorf("failed to Update robot")
+			}
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.BoolVarP(
+		&all,
+		"all-permission",
+		"a",
+		false,
+		"Select all permissions for the robot account",
+	)
+	flags.StringVarP(&opts.Name, "name", "", "", "name of the robot account")
+	flags.StringVarP(&opts.Description, "description", "", "", "description of the robot account")
+	flags.Int64VarP(&opts.Duration, "duration", "", 0, "set expiration of robot account in days")
+
+	return cmd
+}
+
+func updateRobotView(updateView *update.UpdateView) error {
+	if updateView == nil {
+		updateView = &update.UpdateView{}
+	}
+
+	update.UpdateRobotView(updateView)
+	return api.UpdateRobot(updateView)
+}

--- a/cmd/harbor/root/project/robot/update.go
+++ b/cmd/harbor/root/project/robot/update.go
@@ -1,3 +1,16 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package robot
 
 import (
@@ -30,7 +43,6 @@ func UpdateRobotCommand() *cobra.Command {
 				if err != nil {
 					log.Fatalf("failed to parse robot ID: %v", err)
 				}
-
 			} else {
 				projectID := prompt.GetProjectIDFromUser()
 				robotID = prompt.GetRobotIDFromUser(projectID)
@@ -56,7 +68,7 @@ func UpdateRobotCommand() *cobra.Command {
 			}
 
 			// declare empty permissions to hold permissions
-			permissions := []models.Permission{}
+			var permissions []models.Permission
 
 			if all {
 				perms, _ := api.GetPermissions()
@@ -90,7 +102,7 @@ func UpdateRobotCommand() *cobra.Command {
 
 			err = updateRobotView(&opts)
 			if err != nil {
-        log.Fatalf("failed to Update robot: %v", err)
+				log.Fatalf("failed to Update robot: %v", err)
 			}
 		},
 	}

--- a/cmd/harbor/root/project/robot/view.go
+++ b/cmd/harbor/root/project/robot/view.go
@@ -1,0 +1,40 @@
+package robot
+
+import (
+	"strconv"
+
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/robot"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/views/robot/list"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/spf13/cobra"
+)
+
+// ViewCommand creates a new `harbor project robot view` command
+func ViewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "view [robotID]",
+		Short: "get robot by id",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			var robot *robot.GetRobotByIDOK
+
+			if len(args) == 1 {
+				robotID, err := strconv.ParseInt(args[0], 10, 64)
+				if err != nil {
+					log.Errorf("failed to parse robot ID: %v", err)
+				}
+				robot, err = api.GetRobot(robotID)
+				if err != nil {
+					log.Errorf("failed to List robots")
+				}
+			}
+			robots := []*models.Robot{robot.Payload}
+			list.ListRobots(robots)
+		},
+	}
+
+	return cmd
+}

--- a/cmd/harbor/root/project/robot/view.go
+++ b/cmd/harbor/root/project/robot/view.go
@@ -1,38 +1,46 @@
 package robot
 
 import (
-	"os"
 	"strconv"
 
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/robot"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/views/robot/list"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/spf13/cobra"
 )
 
-// handle robot view with interactive like in list command.
 func ViewRobotCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "view [robotID]",
 		Short: "get robot by id",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			var robot *robot.GetRobotByIDOK
+			var (
+				robot   *robot.GetRobotByIDOK
+				robotID int64
+				err     error
+			)
 
 			if len(args) == 1 {
-				robotID, err := strconv.ParseInt(args[0], 10, 64)
+				robotID, err = strconv.ParseInt(args[0], 10, 64)
 				if err != nil {
-					log.Errorf("failed to parse robot ID: %v", err)
+					log.Fatalf("failed to parse robot ID: %v", err)
 				}
-				robot, err = api.GetRobot(robotID)
-				if err != nil {
-					log.Errorf("failed to List robots")
-					os.Exit(1)
-				}
+			} else {
+				projectID := prompt.GetProjectIDFromUser()
+				robotID = prompt.GetRobotIDFromUser(projectID)
 			}
+
+			robot, err = api.GetRobot(robotID)
+			if err != nil {
+				log.Fatalf("failed to get robot: %v", err)
+			}
+
+			// Convert to a list and display
 			robots := []*models.Robot{robot.Payload}
 			list.ListRobots(robots)
 		},

--- a/cmd/harbor/root/project/robot/view.go
+++ b/cmd/harbor/root/project/robot/view.go
@@ -1,6 +1,7 @@
 package robot
 
 import (
+	"os"
 	"strconv"
 
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/robot"
@@ -12,8 +13,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// ViewCommand creates a new `harbor project robot view` command
-func ViewCommand() *cobra.Command {
+// handle robot view with interactive like in list command.
+func ViewRobotCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "view [robotID]",
 		Short: "get robot by id",
@@ -29,6 +30,7 @@ func ViewCommand() *cobra.Command {
 				robot, err = api.GetRobot(robotID)
 				if err != nil {
 					log.Errorf("failed to List robots")
+					os.Exit(1)
 				}
 			}
 			robots := []*models.Robot{robot.Payload}

--- a/cmd/harbor/root/project/robot/view.go
+++ b/cmd/harbor/root/project/robot/view.go
@@ -1,3 +1,16 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package robot
 
 import (

--- a/doc/cli-docs/harbor-project-robot-create.md
+++ b/doc/cli-docs/harbor-project-robot-create.md
@@ -1,0 +1,37 @@
+---
+title: harbor project robot create
+weight: 15
+---
+## harbor project robot create
+
+### Description
+
+##### create robot
+
+```sh
+harbor project robot create [flags]
+```
+
+### Options
+
+```sh
+  -a, --all-permission       Select all permissions for the robot account
+      --description string   description of the robot account
+      --duration int         set expiration of robot account in days
+  -h, --help                 help for create
+      --name string          name of the robot account
+      --project string       set project name
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor project robot](harbor-project-robot.md)	 - Manage robot accounts
+

--- a/doc/cli-docs/harbor-project-robot-delete.md
+++ b/doc/cli-docs/harbor-project-robot-delete.md
@@ -1,0 +1,32 @@
+---
+title: harbor project robot delete
+weight: 5
+---
+## harbor project robot delete
+
+### Description
+
+##### delete robot by id
+
+```sh
+harbor project robot delete [robotID] [flags]
+```
+
+### Options
+
+```sh
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor project robot](harbor-project-robot.md)	 - Manage robot accounts
+

--- a/doc/cli-docs/harbor-project-robot-list.md
+++ b/doc/cli-docs/harbor-project-robot-list.md
@@ -1,0 +1,37 @@
+---
+title: harbor project robot list
+weight: 35
+---
+## harbor project robot list
+
+### Description
+
+##### list robot
+
+```sh
+harbor project robot list [projectName] [flags]
+```
+
+### Options
+
+```sh
+  -h, --help             help for list
+      --page int         Page number (default 1)
+      --page-size int    Size of per page (default 10)
+      --project-id int   Project ID
+  -q, --query string     Query string to query resources
+      --sort string      Sort the resource list in ascending or descending order
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor project robot](harbor-project-robot.md)	 - Manage robot accounts
+

--- a/doc/cli-docs/harbor-project-robot-refresh.md
+++ b/doc/cli-docs/harbor-project-robot-refresh.md
@@ -1,0 +1,34 @@
+---
+title: harbor project robot refresh
+weight: 25
+---
+## harbor project robot refresh
+
+### Description
+
+##### refresh robot secret by id
+
+```sh
+harbor project robot refresh [robotID] [flags]
+```
+
+### Options
+
+```sh
+  -h, --help            help for refresh
+      --secret string   secret
+      --secret-stdin    Take the robot secret from stdin
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor project robot](harbor-project-robot.md)	 - Manage robot accounts
+

--- a/doc/cli-docs/harbor-project-robot-update.md
+++ b/doc/cli-docs/harbor-project-robot-update.md
@@ -1,0 +1,36 @@
+---
+title: harbor project robot update
+weight: 55
+---
+## harbor project robot update
+
+### Description
+
+##### update robot by id
+
+```sh
+harbor project robot update [robotID] [flags]
+```
+
+### Options
+
+```sh
+  -a, --all-permission       Select all permissions for the robot account
+      --description string   description of the robot account
+      --duration int         set expiration of robot account in days
+  -h, --help                 help for update
+      --name string          name of the robot account
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor project robot](harbor-project-robot.md)	 - Manage robot accounts
+

--- a/doc/cli-docs/harbor-project-robot-view.md
+++ b/doc/cli-docs/harbor-project-robot-view.md
@@ -1,0 +1,32 @@
+---
+title: harbor project robot view
+weight: 50
+---
+## harbor project robot view
+
+### Description
+
+##### get robot by id
+
+```sh
+harbor project robot view [robotID] [flags]
+```
+
+### Options
+
+```sh
+  -h, --help   help for view
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor project robot](harbor-project-robot.md)	 - Manage robot accounts
+

--- a/doc/cli-docs/harbor-project-robot.md
+++ b/doc/cli-docs/harbor-project-robot.md
@@ -1,0 +1,40 @@
+---
+title: harbor project robot
+weight: 40
+---
+## harbor project robot
+
+### Description
+
+##### Manage robot accounts
+
+### Examples
+
+```sh
+  harbor project robot list
+```
+
+### Options
+
+```sh
+  -h, --help   help for robot
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor project](harbor-project.md)	 - Manage projects and assign resources to them
+* [harbor project robot create](harbor-project-robot-create.md)	 - create robot
+* [harbor project robot delete](harbor-project-robot-delete.md)	 - delete robot by id
+* [harbor project robot list](harbor-project-robot-list.md)	 - list robot
+* [harbor project robot refresh](harbor-project-robot-refresh.md)	 - refresh robot secret by id
+* [harbor project robot update](harbor-project-robot-update.md)	 - update robot by id
+* [harbor project robot view](harbor-project-robot-view.md)	 - get robot by id
+

--- a/doc/man-docs/man1/harbor-project-robot-create.1
+++ b/doc/man-docs/man1/harbor-project-robot-create.1
@@ -1,0 +1,55 @@
+.nh
+.TH "HARBOR" "1"  "Habor Community" "Harbor User Mannuals"
+
+.SH NAME
+harbor-project-robot-create - create robot
+
+
+.SH SYNOPSIS
+\fBharbor project robot create [flags]\fP
+
+
+.SH DESCRIPTION
+create robot
+
+
+.SH OPTIONS
+\fB-a\fP, \fB--all-permission\fP[=false]
+	Select all permissions for the robot account
+
+.PP
+\fB--description\fP=""
+	description of the robot account
+
+.PP
+\fB--duration\fP=0
+	set expiration of robot account in days
+
+.PP
+\fB-h\fP, \fB--help\fP[=false]
+	help for create
+
+.PP
+\fB--name\fP=""
+	name of the robot account
+
+.PP
+\fB--project\fP=""
+	set project name
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+\fB-c\fP, \fB--config\fP=""
+	config file (default is $HOME/.config/harbor-cli/config.yaml)
+
+.PP
+\fB-o\fP, \fB--output-format\fP=""
+	Output format. One of: json|yaml
+
+.PP
+\fB-v\fP, \fB--verbose\fP[=false]
+	verbose output
+
+
+.SH SEE ALSO
+\fBharbor-project-robot(1)\fP

--- a/doc/man-docs/man1/harbor-project-robot-delete.1
+++ b/doc/man-docs/man1/harbor-project-robot-delete.1
@@ -1,0 +1,35 @@
+.nh
+.TH "HARBOR" "1"  "Habor Community" "Harbor User Mannuals"
+
+.SH NAME
+harbor-project-robot-delete - delete robot by id
+
+
+.SH SYNOPSIS
+\fBharbor project robot delete [robotID] [flags]\fP
+
+
+.SH DESCRIPTION
+delete robot by id
+
+
+.SH OPTIONS
+\fB-h\fP, \fB--help\fP[=false]
+	help for delete
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+\fB-c\fP, \fB--config\fP=""
+	config file (default is $HOME/.config/harbor-cli/config.yaml)
+
+.PP
+\fB-o\fP, \fB--output-format\fP=""
+	Output format. One of: json|yaml
+
+.PP
+\fB-v\fP, \fB--verbose\fP[=false]
+	verbose output
+
+
+.SH SEE ALSO
+\fBharbor-project-robot(1)\fP

--- a/doc/man-docs/man1/harbor-project-robot-list.1
+++ b/doc/man-docs/man1/harbor-project-robot-list.1
@@ -1,0 +1,55 @@
+.nh
+.TH "HARBOR" "1"  "Habor Community" "Harbor User Mannuals"
+
+.SH NAME
+harbor-project-robot-list - list robot
+
+
+.SH SYNOPSIS
+\fBharbor project robot list [projectName] [flags]\fP
+
+
+.SH DESCRIPTION
+list robot
+
+
+.SH OPTIONS
+\fB-h\fP, \fB--help\fP[=false]
+	help for list
+
+.PP
+\fB--page\fP=1
+	Page number
+
+.PP
+\fB--page-size\fP=10
+	Size of per page
+
+.PP
+\fB--project-id\fP=0
+	Project ID
+
+.PP
+\fB-q\fP, \fB--query\fP=""
+	Query string to query resources
+
+.PP
+\fB--sort\fP=""
+	Sort the resource list in ascending or descending order
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+\fB-c\fP, \fB--config\fP=""
+	config file (default is $HOME/.config/harbor-cli/config.yaml)
+
+.PP
+\fB-o\fP, \fB--output-format\fP=""
+	Output format. One of: json|yaml
+
+.PP
+\fB-v\fP, \fB--verbose\fP[=false]
+	verbose output
+
+
+.SH SEE ALSO
+\fBharbor-project-robot(1)\fP

--- a/doc/man-docs/man1/harbor-project-robot-refresh.1
+++ b/doc/man-docs/man1/harbor-project-robot-refresh.1
@@ -1,0 +1,43 @@
+.nh
+.TH "HARBOR" "1"  "Habor Community" "Harbor User Mannuals"
+
+.SH NAME
+harbor-project-robot-refresh - refresh robot secret by id
+
+
+.SH SYNOPSIS
+\fBharbor project robot refresh [robotID] [flags]\fP
+
+
+.SH DESCRIPTION
+refresh robot secret by id
+
+
+.SH OPTIONS
+\fB-h\fP, \fB--help\fP[=false]
+	help for refresh
+
+.PP
+\fB--secret\fP=""
+	secret
+
+.PP
+\fB--secret-stdin\fP[=false]
+	Take the robot secret from stdin
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+\fB-c\fP, \fB--config\fP=""
+	config file (default is $HOME/.config/harbor-cli/config.yaml)
+
+.PP
+\fB-o\fP, \fB--output-format\fP=""
+	Output format. One of: json|yaml
+
+.PP
+\fB-v\fP, \fB--verbose\fP[=false]
+	verbose output
+
+
+.SH SEE ALSO
+\fBharbor-project-robot(1)\fP

--- a/doc/man-docs/man1/harbor-project-robot-update.1
+++ b/doc/man-docs/man1/harbor-project-robot-update.1
@@ -1,0 +1,51 @@
+.nh
+.TH "HARBOR" "1"  "Habor Community" "Harbor User Mannuals"
+
+.SH NAME
+harbor-project-robot-update - update robot by id
+
+
+.SH SYNOPSIS
+\fBharbor project robot update [robotID] [flags]\fP
+
+
+.SH DESCRIPTION
+update robot by id
+
+
+.SH OPTIONS
+\fB-a\fP, \fB--all-permission\fP[=false]
+	Select all permissions for the robot account
+
+.PP
+\fB--description\fP=""
+	description of the robot account
+
+.PP
+\fB--duration\fP=0
+	set expiration of robot account in days
+
+.PP
+\fB-h\fP, \fB--help\fP[=false]
+	help for update
+
+.PP
+\fB--name\fP=""
+	name of the robot account
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+\fB-c\fP, \fB--config\fP=""
+	config file (default is $HOME/.config/harbor-cli/config.yaml)
+
+.PP
+\fB-o\fP, \fB--output-format\fP=""
+	Output format. One of: json|yaml
+
+.PP
+\fB-v\fP, \fB--verbose\fP[=false]
+	verbose output
+
+
+.SH SEE ALSO
+\fBharbor-project-robot(1)\fP

--- a/doc/man-docs/man1/harbor-project-robot-view.1
+++ b/doc/man-docs/man1/harbor-project-robot-view.1
@@ -1,0 +1,35 @@
+.nh
+.TH "HARBOR" "1"  "Habor Community" "Harbor User Mannuals"
+
+.SH NAME
+harbor-project-robot-view - get robot by id
+
+
+.SH SYNOPSIS
+\fBharbor project robot view [robotID] [flags]\fP
+
+
+.SH DESCRIPTION
+get robot by id
+
+
+.SH OPTIONS
+\fB-h\fP, \fB--help\fP[=false]
+	help for view
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+\fB-c\fP, \fB--config\fP=""
+	config file (default is $HOME/.config/harbor-cli/config.yaml)
+
+.PP
+\fB-o\fP, \fB--output-format\fP=""
+	Output format. One of: json|yaml
+
+.PP
+\fB-v\fP, \fB--verbose\fP[=false]
+	verbose output
+
+
+.SH SEE ALSO
+\fBharbor-project-robot(1)\fP

--- a/doc/man-docs/man1/harbor-project-robot.1
+++ b/doc/man-docs/man1/harbor-project-robot.1
@@ -1,0 +1,41 @@
+.nh
+.TH "HARBOR" "1"  "Habor Community" "Harbor User Mannuals"
+
+.SH NAME
+harbor-project-robot - Manage robot accounts
+
+
+.SH SYNOPSIS
+\fBharbor project robot [flags]\fP
+
+
+.SH DESCRIPTION
+Manage robot accounts
+
+
+.SH OPTIONS
+\fB-h\fP, \fB--help\fP[=false]
+	help for robot
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+\fB-c\fP, \fB--config\fP=""
+	config file (default is $HOME/.config/harbor-cli/config.yaml)
+
+.PP
+\fB-o\fP, \fB--output-format\fP=""
+	Output format. One of: json|yaml
+
+.PP
+\fB-v\fP, \fB--verbose\fP[=false]
+	verbose output
+
+
+.SH EXAMPLE
+.EX
+  harbor project robot list
+.EE
+
+
+.SH SEE ALSO
+\fBharbor-project(1)\fP, \fBharbor-project-robot-create(1)\fP, \fBharbor-project-robot-delete(1)\fP, \fBharbor-project-robot-list(1)\fP, \fBharbor-project-robot-refresh(1)\fP, \fBharbor-project-robot-update(1)\fP, \fBharbor-project-robot-view(1)\fP

--- a/pkg/api/robot_handler.go
+++ b/pkg/api/robot_handler.go
@@ -6,6 +6,7 @@ import (
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/robot/create"
+	"github.com/goharbor/harbor-cli/pkg/views/robot/update"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -59,7 +60,7 @@ func DeleteRobot(robotID int64) error {
 	return nil
 }
 
-func CreateRobot(opts create.CreateView) (*robot.CreateRobotCreated ,error) {
+func CreateRobot(opts create.CreateView) (*robot.CreateRobotCreated, error) {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {
 		return nil, err
@@ -79,7 +80,7 @@ func CreateRobot(opts create.CreateView) (*robot.CreateRobotCreated ,error) {
 		}
 		convertedPerms = append(convertedPerms, convertedPerm)
 	}
-  response, err := client.Robot.CreateRobot(
+	response, err := client.Robot.CreateRobot(
 		ctx,
 		&robot.CreateRobotParams{
 			Robot: &models.RobotCreate{
@@ -93,11 +94,60 @@ func CreateRobot(opts create.CreateView) (*robot.CreateRobotCreated ,error) {
 		},
 	)
 	if err != nil {
-		return nil,err
+		return nil, err
 	}
 
 	log.Info("robot created successfully.")
 	return response, nil
+}
+
+// update robot with robotID
+func UpdateRobot(opts *update.UpdateView) error {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		log.Errorf("Error: %v", err)
+		return err
+	}
+
+	log.Println(opts)
+
+	// Create a slice to store converted permissions
+	permissions := opts.Permissions
+	convertedPerms := make([]*models.RobotPermission, 0, len(permissions))
+
+	kind := "project"
+	// Loop through original permissions and convert them
+	for _, perm := range permissions {
+		convertedPerm := &models.RobotPermission{
+			Access: perm.Access,
+			Kind:   kind,
+      Namespace: opts.Permissions[0].Namespace,
+		}
+		convertedPerms = append(convertedPerms, convertedPerm)
+	}
+	_, err = client.Robot.UpdateRobot(
+		ctx,
+		&robot.UpdateRobotParams{
+			Robot: &models.Robot{
+				Description: opts.Description,
+				Duration:    opts.Duration,
+				Editable:    opts.Editable,
+				Disable:     opts.Disable,
+				ID:          opts.ID,
+				Level:       opts.Level,
+				Name:        opts.Name,
+				Permissions: convertedPerms,
+			},
+			RobotID: opts.ID,
+		},
+	)
+	if err != nil {
+		log.Errorf("Error in updating Robot: %v", err)
+		return err
+	}
+
+	log.Info("robot updated successfully.")
+	return nil
 }
 
 func GetPermissions() (*permissions.GetPermissionsOK, error) {

--- a/pkg/api/robot_handler.go
+++ b/pkg/api/robot_handler.go
@@ -119,9 +119,9 @@ func UpdateRobot(opts *update.UpdateView) error {
 	// Loop through original permissions and convert them
 	for _, perm := range permissions {
 		convertedPerm := &models.RobotPermission{
-			Access: perm.Access,
-			Kind:   kind,
-      Namespace: opts.Permissions[0].Namespace,
+			Access:    perm.Access,
+			Kind:      kind,
+			Namespace: opts.Permissions[0].Namespace,
 		}
 		convertedPerms = append(convertedPerms, convertedPerm)
 	}
@@ -159,6 +159,27 @@ func GetPermissions() (*permissions.GetPermissionsOK, error) {
 		ctx,
 		&permissions.GetPermissionsParams{},
 	)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func RefreshSecret(secret string, robotID int64) (*robot.RefreshSecOK, error) {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return nil, err
+	}
+
+	robotSec := &models.RobotSec{
+		Secret: secret,
+	}
+
+	response, err := client.Robot.RefreshSec(ctx, &robot.RefreshSecParams{
+		RobotSec: robotSec,
+		RobotID:  robotID,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/robot_handler.go
+++ b/pkg/api/robot_handler.go
@@ -3,6 +3,7 @@ package api
 import (
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/robot"
 	"github.com/goharbor/harbor-cli/pkg/utils"
+	log "github.com/sirupsen/logrus"
 )
 
 func ListRobot(opts ListFlags) (*robot.ListRobotOK, error) {
@@ -25,4 +26,32 @@ func ListRobot(opts ListFlags) (*robot.ListRobotOK, error) {
 	}
 
 	return response, nil
+}
+
+func GetRobot(robotID int64) (*robot.GetRobotByIDOK, error) {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return nil, err
+	}
+	response, err := client.Robot.GetRobotByID(ctx, &robot.GetRobotByIDParams{RobotID: robotID})
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func DeleteRobot(robotID int64) error {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return err
+	}
+	_, err = client.Robot.DeleteRobot(ctx, &robot.DeleteRobotParams{RobotID: robotID})
+	if err != nil {
+		return err
+	}
+
+	log.Info("robot deleted successfully")
+
+	return nil
 }

--- a/pkg/api/robot_handler.go
+++ b/pkg/api/robot_handler.go
@@ -1,0 +1,28 @@
+package api
+
+import (
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/robot"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+)
+
+func ListRobot(opts ListFlags) (*robot.ListRobotOK, error) {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := client.Robot.ListRobot(
+		ctx,
+		&robot.ListRobotParams{
+			Page:     &opts.Page,
+			PageSize: &opts.PageSize,
+			Q:        &opts.Q,
+			Sort:     &opts.Sort,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/robot_handler.go
+++ b/pkg/api/robot_handler.go
@@ -60,7 +60,7 @@ func DeleteRobot(robotID int64) error {
 	return nil
 }
 
-func CreateRobot(opts create.CreateView) (*robot.CreateRobotCreated, error) {
+func CreateRobot(opts create.CreateView, kind string) (*robot.CreateRobotCreated, error) {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {
 		return nil, err
@@ -70,12 +70,11 @@ func CreateRobot(opts create.CreateView) (*robot.CreateRobotCreated, error) {
 	permissions := opts.Permissions
 	convertedPerms := make([]*models.RobotPermission, 0, len(permissions))
 
-	project := "project"
 	// Loop through original permissions and convert them
 	for _, perm := range permissions {
 		convertedPerm := &models.RobotPermission{
 			Access:    perm.Access,
-			Kind:      project,
+			Kind:      kind,
 			Namespace: opts.ProjectName,
 		}
 		convertedPerms = append(convertedPerms, convertedPerm)
@@ -87,7 +86,7 @@ func CreateRobot(opts create.CreateView) (*robot.CreateRobotCreated, error) {
 				Description: opts.Description,
 				Disable:     false,
 				Duration:    opts.Duration,
-				Level:       opts.Level,
+				Level:       kind,
 				Name:        opts.Name,
 				Permissions: convertedPerms,
 			},
@@ -109,18 +108,15 @@ func UpdateRobot(opts *update.UpdateView) error {
 		return err
 	}
 
-	log.Println(opts)
-
 	// Create a slice to store converted permissions
 	permissions := opts.Permissions
 	convertedPerms := make([]*models.RobotPermission, 0, len(permissions))
 
-	kind := "project"
 	// Loop through original permissions and convert them
 	for _, perm := range permissions {
 		convertedPerm := &models.RobotPermission{
 			Access:    perm.Access,
-			Kind:      kind,
+			Kind:      opts.Permissions[0].Kind,
 			Namespace: opts.Permissions[0].Namespace,
 		}
 		convertedPerms = append(convertedPerms, convertedPerm)

--- a/pkg/api/robot_handler.go
+++ b/pkg/api/robot_handler.go
@@ -1,8 +1,11 @@
 package api
 
 import (
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/permissions"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/robot"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/goharbor/harbor-cli/pkg/views/robot/create"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -54,4 +57,61 @@ func DeleteRobot(robotID int64) error {
 	log.Info("robot deleted successfully")
 
 	return nil
+}
+
+func CreateRobot(opts create.CreateView) (*robot.CreateRobotCreated ,error) {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a slice to store converted permissions
+	permissions := opts.Permissions
+	convertedPerms := make([]*models.RobotPermission, 0, len(permissions))
+
+	project := "project"
+	// Loop through original permissions and convert them
+	for _, perm := range permissions {
+		convertedPerm := &models.RobotPermission{
+			Access:    perm.Access,
+			Kind:      project,
+			Namespace: opts.ProjectName,
+		}
+		convertedPerms = append(convertedPerms, convertedPerm)
+	}
+  response, err := client.Robot.CreateRobot(
+		ctx,
+		&robot.CreateRobotParams{
+			Robot: &models.RobotCreate{
+				Description: opts.Description,
+				Disable:     false,
+				Duration:    opts.Duration,
+				Level:       opts.Level,
+				Name:        opts.Name,
+				Permissions: convertedPerms,
+			},
+		},
+	)
+	if err != nil {
+		return nil,err
+	}
+
+	log.Info("robot created successfully.")
+	return response, nil
+}
+
+func GetPermissions() (*permissions.GetPermissionsOK, error) {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return nil, err
+	}
+	response, err := client.Permissions.GetPermissions(
+		ctx,
+		&permissions.GetPermissionsParams{},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
 }

--- a/pkg/api/robot_handler.go
+++ b/pkg/api/robot_handler.go
@@ -1,3 +1,16 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package api
 
 import (

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -12,3 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 package constants
+
+const (
+	HarborCredentialName = "HARBORCREDENTIALNAME"
+	CredentialNameOption = "credential-name"
+	CredentialNameHelp   = "Name of the credential to use for authentication (defaults to the current logged in session)"
+	ProjectQString       = "Level%3Dproject%2CProjectID%3D"
+)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -14,8 +14,5 @@
 package constants
 
 const (
-	HarborCredentialName = "HARBORCREDENTIALNAME"
-	CredentialNameOption = "credential-name"
-	CredentialNameHelp   = "Name of the credential to use for authentication (defaults to the current logged in session)"
-	ProjectQString       = "Level%3Dproject%2CProjectID%3D"
+	ProjectQString = "Level%3Dproject%2CProjectID%3D"
 )

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -83,6 +83,16 @@ func GetProjectNameFromUser() (string, error) {
 	return res.name, res.err
 }
 
+func GetProjectIDFromUser() int64 {
+	projectID := make(chan int64)
+	go func() {
+		response, _ := api.ListProject()
+		pview.ProjectListID(response.Payload, projectID)
+	}()
+
+	return <-projectID
+}
+
 func GetRepoNameFromUser(projectName string) string {
 	repositoryName := make(chan string)
 

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -31,6 +31,7 @@ import (
 	qview "github.com/goharbor/harbor-cli/pkg/views/quota/select"
 	rview "github.com/goharbor/harbor-cli/pkg/views/registry/select"
 	repoView "github.com/goharbor/harbor-cli/pkg/views/repository/select"
+	robotView "github.com/goharbor/harbor-cli/pkg/views/robot/select"
 	sview "github.com/goharbor/harbor-cli/pkg/views/scanner/select"
 	uview "github.com/goharbor/harbor-cli/pkg/views/user/select"
 	wview "github.com/goharbor/harbor-cli/pkg/views/webhook/select"
@@ -210,7 +211,6 @@ func GetLabelIdFromUser(labelList []*models.Label) int64 {
 
 	return <-labelId
 }
-
 func GetInstanceFromUser() string {
 	instanceName := make(chan string)
 
@@ -253,4 +253,13 @@ func GetActiveContextFromUser() (string, error) {
 	}
 
 	return res, nil
+}
+
+func GetRobotPermissionsFromUser() []models.Permission {
+	permissions := make(chan []models.Permission)
+	go func() {
+		response, _ := api.GetPermissions()
+		robotView.ListPermissions(response.Payload, permissions)
+	}()
+	return <-permissions
 }

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -17,11 +17,14 @@ import (
 	"errors"
 	"fmt"
 
+	"strconv"
+
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	list "github.com/goharbor/harbor-cli/pkg/views/context/switch"
 
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/constants"
 	aview "github.com/goharbor/harbor-cli/pkg/views/artifact/select"
 	tview "github.com/goharbor/harbor-cli/pkg/views/artifact/tags/select"
 	immview "github.com/goharbor/harbor-cli/pkg/views/immutable/select"
@@ -262,4 +265,16 @@ func GetRobotPermissionsFromUser() []models.Permission {
 		robotView.ListPermissions(response.Payload, permissions)
 	}()
 	return <-permissions
+}
+
+func GetRobotIDFromUser(projectID int64) int64 {
+	robotID := make(chan int64)
+	var opts api.ListFlags
+	opts.Q = constants.ProjectQString + strconv.FormatInt(projectID, 10)
+
+	go func() {
+		response, _ := api.ListRobot(opts)
+		robotView.ListRobot(response.Payload, robotID)
+	}()
+	return <-robotID
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -159,7 +159,7 @@ func SavePayloadJSON(filename string, payload any) {
 	}
 	// Define the filename
 	filename = filename + ".json"
-	err = os.WriteFile(filename, jsonStr, 0644)
+	err = os.WriteFile(filename, jsonStr, 0600)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -17,12 +17,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
+	"syscall"
 
 	log "github.com/sirupsen/logrus"
-	"sigs.k8s.io/yaml"
+	"golang.org/x/term"
+	"gopkg.in/yaml.v3"
 )
 
 // Returns Harbor v2 client for given clientConfig
@@ -146,4 +149,30 @@ func StorageStringToBytes(storage string) (int64, error) {
 	}
 
 	return bytes, nil
+}
+
+func SavePayloadJSON(filename string, payload any) {
+	// Marshal the payload into a JSON string with indentation
+	jsonStr, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	// Define the filename
+	filename = filename + ".json"
+	err = os.WriteFile(filename, jsonStr, 0644)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("JSON data has been written to %s\n", filename)
+}
+
+// Get Password as Stdin
+func GetSecretStdin(prompt string) (string, error) {
+	fmt.Print(prompt)
+	bytePassword, err := term.ReadPassword(int(syscall.Stdin))
+	if err != nil {
+		return "", err
+	}
+	fmt.Println() // move to the next line after input
+	return strings.TrimSpace(string(bytePassword)), nil
 }

--- a/pkg/views/base/multiselect/model.go
+++ b/pkg/views/base/multiselect/model.go
@@ -1,0 +1,196 @@
+package multiselect
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+)
+
+const useHighPerformanceRenderer = false
+
+var (
+	titleStyle = func() lipgloss.Style {
+		b := lipgloss.RoundedBorder()
+		b.Right = "├"
+		return lipgloss.NewStyle().BorderStyle(b).Padding(0, 1)
+	}()
+
+	selectedStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("43"))
+	itemStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("46"))
+	blockStyle = lipgloss.NewStyle().
+			Background(lipgloss.Color("81")).
+			Foreground(lipgloss.Color("#000000")).
+			Bold(true).
+			Padding(0, 1, 0)
+
+	infoStyle = func() lipgloss.Style {
+		b := lipgloss.RoundedBorder()
+		b.Left = "┤"
+		return titleStyle.BorderStyle(b)
+	}()
+)
+
+type Model struct {
+	content  string
+	ready    bool
+	viewport viewport.Model
+	choices  []models.Permission // items on the to-do list
+	cursor   int                 // which to-do list item our cursor is pointing at
+	selected map[int]struct{}    // which to-do items are selected
+	selects  *[]models.Permission
+}
+
+func (m Model) Init() tea.Cmd {
+	return nil
+}
+
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var (
+		cmd  tea.Cmd
+		cmds []tea.Cmd
+	)
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "q", "esc":
+			return m, tea.Quit
+		case "y":
+			m.GetSelectedPermissions()
+			return m, tea.Quit
+		case "up", "k":
+			if m.cursor > 0 {
+				m.cursor--
+			}
+		case "down", "j":
+			if m.cursor < len(m.choices)-1 {
+				m.cursor++
+			}
+		case "enter", " ":
+			_, ok := m.selected[m.cursor]
+			if ok {
+				delete(m.selected, m.cursor)
+			} else {
+				m.selected[m.cursor] = struct{}{}
+			}
+		}
+
+	case tea.WindowSizeMsg:
+		headerHeight := lipgloss.Height(m.headerView())
+		footerHeight := lipgloss.Height(m.footerView())
+		verticalMarginHeight := headerHeight + footerHeight
+
+		if !m.ready {
+			m.viewport = viewport.New(msg.Width, msg.Height-verticalMarginHeight)
+			m.viewport.YPosition = headerHeight
+			m.viewport.HighPerformanceRendering = useHighPerformanceRenderer
+			m.viewport.SetContent(m.listView())
+			m.ready = true
+			m.viewport.YPosition = headerHeight - 1
+		} else {
+			m.viewport.Width = msg.Width
+			m.viewport.Height = msg.Height - verticalMarginHeight - 1
+		}
+
+		if useHighPerformanceRenderer {
+			cmds = append(cmds, viewport.Sync(m.viewport))
+		}
+	}
+
+	m.viewport.SetContent(m.listView())
+	m.viewport, cmd = m.viewport.Update(msg)
+	cmds = append(cmds, cmd)
+
+	return m, tea.Batch(cmds...)
+}
+
+func (m Model) View() string {
+	if !m.ready {
+		return "\n  Initializing..."
+	}
+	return fmt.Sprintf("%s\n%s\n%s", m.headerView(), m.viewport.View(), m.footerView())
+}
+
+func (m Model) headerView() string {
+	title := titleStyle.Render("Select Permissions for Robot Account")
+	line := strings.Repeat("─", max(0, m.viewport.Width-lipgloss.Width(title)))
+	return lipgloss.JoinHorizontal(lipgloss.Center, title, line)
+}
+
+func (m Model) footerView() string {
+	help := lipgloss.NewStyle().Foreground(lipgloss.Color("238")).Render(
+		fmt.Sprint(
+			"  up/down: navigate • ", "enter: select permissions • ", "q: quit • ", " y: confirm\t",
+		),
+	)
+	info := infoStyle.Render(fmt.Sprintf("%3.f%%", m.viewport.ScrollPercent()*100))
+	line := strings.Repeat("─", max(0, m.viewport.Width-lipgloss.Width(info)-lipgloss.Width(help)))
+	return lipgloss.JoinHorizontal(lipgloss.Center, help, line, info)
+}
+
+func (m Model) listView() string {
+	s := "Select Robot Permissions\n\n"
+	var prev string
+	for i, choice := range m.choices {
+		// Render the row ith appropriate action message
+		choiceRes := choice.Resource
+		choiceAct := choice.Action
+		now := choice.Resource
+		if prev != now {
+			prev = now
+			s += blockStyle.Render(prev)
+			s += "\n\n"
+		}
+		cursor := " " // no cursor
+		if m.cursor == i {
+			choiceRes = itemStyle.Render(choice.Resource)
+			choiceAct = itemStyle.Render(choice.Action)
+			cursor = ">" // cursor!
+		}
+		checked := " " // not selected
+		if _, ok := m.selected[i]; ok {
+			choiceRes = selectedStyle.Render(choice.Resource)
+			choiceAct = selectedStyle.Render(choice.Action)
+			checked = "x" // selected!
+		}
+		s += fmt.Sprintf(
+			"%s [%s] %s %s\n\n",
+			cursor,
+			checked,
+			choiceAct,
+			choiceRes,
+		)
+	}
+	s += "\nPress q to quit.\n"
+
+	return s
+}
+
+
+func (m Model) GetSelectedPermissions() *[]models.Permission {
+	selectedPermissions := make([]models.Permission, 0, len(m.selected))
+	for index := range m.selected {
+		selectedPermissions = append(selectedPermissions, m.choices[index])
+	}
+	*m.selects = selectedPermissions
+	return m.selects
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func NewModel(choices []models.Permission, selects *[]models.Permission) Model {
+	return Model{
+		choices:  choices,
+		selected: make(map[int]struct{}),
+		selects:  selects,
+	}
+}

--- a/pkg/views/base/multiselect/model.go
+++ b/pkg/views/base/multiselect/model.go
@@ -38,9 +38,9 @@ type Model struct {
 	content  string
 	ready    bool
 	viewport viewport.Model
-	choices  []models.Permission // items on the to-do list
-	cursor   int                 // which to-do list item our cursor is pointing at
-	selected map[int]struct{}    // which to-do items are selected
+	choices  []models.Permission
+	cursor   int
+	selected map[int]struct{}
 	selects  *[]models.Permission
 }
 

--- a/pkg/views/base/multiselect/model.go
+++ b/pkg/views/base/multiselect/model.go
@@ -1,3 +1,16 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package multiselect
 
 import (
@@ -35,7 +48,6 @@ var (
 )
 
 type Model struct {
-	content  string
 	ready    bool
 	viewport viewport.Model
 	choices  []models.Permission

--- a/pkg/views/base/multiselect/model.go
+++ b/pkg/views/base/multiselect/model.go
@@ -19,9 +19,9 @@ var (
 		return lipgloss.NewStyle().BorderStyle(b).Padding(0, 1)
 	}()
 
-	selectedStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("43"))
-	itemStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("46"))
-	blockStyle = lipgloss.NewStyle().
+	selectedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("43"))
+	itemStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("46"))
+	blockStyle    = lipgloss.NewStyle().
 			Background(lipgloss.Color("81")).
 			Foreground(lipgloss.Color("#000000")).
 			Bold(true).
@@ -169,7 +169,6 @@ func (m Model) listView() string {
 
 	return s
 }
-
 
 func (m Model) GetSelectedPermissions() *[]models.Permission {
 	selectedPermissions := make([]models.Permission, 0, len(m.selected))

--- a/pkg/views/project/select/view.go
+++ b/pkg/views/project/select/view.go
@@ -16,6 +16,7 @@ package project
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"

--- a/pkg/views/project/select/view.go
+++ b/pkg/views/project/select/view.go
@@ -50,3 +50,26 @@ func ProjectList(projects []*models.Project) (string, error) {
 
 	return "", errors.New("unexpected program result")
 }
+
+func ProjectListID(project []*models.Project, choice chan<- int64) {
+	itemList := make([]list.Item, len(project))
+
+	items := map[string]int32{}
+
+	for i, p := range project {
+		itemList[i] = selection.Item(p.Name)
+		items[p.Name] = p.ProjectID
+	}
+
+	m := selection.NewModel(itemList, "Project")
+
+	p, err := tea.NewProgram(m, tea.WithAltScreen()).Run()
+	if err != nil {
+		fmt.Println("Error running program:", err)
+		os.Exit(1)
+	}
+
+	if p, ok := p.(selection.Model); ok {
+		choice <- int64(items[p.Choice])
+	}
+}

--- a/pkg/views/robot/create/view.go
+++ b/pkg/views/robot/create/view.go
@@ -72,21 +72,13 @@ func CreateRobotView(createView *CreateView) {
 	}
 }
 
-func CreateRobotSecretView(response *models.RobotCreated) {
-	name := response.Name
-	secret := response.Secret
+func CreateRobotSecretView(name string, secret string) {
 	theme := huh.ThemeCharm()
 	err := huh.NewForm(
 		huh.NewGroup(
 			huh.NewInput().
 				Title("Robot Name").
-				Value(&name).
-				Validate(func(str string) error {
-					if str == "" {
-						return errors.New("Name cannot be empty")
-					}
-					return nil
-				}),
+				Value(&name),
 			huh.NewInput().
 				Title("Secret").
 				Value(&secret),

--- a/pkg/views/robot/create/view.go
+++ b/pkg/views/robot/create/view.go
@@ -40,7 +40,7 @@ func CreateRobotView(createView *CreateView) {
 	err := huh.NewForm(
 		huh.NewGroup(
 			huh.NewInput().
-				Title("Name").
+				Title("Robot Name").
 				Value(&createView.Name).
 				Validate(func(str string) error {
 					if str == "" {
@@ -80,7 +80,8 @@ func CreateRobotSecretView(name string, secret string) {
 				Title("Robot Name").
 				Value(&name),
 			huh.NewInput().
-				Title("Secret").
+				Title("Robot Secret").
+				Description("Copy the secret or press enter to copy to clipboard.").
 				Value(&secret),
 		),
 	).WithTheme(theme).Run()

--- a/pkg/views/robot/create/view.go
+++ b/pkg/views/robot/create/view.go
@@ -1,0 +1,98 @@
+package create
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/charmbracelet/huh"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	log "github.com/sirupsen/logrus"
+)
+
+type CreateView struct {
+	Description string             `json:"description,omitempty"`
+	Disable     bool               `json:"disable,omitempty"`
+	Duration    int64              `json:"duration,omitempty"`
+	Level       string             `json:"level,omitempty"`
+	Name        string             `json:"name,omitempty"`
+	Permissions []*RobotPermission `json:"permissions"`
+	Secret      string             `json:"secret,omitempty"`
+	ProjectName string
+}
+
+type RobotPermission struct {
+	Access    []*models.Access `json:"access"`
+	Kind      string           `json:"kind,omitempty"`
+	Namespace string           `json:"namespace,omitempty"`
+}
+
+type Access struct {
+	Action   string `json:"action,omitempty"`
+	Effect   string `json:"effect,omitempty"`
+	Resource string `json:"resource,omitempty"`
+}
+
+func CreateRobotView(createView *CreateView) {
+	var duration string
+	duration = strconv.FormatInt(createView.Duration, 10)
+
+	theme := huh.ThemeCharm()
+	err := huh.NewForm(
+		huh.NewGroup(
+			huh.NewInput().
+				Title("Name").
+				Value(&createView.Name).
+				Validate(func(str string) error {
+					if str == "" {
+						return errors.New("Name cannot be empty")
+					}
+					return nil
+				}),
+			huh.NewInput().
+				Title("Description").
+				Value(&createView.Description),
+			huh.NewInput().
+				Title("Expiration").
+				Value(&duration).
+				Validate(func(str string) error {
+					if str == "" {
+						return errors.New("Expiration cannot be empty")
+					}
+					dur, err := strconv.ParseInt(str, 10, 64)
+					if err != nil {
+						return errors.New("invalid expiration time: Enter expiration time in days")
+					}
+					createView.Duration = dur
+					return nil
+				}),
+		),
+	).WithTheme(theme).Run()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func CreateRobotSecretView(response *models.RobotCreated) {
+	name := response.Name
+	secret := response.Secret
+	theme := huh.ThemeCharm()
+	err := huh.NewForm(
+		huh.NewGroup(
+			huh.NewInput().
+				Title("Robot Name").
+				Value(&name).
+				Validate(func(str string) error {
+					if str == "" {
+						return errors.New("Name cannot be empty")
+					}
+					return nil
+				}),
+			huh.NewInput().
+				Title("Secret").
+				Value(&secret),
+		),
+	).WithTheme(theme).Run()
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/pkg/views/robot/create/view.go
+++ b/pkg/views/robot/create/view.go
@@ -1,3 +1,16 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package create
 
 import (

--- a/pkg/views/robot/list/view.go
+++ b/pkg/views/robot/list/view.go
@@ -16,6 +16,7 @@ import (
 )
 
 var columns = []table.Column{
+	{Title: "ID", Width: 4},
 	{Title: "Name", Width: 30},
 	{Title: "Status", Width: 18},
 	{Title: "Permissions", Width: 12},
@@ -47,10 +48,11 @@ func ListRobots(robots []*models.Robot) {
 
 		createdTime, _ := utils.FormatCreatedTime(robot.CreationTime.String())
 		rows = append(rows, table.Row{
-			robot.Name,    // Project Name
-			enabledStatus, // Access Level
+			strconv.FormatInt(robot.ID, 10),
+			robot.Name,
+			enabledStatus,
 			TotalPermissions,
-			createdTime, // Creation Time
+			createdTime,
 			expires,
 			robot.Description,
 		})

--- a/pkg/views/robot/list/view.go
+++ b/pkg/views/robot/list/view.go
@@ -2,7 +2,6 @@ package list
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"strconv"
 	"time"
@@ -46,7 +45,6 @@ func ListRobots(robots []*models.Robot) {
 			expires = remainingTime(robot.ExpiresAt)
 		}
 
-		log.Println(expires)
 		createdTime, _ := utils.FormatCreatedTime(robot.CreationTime.String())
 		rows = append(rows, table.Row{
 			robot.Name,    // Project Name

--- a/pkg/views/robot/list/view.go
+++ b/pkg/views/robot/list/view.go
@@ -38,7 +38,7 @@ func ListRobots(robots []*models.Robot) {
 			enabledStatus = views.GreenStyle.Render("Enabled")
 		}
 
-		TotalPermissions := strconv.FormatInt(int64(len(robot.Permissions)), 10)
+		TotalPermissions := strconv.FormatInt(int64(len(robot.Permissions[0].Access)), 10)
 
 		if robot.ExpiresAt == -1 {
 			expires = "Never"

--- a/pkg/views/robot/list/view.go
+++ b/pkg/views/robot/list/view.go
@@ -1,0 +1,92 @@
+package list
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/goharbor/harbor-cli/pkg/views"
+	"github.com/goharbor/harbor-cli/pkg/views/base/tablelist"
+)
+
+var columns = []table.Column{
+	{Title: "Name", Width: 30},
+	{Title: "Status", Width: 18},
+	{Title: "Permissions", Width: 12},
+	{Title: "Creation Time", Width: 16},
+	{Title: "Expires in", Width: 14},
+	{Title: "Description", Width: 12},
+}
+
+func ListRobots(robots []*models.Robot) {
+	var rows []table.Row
+
+	for _, robot := range robots {
+		var enabledStatus string
+		var expires string
+
+		if robot.Disable {
+			enabledStatus = views.RedStyle.Render("Disabled")
+		} else {
+			enabledStatus = views.GreenStyle.Render("Enabled")
+		}
+
+		TotalPermissions := strconv.FormatInt(int64(len(robot.Permissions)), 10)
+
+		if robot.ExpiresAt == -1 {
+			expires = "Never"
+		} else {
+			expires = remainingTime(robot.ExpiresAt)
+		}
+
+		log.Println(expires)
+		createdTime, _ := utils.FormatCreatedTime(robot.CreationTime.String())
+		rows = append(rows, table.Row{
+			robot.Name,    // Project Name
+			enabledStatus, // Access Level
+			TotalPermissions,
+			createdTime, // Creation Time
+			expires,
+			robot.Description,
+		})
+	}
+
+	m := tablelist.NewModel(columns, rows, len(rows))
+
+	if _, err := tea.NewProgram(m).Run(); err != nil {
+		fmt.Println("Error running program:", err)
+		os.Exit(1)
+	}
+}
+
+func remainingTime(unixTimestamp int64) string {
+	// Get the current time
+	now := time.Now()
+	// Convert the Unix timestamp to time.Time
+	expirationTime := time.Unix(unixTimestamp, 0)
+	// Calculate the duration between now and the expiration time
+	duration := expirationTime.Sub(now)
+
+	// Calculate days, hours, minutes, and seconds
+	days := int(duration.Hours() / 24)
+	hours := int(duration.Hours()) % 24
+	minutes := int(duration.Minutes()) % 60
+
+	// Format the output string
+	return fmt.Sprintf("%dd %dh %dm", days, hours, minutes)
+}
+
+func getStatusStyle(status string) lipgloss.Style {
+	statusStyle := views.RedStyle
+	if status == "healthy" {
+		statusStyle = views.GreenStyle
+	}
+	return statusStyle
+}

--- a/pkg/views/robot/list/view.go
+++ b/pkg/views/robot/list/view.go
@@ -28,13 +28,12 @@ import (
 )
 
 var columns = []table.Column{
-	{Title: "ID", Width: 4},
-	{Title: "Name", Width: 30},
-	{Title: "Status", Width: 18},
-	{Title: "Permissions", Width: 12},
-	{Title: "Creation Time", Width: 16},
-	{Title: "Expires in", Width: 14},
-	{Title: "Description", Width: 12},
+	{Title: "Name", Width: tablelist.WidthL},
+	{Title: "Status", Width: tablelist.WidthL},
+	{Title: "Permissions", Width: tablelist.WidthM},
+	{Title: "Creation Time", Width: tablelist.WidthXL},
+	{Title: "Expires in", Width: tablelist.WidthM},
+	{Title: "Description", Width: tablelist.WidthXL},
 }
 
 func ListRobots(robots []*models.Robot) {
@@ -45,9 +44,9 @@ func ListRobots(robots []*models.Robot) {
 		var expires string
 
 		if robot.Disable {
-			enabledStatus = views.RedStyle.Render("Disabled")
+			enabledStatus = views.GreenANSI + "Disabled" + views.ResetANSI
 		} else {
-			enabledStatus = views.GreenStyle.Render("Enabled")
+			enabledStatus = views.GreenANSI + "Enabled" + views.ResetANSI
 		}
 
 		TotalPermissions := strconv.FormatInt(int64(len(robot.Permissions[0].Access)), 10)
@@ -60,13 +59,12 @@ func ListRobots(robots []*models.Robot) {
 
 		createdTime, _ := utils.FormatCreatedTime(robot.CreationTime.String())
 		rows = append(rows, table.Row{
-			strconv.FormatInt(robot.ID, 10),
 			robot.Name,
 			enabledStatus,
 			TotalPermissions,
 			createdTime,
 			expires,
-			robot.Description,
+			string(robot.Description),
 		})
 	}
 

--- a/pkg/views/robot/list/view.go
+++ b/pkg/views/robot/list/view.go
@@ -1,3 +1,16 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package list
 
 import (
@@ -8,7 +21,6 @@ import (
 
 	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views"
@@ -81,12 +93,4 @@ func remainingTime(unixTimestamp int64) string {
 
 	// Format the output string
 	return fmt.Sprintf("%dd %dh %dm", days, hours, minutes)
-}
-
-func getStatusStyle(status string) lipgloss.Style {
-	statusStyle := views.RedStyle
-	if status == "healthy" {
-		statusStyle = views.GreenStyle
-	}
-	return statusStyle
 }

--- a/pkg/views/robot/select/view.go
+++ b/pkg/views/robot/select/view.go
@@ -1,0 +1,30 @@
+package robot
+
+import (
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/views/base/multiselect"
+)
+
+func ListPermissions(perms *models.Permissions, ch chan<- []models.Permission) {
+	permissions := perms.Project
+	choices := []models.Permission{}
+
+	// Iterate over permissions and append each item to choices
+	for _, perm := range permissions {
+		choices = append(choices, *perm)
+	}
+
+	selects := &[]models.Permission{}
+
+	m := multiselect.NewModel(choices, selects)
+
+	_, err := tea.NewProgram(m).Run()
+	if err != nil {
+		fmt.Println("Error running program:", err)
+	}
+	// Get selected permissions
+	ch <- *selects
+}

--- a/pkg/views/robot/select/view.go
+++ b/pkg/views/robot/select/view.go
@@ -1,3 +1,16 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package robot
 
 import (

--- a/pkg/views/robot/select/view.go
+++ b/pkg/views/robot/select/view.go
@@ -2,10 +2,13 @@ package robot
 
 import (
 	"fmt"
+	"os"
 
+	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/views/base/multiselect"
+	"github.com/goharbor/harbor-cli/pkg/views/base/selection"
 )
 
 func ListPermissions(perms *models.Permissions, ch chan<- []models.Permission) {
@@ -21,10 +24,33 @@ func ListPermissions(perms *models.Permissions, ch chan<- []models.Permission) {
 
 	m := multiselect.NewModel(choices, selects)
 
-	_, err := tea.NewProgram(m).Run()
+	_, err := tea.NewProgram(m, tea.WithAltScreen()).Run()
 	if err != nil {
 		fmt.Println("Error running program:", err)
 	}
 	// Get selected permissions
 	ch <- *selects
+}
+
+func ListRobot(robots []*models.Robot, choice chan<- int64) {
+	itemsList := make([]list.Item, len(robots))
+
+	items := map[string]int64{}
+
+	for i, r := range robots {
+		items[r.Name] = r.ID
+		itemsList[i] = selection.Item(r.Name)
+	}
+
+	m := selection.NewModel(itemsList, "Robot")
+
+	p, err := tea.NewProgram(m, tea.WithAltScreen()).Run()
+	if err != nil {
+		fmt.Println("Error running program:", err)
+		os.Exit(1)
+	}
+
+	if p, ok := p.(selection.Model); ok {
+		choice <- items[p.Choice]
+	}
 }

--- a/pkg/views/robot/select/view.go
+++ b/pkg/views/robot/select/view.go
@@ -16,11 +16,14 @@ package robot
 import (
 	"fmt"
 	"os"
+	"sort"
+	"strings"
 
+	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/huh"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
-	"github.com/goharbor/harbor-cli/pkg/views/base/multiselect"
 	"github.com/goharbor/harbor-cli/pkg/views/base/selection"
 )
 
@@ -28,19 +31,91 @@ func ListPermissions(perms *models.Permissions, ch chan<- []models.Permission) {
 	permissions := perms.Project
 	choices := []models.Permission{}
 
-	// Iterate over permissions and append each item to choices
+	// collect all possible permissions
 	for _, perm := range permissions {
 		choices = append(choices, *perm)
 	}
-
 	selects := &[]models.Permission{}
 
-	m := multiselect.NewModel(choices, selects)
+	km := huh.NewDefaultKeyMap()
+	km.MultiSelect.SelectAll = key.NewBinding(
+		key.WithKeys("a"), key.WithHelp("a", "all"),
+	)
+	km.MultiSelect.SelectNone = key.NewBinding(
+		key.WithKeys("A"), key.WithHelp("A", "none"),
+	)
 
-	_, err := tea.NewProgram(m, tea.WithAltScreen()).Run()
-	if err != nil {
-		fmt.Println("Error running program:", err)
+	// groups will hold the multi-select groups for each resource
+	// selections will hold the selected actions for each resource
+	var (
+		groups     []*huh.Group
+		selections = make(map[string]*[]string)
+	)
+
+	// resActs groups the actions w.r.t. their resources
+	// e.g. {"repository": ["read", "write"], "project": ["read"]}
+	// this is needed for easier options creation in the multi-select
+	resActs := map[string][]string{}
+	for _, p := range permissions {
+		resActs[p.Resource] = append(resActs[p.Resource], p.Action)
 	}
+
+	resources := make([]string, 0, len(resActs))
+	for r := range resActs {
+		resources = append(resources, r)
+	}
+	sort.Strings(resources)
+
+	// loop over all resources and create a multi select for each
+	// within each resource a multi-select for the actions is created
+	// e.g. for "repository" resource, a multi-select with options "read", "write" is created
+	// the selected actions are stored in selections map
+	// e.g. selections["repository"] = &[]string{"read", "write"}
+	for _, res := range resources {
+		acts := resActs[res]
+		sort.Strings(acts)
+		opts := make([]huh.Option[string], len(acts))
+		for i, a := range acts {
+			opts[i] = huh.NewOption(a, a)
+		}
+		pick := []string{}
+		selections[res] = &pick
+		ms := huh.NewMultiSelect[string]().
+			Options(opts...).
+			Title(strings.ToUpper(res)).
+			Value(&pick).
+			WithKeyMap(km)
+		groups = append(groups, huh.NewGroup(ms))
+	}
+
+	// all huh groups are displaye in the form grid
+	form := huh.NewForm(groups...).
+		WithLayout(huh.LayoutGrid(4, 6)).
+		WithTheme(huh.ThemeDracula())
+	if err := form.Run(); err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+
+	// we have created a resource: [actions] like mapping earlier
+	// now we have to convert it back to []models.Permission
+	for res, acts := range selections {
+		for _, act := range *acts {
+			*selects = append(*selects, models.Permission{
+				Resource: res,
+				Action:   act,
+			})
+		}
+	}
+
+	//ToDo: This has to generalized for a multi-select view and moved out of this file
+
+	// m := multiselect.NewModel(choices, selects)
+
+	// _, err := tea.NewProgram(m, tea.WithAltScreen()).Run()
+	// if err != nil {
+	// 	fmt.Println("Error running program:", err)
+	// }
 	// Get selected permissions
 	ch <- *selects
 }

--- a/pkg/views/robot/update/view.go
+++ b/pkg/views/robot/update/view.go
@@ -1,0 +1,74 @@
+package update
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/charmbracelet/huh"
+	"github.com/go-openapi/strfmt"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	log "github.com/sirupsen/logrus"
+)
+
+type UpdateView struct {
+	CreationTime strfmt.DateTime    `json:"creation_time,omitempty"`
+	Description  string             `json:"description,omitempty"`
+	Disable      bool               `json:"disable,omitempty"`
+	Duration     int64              `json:"duration,omitempty"`
+	Editable     bool               `json:"editable"`
+	ExpiresAt    int64              `json:"expires_at,omitempty"`
+	ID           int64              `json:"id,omitempty"`
+	Level        string             `json:"level,omitempty"`
+	Name         string             `json:"name,omitempty"`
+	Permissions  []*RobotPermission `json:"permissions"`
+	Secret       string             `json:"secret,omitempty"`
+	UpdateTime   strfmt.DateTime    `json:"update_time,omitempty"`
+}
+
+type RobotPermission struct {
+	Access    []*models.Access `json:"access"`
+	Kind      string           `json:"kind,omitempty"`
+	Namespace string           `json:"namespace,omitempty"`
+}
+
+type Access struct {
+	Action   string `json:"action,omitempty"`
+	Effect   string `json:"effect,omitempty"`
+	Resource string `json:"resource,omitempty"`
+}
+
+func UpdateRobotView(updateView *UpdateView) {
+	var duration string
+	duration = strconv.FormatInt(updateView.Duration, 10)
+
+	theme := huh.ThemeCharm()
+	err := huh.NewForm(
+		huh.NewGroup(
+			huh.NewInput().
+				Title("Description").
+				Value(&updateView.Description),
+			huh.NewInput().
+				Title("Expiration").
+				Value(&duration).
+				Validate(func(str string) error {
+					if str == "" {
+						return errors.New("Expiration cannot be empty")
+					}
+					dur, err := strconv.ParseInt(str, 10, 64)
+					if err != nil {
+						return errors.New("invalid expiration time: Enter expiration time in days")
+					}
+					updateView.Duration = dur
+					return nil
+				}),
+			huh.NewConfirm().
+				Title("Disable").
+				Value(&updateView.Disable).
+				Affirmative("yes").
+				Negative("no"),
+		),
+	).WithTheme(theme).Run()
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/pkg/views/robot/update/view.go
+++ b/pkg/views/robot/update/view.go
@@ -1,3 +1,16 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package update
 
 import (

--- a/pkg/views/styles.go
+++ b/pkg/views/styles.go
@@ -24,9 +24,6 @@ var (
 	SelectedItemStyle = lipgloss.NewStyle().PaddingLeft(2).Foreground(lipgloss.Color("170"))
 	PaginationStyle   = list.DefaultStyles().PaginationStyle.PaddingLeft(4)
 	HelpStyle         = list.DefaultStyles().HelpStyle.PaddingLeft(4).PaddingBottom(1)
-	RedStyle          = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000"))
-	GreenStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("#04B575"))
-	WhiteStyle        = list.DefaultStyles()
 )
 
 var BaseStyle = lipgloss.NewStyle().

--- a/pkg/views/styles.go
+++ b/pkg/views/styles.go
@@ -26,6 +26,7 @@ var (
 	HelpStyle         = list.DefaultStyles().HelpStyle.PaddingLeft(4).PaddingBottom(1)
 	RedStyle          = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000"))
 	GreenStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("#04B575"))
+	WhiteStyle        = list.DefaultStyles()
 )
 
 var BaseStyle = lipgloss.NewStyle().


### PR DESCRIPTION
# Objective:

- Implement robot account management in CLI which helps to run automated operations.
- Add commands to manage both system and project robot accounts.
- Manage permissions for the robot account 
- Continue work of @bupd in PR #101 

# Tasks

Add CLI Commands for Robot Account Management on System Level:

- [ ] Create: Add a new robot account.
- [ ] Update: Modify an existing robot account.
- [ ] Delete: Remove a robot account.
- [ ] View: Display details of robot accounts.
- [ ] Refresh: Refresh the robot secret.
- [ ] Ensure no sensitive information is leaked during managing robot secrets.
- [ ] Conceptualize and implement a way for permission selection in the CLI

Finalizing work of @bupd on CLI Commands for Robot Account Management on Project Level.

# Rationale

Implementing secure and efficient robot account management in the CLI is crucial for enabling automated operations and replication, enhancing overall project security and functionality.


# Changes

I want to suggest a change in the way how permissions can be selected for the robot account creation. I used a `huh` Form to emulate a grid like experience we also have in the harbor UI. I would like to use it as a discussion basis:


https://github.com/user-attachments/assets/399c75b5-1dd5-4c6c-87c9-a33d6b576dca


