### PR TITLE
Enhanced Robot Account Configuration Format

### DIFF
--- a/cmd/harbor/root/project/robot/create.go
+++ b/cmd/harbor/root/project/robot/create.go
@@ -183,7 +183,7 @@ Examples:
 			if exists {
 				return fmt.Errorf("robot account with name '%s' already exists in project '%s'", opts.Name, opts.ProjectName)
 			}
-			response, err := api.CreateRobot(opts, "project")
+			response, err := api.CreateRobot(opts, opts.Level)
 			if err != nil {
 				return fmt.Errorf("failed to create robot: %v", utils.ParseHarborErrorMsg(err))
 			}

--- a/examples/config/robot-account/robot-config.json
+++ b/examples/config/robot-account/robot-config.json
@@ -2,7 +2,7 @@
   "name": "ci-pipeline-robot",
   "description": "Robot account for CI/CD pipeline",
   "duration": 90,
-  "kind": "project",
+  "level": "project",
   "permissions": [
     {
       "access": [

--- a/examples/config/robot-account/robot-config.yaml
+++ b/examples/config/robot-account/robot-config.yaml
@@ -1,7 +1,7 @@
 name: ci-pipeline-robot
 description: "Robot account for CI/CD pipeline"
 duration: 90
-kind: project
+level: project
 permissions:
   - access: 
     - resource: repository

--- a/pkg/config/robot.go
+++ b/pkg/config/robot.go
@@ -33,7 +33,7 @@ type RobotPermissionConfig struct {
 	Description string            `yaml:"description" json:"description"`
 	Duration    int64             `yaml:"duration" json:"duration"`
 	Project     string            `yaml:"project,omitempty" json:"project,omitempty"` // Legacy field for backward compatibility
-	Kind        string            `yaml:"kind,omitempty" json:"kind,omitempty"`       // "project" or "system"
+	Level       string            `yaml:"kind,omitempty" json:"kind,omitempty"`       // "project" or "system"
 	Permissions []PermissionScope `yaml:"permissions" json:"permissions"`
 }
 
@@ -86,8 +86,8 @@ func LoadRobotConfigFromYAMLorJSON(filename string, fileType string) (*create.Cr
 
 	// Determine the robot kind
 	robotKind := "project" // Default to project robot
-	if config.Kind != "" {
-		robotKind = config.Kind
+	if config.Level != "" {
+		robotKind = config.Level
 	}
 
 	// Create the base view object
@@ -95,7 +95,7 @@ func LoadRobotConfigFromYAMLorJSON(filename string, fileType string) (*create.Cr
 		Name:        config.Name,
 		Description: config.Description,
 		Duration:    config.Duration,
-		Kind:        robotKind,
+		Level:       robotKind,
 	}
 
 	// For backward compatibility, set ProjectName if present in config
@@ -296,7 +296,7 @@ func LoadRobotConfigFromFile(filename string) (*create.CreateView, error) {
 	}
 
 	// Kind-specific validation
-	if opts.Kind == "project" {
+	if opts.Level == "project" {
 		// Project robot requires a project
 		projectName := ""
 		if opts.ProjectName != "" {
@@ -340,13 +340,13 @@ func LoadRobotConfigFromFile(filename string) (*create.CreateView, error) {
 			return nil, fmt.Errorf("project robots must have a permission scope of kind 'project', found '%s'",
 				opts.Permissions[0].Kind)
 		}
-	} else if opts.Kind == "system" {
+	} else if opts.Level == "system" {
 		// System robot validation
 		if len(opts.Permissions) == 0 {
 			return nil, fmt.Errorf("system robot must have at least one permission scope")
 		}
 	} else {
-		return nil, fmt.Errorf("invalid robot kind: %s. Must be 'project' or 'system'", opts.Kind)
+		return nil, fmt.Errorf("invalid robot kind: %s. Must be 'project' or 'system'", opts.Level)
 	}
 
 	// Validate permissions

--- a/pkg/views/robot/create/view.go
+++ b/pkg/views/robot/create/view.go
@@ -28,7 +28,6 @@ type CreateView struct {
 	Duration    int64              `json:"duration,omitempty"`
 	Level       string             `json:"level,omitempty"`
 	Name        string             `json:"name,omitempty"`
-	Kind        string             `json:"kind,omitempty"`
 	Permissions []*RobotPermission `json:"permissions"`
 	Secret      string             `json:"secret,omitempty"`
 	ProjectName string


### PR DESCRIPTION
# Overview

This PR updates the robot account configuration file format to prepare for upcoming system robot account support. The enhanced format aligns with Harbor's API specification by adding kind and namespace fields, which enables better definition of cross-project permissions for system level robot accounts.

# Changes
- Add support for kind field in robot configurations (values: "project" or "system")
- Introduce namespace field to specify the scope of permissions
- Update robot configuration parsing to handle nested permission structures
- Add validation for permission scopes based on robot type
- Improve error messages for invalid configurations
- Update documentation with examples of the new format

# New Configuration Format

```yaml
name: "ci-pipeline-robot"
description: "Robot account for CI/CD pipeline"
duration: 90
level: "project"  # Robot type: "project" or "system"
permissions:
  - access:
    - resource: "repository"
      actions:
        - "pull"
        - "push"
    kind: "project"  # Permission scope kind
    namespace: "demo-project"  # Project name for this scope
```

# Implementation Notes

- This PR only updates the configuration format and parsing logic
- Actual implementation of system robot account creation will follow in a separate PR
- Maintains backwards compatibility with existing project robot configurations
- Validates that project robots have only one permission scope