### PR TITLE
Proposal : Introduce support for piped outputs

### DIFF
--- a/cmd/harbor/root/project/list.go
+++ b/cmd/harbor/root/project/list.go
@@ -79,10 +79,14 @@ func ListProjectCommand() *cobra.Command {
 				if err != nil {
 					return err
 				}
+			} else if utils.IsOutputPiped() {
+				log.Debug("Pipe detected")
+				list.ListProjectsTabSeparated(allProjects)
 			} else {
 				log.Debug("Listing projects using default view")
 				list.ListProjects(allProjects)
 			}
+
 			return nil
 		},
 	}

--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -14,8 +14,11 @@
 package utils
 
 import (
+	"os"
+
 	"errors"
 	"fmt"
+	"golang.org/x/term"
 	"net"
 	"net/url"
 	"regexp"
@@ -212,4 +215,8 @@ func EmptyStringValidator(variable string) func(string) error {
 		}
 		return nil
 	}
+}
+
+func IsOutputPiped() bool {
+	return !term.IsTerminal(int(os.Stdout.Fd()))
 }

--- a/pkg/views/project/list/view.go
+++ b/pkg/views/project/list/view.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"text/tabwriter"
 
 	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
@@ -64,6 +65,42 @@ func ListProjects(projects []*models.Project) {
 		fmt.Println("Error running program:", err)
 		os.Exit(1)
 	}
+}
+
+func ListProjectsTabSeparated(projects []*models.Project) {
+
+	//formatting parameters can be discussed
+	w := tabwriter.NewWriter(os.Stdout, 0, 3, 2, ' ', 0)
+
+	fmt.Fprintln(w, "ID\tName\tAccess\tType\tRepoCount\tCreated")
+
+	// Print each project
+	for _, project := range projects {
+		accessLevel := "public"
+		if project.Metadata.Public != "true" {
+			accessLevel = "private"
+		}
+
+		projectType := "project"
+		if project.RegistryID != 0 {
+			projectType = "proxy cache"
+		}
+
+		createdTime, _ := utils.FormatCreatedTime(project.CreationTime.String())
+
+		fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%d\t%s\n",
+			project.ProjectID,
+			project.Name,
+			accessLevel,
+			projectType,
+			project.RepoCount,
+			createdTime,
+		)
+	}
+
+	//enforce writing of output
+	w.Flush()
+
 }
 
 func SearchProjects(projects []*models.Project) {


### PR DESCRIPTION
# Related issue 

#479 

TLDR : If CLI output is piped, TUI formatting breaks ; making tabular output pipe friendly and UNIX compliant is required. Potentially replaces search commands

# Solution
- Currently only a prototype to address above issue. 
- Currently only for `project` command, can be extended easily (Waiting for approval)
- If pipe is detected, print tab separated output, which is the only way to do formatting with pipes
 
