### PR TITLE
feat(logs): add audit logs command with follow support

### DIFF
--- a/cmd/harbor/root/cmd.go
+++ b/cmd/harbor/root/cmd.go
@@ -185,5 +185,9 @@ harbor help
 	cmd.GroupID = "utils"
 	root.AddCommand(cmd)
 
+	cmd = Logs()
+	cmd.GroupID = "utils"
+	root.AddCommand(cmd)
+
 	return root
 }

--- a/cmd/harbor/root/logs.go
+++ b/cmd/harbor/root/logs.go
@@ -1,0 +1,46 @@
+package root
+
+import (
+	"log"
+
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	list "github.com/goharbor/harbor-cli/pkg/views/logs"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func Logs() *cobra.Command {
+	var opts api.ListFlags
+
+	cmd := &cobra.Command{
+		Use:   "logs",
+		Short: "Get recent logs of the projects which the user is a member of",
+		Run: func(cmd *cobra.Command, args []string) {
+			logs, err := api.AuditLogs(opts)
+			if err != nil {
+				log.Fatalf("failed to get projects list: %v", err)
+			}
+			FormatFlag := viper.GetString("output-format")
+			if FormatFlag != "" {
+				utils.PrintPayloadInJSONFormat(logs.Payload)
+				return
+			}
+			list.ListLogs(logs.Payload)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.Int64VarP(&opts.Page, "page", "", 1, "Page number")
+	flags.Int64VarP(&opts.PageSize, "page-size", "", 10, "Size of per page")
+	flags.StringVarP(&opts.Q, "query", "q", "", "Query string to query resources")
+	flags.StringVarP(
+		&opts.Sort,
+		"sort",
+		"",
+		"",
+		"Sort the resource list in ascending or descending order",
+	)
+
+	return cmd
+}

--- a/cmd/harbor/root/logs.go
+++ b/cmd/harbor/root/logs.go
@@ -48,7 +48,6 @@ harbor-cli logs --follow --refresh-interval 2s
 
 harbor-cli logs --output-format json`,
 		Run: func(cmd *cobra.Command, args []string) {
-			FormatFlag := viper.GetString("output-format")
 
 			if refreshInterval != "" && !follow {
 				fmt.Println("The --refresh-interval flag is only applicable when using --follow. It will be ignored.")
@@ -70,11 +69,17 @@ harbor-cli logs --output-format json`,
 					log.Fatalf("failed to retrieve audit logs: %v", err)
 				}
 
-				if FormatFlag != "" {
-					utils.PrintPayloadInJSONFormat(logs.Payload)
-					return
+				formatFlag := viper.GetString("output-format")
+				if formatFlag != "" {
+					log.WithField("output_format", formatFlag).Debug("Output format selected")
+					err = utils.PrintFormat(logs.Payload, formatFlag)
+					if err != nil {
+						return
+					}
+				} else {
+
+					list.ListLogs(logs.Payload)
 				}
-				list.ListLogs(logs.Payload)
 			}
 		},
 	}

--- a/cmd/harbor/root/logs.go
+++ b/cmd/harbor/root/logs.go
@@ -80,7 +80,7 @@ func followLogs(opts api.ListFlags, formatFlag string) {
 		}
 
 		// Filter new logs if we have a timestamp from the last fetch
-		var newLogs []*models.AuditLog
+		var newLogs []*models.AuditLogExt
 		if lastLogTime != nil {
 			for _, logEntry := range logs.Payload {
 				// Convert strfmt.DateTime to time.Time
@@ -116,7 +116,7 @@ func followLogs(opts api.ListFlags, formatFlag string) {
 	}
 }
 
-func printLogsAsStream(logs []*models.AuditLog) {
+func printLogsAsStream(logs []*models.AuditLogExt) {
 	for _, logEntry := range logs {
 		// Format the timestamp
 		logTime := time.Time(logEntry.OpTime)

--- a/cmd/harbor/root/logs.go
+++ b/cmd/harbor/root/logs.go
@@ -19,7 +19,7 @@ func Logs() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			logs, err := api.AuditLogs(opts)
 			if err != nil {
-				log.Fatalf("failed to get projects list: %v", err)
+				log.Fatalf("failed to retrieve audit logs: %v", err)
 			}
 			FormatFlag := viper.GetString("output-format")
 			if FormatFlag != "" {

--- a/cmd/harbor/root/logs.go
+++ b/cmd/harbor/root/logs.go
@@ -168,13 +168,6 @@ func getUsername(username string) string {
 	return username
 }
 
-func getProjectName(projectID int64) string {
-	if projectID == 0 {
-		return "unknown"
-	}
-	return fmt.Sprintf("project-%d", projectID)
-}
-
 func getResourceInfo(resourceType, resource string) string {
 	if resourceType == "" && resource == "" {
 		return "unknown"

--- a/cmd/harbor/root/logs.go
+++ b/cmd/harbor/root/logs.go
@@ -48,7 +48,6 @@ harbor-cli logs --follow --refresh-interval 2s
 
 harbor-cli logs --output-format json`,
 		Run: func(cmd *cobra.Command, args []string) {
-
 			if refreshInterval != "" && !follow {
 				fmt.Println("The --refresh-interval flag is only applicable when using --follow. It will be ignored.")
 			}
@@ -77,7 +76,6 @@ harbor-cli logs --output-format json`,
 						return
 					}
 				} else {
-
 					list.ListLogs(logs.Payload)
 				}
 			}

--- a/cmd/harbor/root/logs.go
+++ b/cmd/harbor/root/logs.go
@@ -1,32 +1,44 @@
 package root
 
 import (
-	"log"
+	"fmt"
+	"time"
 
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	list "github.com/goharbor/harbor-cli/pkg/views/logs"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
 func Logs() *cobra.Command {
 	var opts api.ListFlags
+	var follow bool
 
 	cmd := &cobra.Command{
 		Use:   "logs",
 		Short: "Get recent logs of the projects which the user is a member of",
 		Run: func(cmd *cobra.Command, args []string) {
-			logs, err := api.AuditLogs(opts)
-			if err != nil {
-				log.Fatalf("failed to retrieve audit logs: %v", err)
-			}
 			FormatFlag := viper.GetString("output-format")
-			if FormatFlag != "" {
-				utils.PrintPayloadInJSONFormat(logs.Payload)
-				return
+
+			if follow {
+				// Follow mode - continuous tailing
+				followLogs(opts, FormatFlag)
+			} else {
+				// Single fetch mode
+				logs, err := api.AuditLogs(opts)
+				if err != nil {
+					log.Fatalf("failed to retrieve audit logs: %v", err)
+				}
+
+				if FormatFlag != "" {
+					utils.PrintPayloadInJSONFormat(logs.Payload)
+					return
+				}
+				list.ListLogs(logs.Payload)
 			}
-			list.ListLogs(logs.Payload)
 		},
 	}
 
@@ -41,6 +53,137 @@ func Logs() *cobra.Command {
 		"",
 		"Sort the resource list in ascending or descending order",
 	)
+	flags.BoolVarP(&follow, "follow", "f", false, "Follow log output (tail -f behavior)")
 
 	return cmd
+}
+
+func followLogs(opts api.ListFlags, formatFlag string) {
+	var lastLogTime *time.Time
+
+	// Set up logrus for clean output
+	log.SetFormatter(&log.TextFormatter{
+		FullTimestamp:   true,
+		TimestampFormat: "2006-01-02 15:04:05",
+		DisableColors:   false,
+	})
+
+	fmt.Println("Following Harbor audit logs... (Press Ctrl+C to stop)")
+	fmt.Println()
+
+	for {
+		logs, err := api.AuditLogs(opts)
+		if err != nil {
+			log.Errorf("failed to retrieve audit logs: %v", err)
+			time.Sleep(2 * time.Second)
+			continue
+		}
+
+		// Filter new logs if we have a timestamp from the last fetch
+		var newLogs []*models.AuditLog
+		if lastLogTime != nil {
+			for _, logEntry := range logs.Payload {
+				// Convert strfmt.DateTime to time.Time
+				logTime := time.Time(logEntry.OpTime)
+				if !logTime.IsZero() && logTime.After(*lastLogTime) {
+					newLogs = append(newLogs, logEntry)
+				}
+			}
+		} else {
+			// First run, show all logs
+			newLogs = logs.Payload
+		}
+
+		// Update last log time with the most recent log
+		if len(logs.Payload) > 0 {
+			logTime := time.Time(logs.Payload[0].OpTime)
+			if !logTime.IsZero() {
+				lastLogTime = &logTime
+			}
+		}
+
+		// Display new logs in streaming fashion
+		if len(newLogs) > 0 {
+			if formatFlag != "" {
+				utils.PrintPayloadInJSONFormat(newLogs)
+			} else {
+				printLogsAsStream(newLogs)
+			}
+		}
+
+		// Wait before next poll
+		time.Sleep(2 * time.Second)
+	}
+}
+
+func printLogsAsStream(logs []*models.AuditLog) {
+	for _, logEntry := range logs {
+		// Format the timestamp
+		logTime := time.Time(logEntry.OpTime)
+		timeStr := logTime.Format("2006-01-02 15:04:05")
+
+		// Determine log level based on operation
+		level := getLogLevel(logEntry.Operation)
+
+		// Create a structured log entry
+		// var logEntry *models.AuditLog
+		entry := log.WithFields(log.Fields{
+			"time":      timeStr,
+			"user":      getUsername(logEntry.Username),
+			"resource":  getResourceInfo(logEntry.ResourceType, logEntry.Resource),
+			"operation": logEntry.Operation,
+		})
+
+		// Print with appropriate log level
+		switch level {
+		case "error":
+			entry.Error(fmt.Sprintf("%s performed %s", getUsername(logEntry.Username), logEntry.Operation))
+		case "warn":
+			entry.Warn(fmt.Sprintf("%s performed %s", getUsername(logEntry.Username), logEntry.Operation))
+		case "info":
+			entry.Info(fmt.Sprintf("%s performed %s", getUsername(logEntry.Username), logEntry.Operation))
+		default:
+			entry.Debug(fmt.Sprintf("%s performed %s", getUsername(logEntry.Username), logEntry.Operation))
+		}
+	}
+}
+
+func getLogLevel(operation string) string {
+	switch operation {
+	case "delete", "stop", "remove":
+		return "error"
+	case "create", "push", "pull":
+		return "info"
+	case "update", "modify":
+		return "warn"
+	default:
+		return "info"
+	}
+}
+
+func getUsername(username string) string {
+	if username == "" {
+		return "unknown"
+	}
+	return username
+}
+
+func getProjectName(projectID int64) string {
+	if projectID == 0 {
+		return "unknown"
+	}
+	return fmt.Sprintf("project-%d", projectID)
+}
+
+func getResourceInfo(resourceType, resource string) string {
+	if resourceType == "" && resource == "" {
+		return "unknown"
+	}
+	if resourceType != "" && resource != "" {
+		return fmt.Sprintf("%s:%s", resourceType, resource)
+	}
+	if resourceType != "" {
+		return resourceType
+	}
+	return resource
 }

--- a/cmd/harbor/root/project/robot/update.go
+++ b/cmd/harbor/root/project/robot/update.go
@@ -104,11 +104,16 @@ Examples:
 
 			bot := robot.Payload
 
+			var duration int64
+			if bot.Duration != nil {
+				duration = *bot.Duration
+			}
+
 			opts = update.UpdateView{
 				CreationTime: bot.CreationTime,
 				Description:  bot.Description,
 				Disable:      bot.Disable,
-				Duration:     bot.Duration,
+				Duration:     duration,
 				Editable:     bot.Editable,
 				ID:           bot.ID,
 				Level:        bot.Level,

--- a/doc/cli-docs/harbor-logs.md
+++ b/doc/cli-docs/harbor-logs.md
@@ -1,0 +1,49 @@
+---
+title: harbor logs
+weight: 30
+---
+## harbor logs
+
+### Description
+
+##### Get recent logs of the projects which the user is a member of
+
+### Synopsis
+
+Get recent logs of the projects which the user is a member of.
+This command retrieves the audit logs for the projects the user is a member of. It supports pagination, sorting, and filtering through query parameters. The logs can be followed in real-time with the --follow flag, and the output can be formatted as JSON with the --output-format flag.
+
+harbor-cli logs --page 1 --page-size 10 --query "operation=push" --sort "op_time:desc"
+
+harbor-cli logs --follow --refresh-interval 2s
+
+harbor-cli logs --output-format json
+
+```sh
+harbor logs [flags]
+```
+
+### Options
+
+```sh
+  -f, --follow                    Follow log output (tail -f behavior)
+  -h, --help                      help for logs
+      --page int                  Page number (default 1)
+      --page-size int             Size of per page (default 10)
+  -q, --query string              Query string to query resources
+  -n, --refresh-interval string   Interval to refresh logs when following (default: 1s)
+      --sort string               Sort the resource list in ascending or descending order
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor](harbor.md)	 - Official Harbor CLI
+

--- a/doc/cli-docs/harbor.md
+++ b/doc/cli-docs/harbor.md
@@ -43,6 +43,7 @@ harbor help
 * [harbor instance](harbor-instance.md)	 - Manage preheat provider instances in Harbor
 * [harbor label](harbor-label.md)	 - Manage labels in Harbor
 * [harbor login](harbor-login.md)	 - Log in to Harbor registry
+* [harbor logs](harbor-logs.md)	 - Get recent logs of the projects which the user is a member of
 * [harbor project](harbor-project.md)	 - Manage projects and assign resources to them
 * [harbor quota](harbor-quota.md)	 - Manage quotas
 * [harbor registry](harbor-registry.md)	 - Manage registries

--- a/doc/man-docs/man1/harbor-logs.1
+++ b/doc/man-docs/man1/harbor-logs.1
@@ -1,0 +1,69 @@
+.nh
+.TH "HARBOR" "1"  "Harbor Community" "Harbor User Manuals"
+
+.SH NAME
+harbor-logs - Get recent logs of the projects which the user is a member of
+
+
+.SH SYNOPSIS
+\fBharbor logs [flags]\fP
+
+
+.SH DESCRIPTION
+Get recent logs of the projects which the user is a member of.
+This command retrieves the audit logs for the projects the user is a member of. It supports pagination, sorting, and filtering through query parameters. The logs can be followed in real-time with the --follow flag, and the output can be formatted as JSON with the --output-format flag.
+
+.PP
+harbor-cli logs --page 1 --page-size 10 --query "operation=push" --sort "op_time:desc"
+
+.PP
+harbor-cli logs --follow --refresh-interval 2s
+
+.PP
+harbor-cli logs --output-format json
+
+
+.SH OPTIONS
+\fB-f\fP, \fB--follow\fP[=false]
+	Follow log output (tail -f behavior)
+
+.PP
+\fB-h\fP, \fB--help\fP[=false]
+	help for logs
+
+.PP
+\fB--page\fP=1
+	Page number
+
+.PP
+\fB--page-size\fP=10
+	Size of per page
+
+.PP
+\fB-q\fP, \fB--query\fP=""
+	Query string to query resources
+
+.PP
+\fB-n\fP, \fB--refresh-interval\fP=""
+	Interval to refresh logs when following (default: 1s)
+
+.PP
+\fB--sort\fP=""
+	Sort the resource list in ascending or descending order
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+\fB-c\fP, \fB--config\fP=""
+	config file (default is $HOME/.config/harbor-cli/config.yaml)
+
+.PP
+\fB-o\fP, \fB--output-format\fP=""
+	Output format. One of: json|yaml
+
+.PP
+\fB-v\fP, \fB--verbose\fP[=false]
+	verbose output
+
+
+.SH SEE ALSO
+\fBharbor(1)\fP

--- a/doc/man-docs/man1/harbor.1
+++ b/doc/man-docs/man1/harbor.1
@@ -43,4 +43,4 @@ harbor help
 
 
 .SH SEE ALSO
-\fBharbor-artifact(1)\fP, \fBharbor-context(1)\fP, \fBharbor-cve-allowlist(1)\fP, \fBharbor-health(1)\fP, \fBharbor-info(1)\fP, \fBharbor-instance(1)\fP, \fBharbor-label(1)\fP, \fBharbor-login(1)\fP, \fBharbor-project(1)\fP, \fBharbor-quota(1)\fP, \fBharbor-registry(1)\fP, \fBharbor-replication(1)\fP, \fBharbor-repo(1)\fP, \fBharbor-scan-all(1)\fP, \fBharbor-scanner(1)\fP, \fBharbor-schedule(1)\fP, \fBharbor-tag(1)\fP, \fBharbor-user(1)\fP, \fBharbor-version(1)\fP, \fBharbor-webhook(1)\fP
+\fBharbor-artifact(1)\fP, \fBharbor-context(1)\fP, \fBharbor-cve-allowlist(1)\fP, \fBharbor-health(1)\fP, \fBharbor-info(1)\fP, \fBharbor-instance(1)\fP, \fBharbor-label(1)\fP, \fBharbor-login(1)\fP, \fBharbor-logs(1)\fP, \fBharbor-project(1)\fP, \fBharbor-quota(1)\fP, \fBharbor-registry(1)\fP, \fBharbor-replication(1)\fP, \fBharbor-repo(1)\fP, \fBharbor-scan-all(1)\fP, \fBharbor-scanner(1)\fP, \fBharbor-schedule(1)\fP, \fBharbor-tag(1)\fP, \fBharbor-user(1)\fP, \fBharbor-version(1)\fP, \fBharbor-webhook(1)\fP

--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/go-openapi/strfmt v0.23.0
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-openapi/validate v0.24.0 // indirect
-	github.com/goharbor/go-client v0.210.0
+	github.com/goharbor/go-client v0.213.1
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
@@ -89,7 +89,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.35.0 // indirect
 	go.opentelemetry.io/otel/trace v1.35.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
-	golang.org/x/text v0.23.0 // indirect
+	golang.org/x/text v0.23.0
 )
 
 replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.0.0-20240518090000-14441aefdf88

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,8 @@ github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIx
 github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
-github.com/goharbor/go-client v0.210.0 h1:QwgLcWNSC3MFhBe7lq3BxDPtKQiD3k6hf6Lt26NChOI=
-github.com/goharbor/go-client v0.210.0/go.mod h1:XMWHucuHU9VTRx6U6wYwbRuyCVhE6ffJGRjaeo0nvwo=
+github.com/goharbor/go-client v0.213.1 h1:bohLwNog8uv8FKhIZ0SHiaDbYr3X/1hovgo5fqZWMdo=
+github.com/goharbor/go-client v0.213.1/go.mod h1:XMWHucuHU9VTRx6U6wYwbRuyCVhE6ffJGRjaeo0nvwo=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=

--- a/pkg/api/auditLogs_handler.go
+++ b/pkg/api/auditLogs_handler.go
@@ -1,0 +1,25 @@
+package api
+
+import (
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/auditlog"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+)
+
+func AuditLogs(opts ListFlags) (*auditlog.ListAuditLogsOK, error) {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := client.Auditlog.ListAuditLogs(ctx, &auditlog.ListAuditLogsParams{
+		Q:        &opts.Q,
+		Sort:     &opts.Sort,
+		Page:     &opts.Page,
+		PageSize: &opts.PageSize,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/auditLogs_handler.go
+++ b/pkg/api/auditLogs_handler.go
@@ -1,3 +1,16 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package api
 
 import (

--- a/pkg/api/auditLogs_handler.go
+++ b/pkg/api/auditLogs_handler.go
@@ -5,18 +5,54 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/utils"
 )
 
-func AuditLogs(opts ListFlags) (*auditlog.ListAuditLogsOK, error) {
+func AuditLogs(opts ListFlags) (*auditlog.ListAuditLogExtsOK, error) {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {
 		return nil, err
 	}
 
-	response, err := client.Auditlog.ListAuditLogs(ctx, &auditlog.ListAuditLogsParams{
-		Q:        &opts.Q,
-		Sort:     &opts.Sort,
-		Page:     &opts.Page,
-		PageSize: &opts.PageSize,
-	})
+	response, err := client.Auditlog.ListAuditLogExts(ctx,
+		&auditlog.ListAuditLogExtsParams{
+			Q:        &opts.Q,
+			Sort:     &opts.Sort,
+			Page:     &opts.Page,
+			PageSize: &opts.PageSize,
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func AuditLogsLegacy(opts ListFlags) (*auditlog.ListAuditLogsOK, error) {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := client.Auditlog.ListAuditLogs(ctx,
+		&auditlog.ListAuditLogsParams{
+			Q:        &opts.Q,
+			Sort:     &opts.Sort,
+			Page:     &opts.Page,
+			PageSize: &opts.PageSize,
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func AuditLogEventTypes() (*auditlog.ListAuditLogEventTypesOK, error) {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := client.Auditlog.ListAuditLogEventTypes(ctx,
+		&auditlog.ListAuditLogEventTypesParams{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/robot_handler.go
+++ b/pkg/api/robot_handler.go
@@ -174,7 +174,7 @@ func UpdateRobot(opts *update.UpdateView) error {
 		&robot.UpdateRobotParams{
 			Robot: &models.Robot{
 				Description: opts.Description,
-				Duration:    opts.Duration,
+				Duration:    &opts.Duration,
 				Editable:    opts.Editable,
 				Disable:     opts.Disable,
 				ID:          opts.ID,

--- a/pkg/views/logs/view.go
+++ b/pkg/views/logs/view.go
@@ -1,0 +1,41 @@
+package list
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/goharbor/harbor-cli/pkg/views/base/tablelist"
+)
+
+var columns = []table.Column{
+	{Title: "User", Width: 18},
+	{Title: "Resource", Width: 18},
+	{Title: "Resource Type", Width: 14},
+	{Title: "Operation", Width: 10},
+	{Title: "Time", Width: 16},
+}
+
+func ListLogs(logs []*models.AuditLog) {
+	var rows []table.Row
+	for _, log := range logs {
+		operationTime, _ := utils.FormatCreatedTime(log.OpTime.String())
+		rows = append(rows, table.Row{
+			log.Username,
+			log.Resource,
+			log.ResourceType,
+			log.Operation,
+			operationTime,
+		})
+	}
+
+	m := tablelist.NewModel(columns, rows, len(rows))
+
+	if _, err := tea.NewProgram(m).Run(); err != nil {
+		fmt.Println("Error running program:", err)
+		os.Exit(1)
+	}
+}

--- a/pkg/views/logs/view.go
+++ b/pkg/views/logs/view.go
@@ -1,3 +1,16 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package list
 
 import (

--- a/pkg/views/logs/view.go
+++ b/pkg/views/logs/view.go
@@ -19,7 +19,7 @@ var columns = []table.Column{
 	{Title: "Time", Width: 16},
 }
 
-func ListLogs(logs []*models.AuditLog) {
+func ListLogs(logs []*models.AuditLogExt) {
 	var rows []table.Row
 	for _, log := range logs {
 		operationTime, _ := utils.FormatCreatedTime(log.OpTime.String())

--- a/pkg/views/robot/update/view.go
+++ b/pkg/views/robot/update/view.go
@@ -51,8 +51,7 @@ type Access struct {
 }
 
 func UpdateRobotView(updateView *UpdateView) {
-	var duration string
-	duration = strconv.FormatInt(updateView.Duration, 10)
+	duration := strconv.FormatInt(updateView.Duration, 10)
 
 	theme := huh.ThemeCharm()
 	err := huh.NewForm(


### PR DESCRIPTION
This PR adds a new `harbor-cli logs` command that allows users to view and follow Harbor audit logs in real-time.

## Features

- **View audit logs**: Display recent audit logs for projects the user is a member of
- **Follow mode**: Real-time log tailing with `-f/--follow` flag (similar to `tail -f`)
- **Configurable refresh interval**: Set custom polling intervals with `--refresh-interval`
- **Pagination support**: Standard pagination with `--page` and `--page-size` flags
- **Query filtering**: Filter logs using `--query` parameter
- **Sorting**: Sort logs with `--sort` parameter
- **JSON output**: Support for JSON format output with `--output-format json`

## Usage Examples

```bash
# View recent logs
harbor-cli logs

# Follow logs in real-time
harbor-cli logs -f

# Follow with custom refresh interval
harbor-cli logs -f --refresh-interval 2s

# Query specific operations
harbor-cli logs --query "operation=push"

# JSON output
harbor-cli logs --output-format json
```

## Implementation Details

- Uses the non-deprecated `/auditlog-exts` API endpoint (instead of `/audit-logs`)
- Implements timestamp-based filtering to show only new logs in follow mode
- Truncates long robot account names for better readability
- Uses separate logger instance to ensure output works without `-v` flag
- Handles `strfmt.DateTime` type conversion properly
- Shows operation results with ✓/✗ indicators

## Related Work

Continues work from PR #106 by @bupd adding the logs subcommand functionality.
This PR has to wait for PR #509 to be merged.

## Screenshots & Recordings

https://github.com/user-attachments/assets/af40adb5-8197-4d64-a0d8-a875764b6c6e

![Screenshot 2025-07-07 at 21 00 04](https://github.com/user-attachments/assets/444b304a-6e7b-42a6-b563-1489f621e9ef)
