### PR TITLE
Replication executions

### DIFF
--- a/cmd/harbor/root/replication/cmd.go
+++ b/cmd/harbor/root/replication/cmd.go
@@ -30,6 +30,7 @@ func Replication() *cobra.Command {
 		ReplicationExecutionsCommand(),
 		StartCommand(),
 		StopCommand(),
+		LogsCommand(),
 	)
 
 	return replicationCmd

--- a/cmd/harbor/root/replication/executions.go
+++ b/cmd/harbor/root/replication/executions.go
@@ -14,22 +14,21 @@
 package replication
 
 import (
+	executions "github.com/goharbor/harbor-cli/cmd/harbor/root/replication/executions"
 	"github.com/spf13/cobra"
 )
 
-func Replication() *cobra.Command {
+func ReplicationExecutionsCommand() *cobra.Command {
 	// replicationCmd represents the replication command.
 	var replicationCmd = &cobra.Command{
-		Use:     "replication",
-		Aliases: []string{"repl"},
-		Short:   "Manage replications",
-		Long:    `Manage replications in Harbor context`,
+		Use:     "executions",
+		Aliases: []string{"exec"},
+		Short:   "Manage replication executions",
+		Long:    `Manage replication executions in Harbor context`,
 	}
 	replicationCmd.AddCommand(
-		ReplicationPoliciesCommand(),
-		ReplicationExecutionsCommand(),
-		StartCommand(),
-		StopCommand(),
+		executions.ListCommand(),
+		executions.ViewCommand(),
 	)
 
 	return replicationCmd

--- a/cmd/harbor/root/replication/executions/list.go
+++ b/cmd/harbor/root/replication/executions/list.go
@@ -31,7 +31,10 @@ func ListCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List replication executions",
-		Args:  cobra.MaximumNArgs(1),
+		Long:  `List all replication executions for a given replication policy. If no policy ID is provided, it will prompt the user to select one interactively.`,
+		Example: `  harbor replication executions list 12345
+  harbor replication executions list`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Debug("Starting replication executions list command")
 

--- a/cmd/harbor/root/replication/executions/list.go
+++ b/cmd/harbor/root/replication/executions/list.go
@@ -11,14 +11,16 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package policies
+package executions
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	"github.com/goharbor/harbor-cli/pkg/views/replication/policies/list"
+	"github.com/goharbor/harbor-cli/pkg/views/replication/execution/list"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -28,37 +30,49 @@ func ListCommand() *cobra.Command {
 	var opts api.ListFlags
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List replication policies",
-		Args:  cobra.ExactArgs(0),
+		Short: "List replication executions",
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			log.Debug("Starting replications list command")
+			log.Debug("Starting replication executions list command")
+
+			var rpolicyID int64
+			if len(args) > 0 {
+				var err error
+				// convert string to int64
+				rpolicyID, err = strconv.ParseInt(args[0], 10, 64)
+				if err != nil {
+					return fmt.Errorf("invalid replication policy ID: %s, %v", args[0], err)
+				}
+			} else {
+				rpolicyID = prompt.GetReplicationPolicyFromUser()
+			}
 
 			if opts.PageSize > 100 {
 				return fmt.Errorf("page size should be less than or equal to 100")
 			}
 
-			log.Debug("Fetching policies...")
-			allPolicies, err := api.ListReplicationPolicies(opts)
+			log.Debug("Fetching executions...")
+			executions, err := api.ListReplicationExecutions(rpolicyID, opts)
 			if err != nil {
 				return fmt.Errorf("failed to get projects list: %v", utils.ParseHarborErrorMsg(err))
 			}
 
-			log.WithField("count", len(allPolicies.Payload)).Debug("Number of policies fetched")
-			if len(allPolicies.Payload) == 0 {
-				log.Info("No policies found")
+			log.WithField("count", len(executions.Payload)).Debug("Number of executions fetched")
+			if len(executions.Payload) == 0 {
+				log.Info("No executions found")
 				return nil
 			}
 
 			formatFlag := viper.GetString("output-format")
 			if formatFlag != "" {
 				log.WithField("output_format", formatFlag).Debug("Output format selected")
-				err = utils.PrintFormat(allPolicies.Payload, formatFlag)
+				err = utils.PrintFormat(executions.Payload, formatFlag)
 				if err != nil {
 					return err
 				}
 			} else {
 				log.Debug("Listing projects using default view")
-				list.ListPolicies(allPolicies.Payload)
+				list.ListExecutions(executions.Payload)
 			}
 			return nil
 		},

--- a/cmd/harbor/root/replication/executions/view.go
+++ b/cmd/harbor/root/replication/executions/view.go
@@ -1,0 +1,67 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package executions
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/prompt"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/goharbor/harbor-cli/pkg/views/replication/execution/view"
+)
+
+func ViewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "view [ID]",
+		Short: "get replication execution by id",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var execID int64
+			if len(args) > 0 {
+				var err error
+				// convert string to int64
+				execID, err = strconv.ParseInt(args[0], 10, 64)
+				if err != nil {
+					return fmt.Errorf("invalid replication execution ID: %s, %v", args[0], err)
+				}
+			} else {
+				rpolicyID := prompt.GetReplicationPolicyFromUser()
+				execID = prompt.GetReplicationExecutionIDFromUser(rpolicyID)
+			}
+
+			execution, err := api.GetReplicationExecution(execID)
+			if err != nil {
+				return fmt.Errorf("failed to get replication execution: %v", utils.ParseHarborErrorMsg(err))
+			}
+
+			FormatFlag := viper.GetString("output-format")
+			if FormatFlag != "" {
+				err = utils.PrintFormat(execution.Payload, FormatFlag)
+				if err != nil {
+					return err
+				}
+			} else {
+				view.ViewExecution(execution.Payload)
+			}
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cmd/harbor/root/replication/logs.go
+++ b/cmd/harbor/root/replication/logs.go
@@ -1,0 +1,75 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package replication
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/prompt"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+)
+
+func LogsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "log [EXECUTION_ID] [TASK_ID]",
+		Short: "get replication execution logs by execution and task id",
+		Long:  `Get the logs of a specific replication execution and task by their IDs. If no IDs are provided, it will prompt the user to select them interactively.`,
+		Example: `  harbor replication log 12345 67890
+  harbor replication log`,
+		Args: cobra.MaximumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var taskID int64
+			var execID int64
+			if len(args) == 2 {
+				var err error
+				execID, err = strconv.ParseInt(args[0], 10, 64)
+				if err != nil {
+					return fmt.Errorf("invalid replication execution ID: %s, %v", args[0], err)
+				}
+				taskID, err = strconv.ParseInt(args[1], 10, 64)
+				if err != nil {
+					return fmt.Errorf("invalid replication task ID: %s, %v", args[1], err)
+				}
+			} else {
+				rpolicyID := prompt.GetReplicationPolicyFromUser()
+				execID = prompt.GetReplicationExecutionIDFromUser(rpolicyID)
+				taskID = prompt.GetReplicationTaskIDFromUser(execID)
+			}
+
+			logs, err := api.GetReplicationLog(execID, taskID)
+			if err != nil {
+				return fmt.Errorf("failed to get replication task logs: %v", utils.ParseHarborErrorMsg(err))
+			}
+
+			FormatFlag := viper.GetString("output-format")
+			if FormatFlag != "" {
+				err = utils.PrintFormat(logs.Payload, FormatFlag)
+				if err != nil {
+					return err
+				}
+			} else {
+				if logs.Payload != "" {
+					fmt.Println(logs.Payload)
+				}
+			}
+			return nil
+		},
+	}
+	return cmd
+}

--- a/doc/cli-docs/harbor-replication-executions-list.md
+++ b/doc/cli-docs/harbor-replication-executions-list.md
@@ -1,0 +1,47 @@
+---
+title: harbor replication executions list
+weight: 10
+---
+## harbor replication executions list
+
+### Description
+
+##### List replication executions
+
+### Synopsis
+
+List all replication executions for a given replication policy. If no policy ID is provided, it will prompt the user to select one interactively.
+
+```sh
+harbor replication executions list [flags]
+```
+
+### Examples
+
+```sh
+  harbor replication executions list 12345
+  harbor replication executions list
+```
+
+### Options
+
+```sh
+  -h, --help            help for list
+      --page int        Page number (default 1)
+      --page-size int   Size of per page (0 to fetch all)
+  -q, --query string    Query string to query resources
+      --sort string     Sort the resource list in ascending or descending order
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor replication executions](harbor-replication-executions.md)	 - Manage replication executions
+

--- a/doc/cli-docs/harbor-replication-executions-view.md
+++ b/doc/cli-docs/harbor-replication-executions-view.md
@@ -1,0 +1,44 @@
+---
+title: harbor replication executions view
+weight: 65
+---
+## harbor replication executions view
+
+### Description
+
+##### get replication execution by id
+
+### Synopsis
+
+Get a specific replication execution by its ID. If no ID is provided, it will prompt the user to select one interactively. If the --no-tasks flag is set, it will not list associated tasks.
+
+```sh
+harbor replication executions view [ID] [flags]
+```
+
+### Examples
+
+```sh
+  harbor replication executions view 12345
+  harbor replication executions view --no-tasks
+```
+
+### Options
+
+```sh
+  -h, --help       help for view
+      --no-tasks   Do not list associated tasks
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor replication executions](harbor-replication-executions.md)	 - Manage replication executions
+

--- a/doc/cli-docs/harbor-replication-executions.md
+++ b/doc/cli-docs/harbor-replication-executions.md
@@ -1,0 +1,34 @@
+---
+title: harbor replication executions
+weight: 70
+---
+## harbor replication executions
+
+### Description
+
+##### Manage replication executions
+
+### Synopsis
+
+Manage replication executions in Harbor context
+
+### Options
+
+```sh
+  -h, --help   help for executions
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor replication](harbor-replication.md)	 - Manage replications
+* [harbor replication executions list](harbor-replication-executions-list.md)	 - List replication executions
+* [harbor replication executions view](harbor-replication-executions-view.md)	 - get replication execution by id
+

--- a/doc/cli-docs/harbor-replication-log.md
+++ b/doc/cli-docs/harbor-replication-log.md
@@ -1,0 +1,43 @@
+---
+title: harbor replication log
+weight: 10
+---
+## harbor replication log
+
+### Description
+
+##### get replication execution logs by execution and task id
+
+### Synopsis
+
+Get the logs of a specific replication execution and task by their IDs. If no IDs are provided, it will prompt the user to select them interactively.
+
+```sh
+harbor replication log [EXECUTION_ID] [TASK_ID] [flags]
+```
+
+### Examples
+
+```sh
+  harbor replication log 12345 67890
+  harbor replication log
+```
+
+### Options
+
+```sh
+  -h, --help   help for log
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor replication](harbor-replication.md)	 - Manage replications
+

--- a/doc/cli-docs/harbor-replication-log.md
+++ b/doc/cli-docs/harbor-replication-log.md
@@ -19,14 +19,18 @@ harbor replication log [EXECUTION_ID] [TASK_ID] [flags]
 ### Examples
 
 ```sh
-  harbor replication log 12345 67890
+  harbor replication log -e 12345 -t 67890
+		  harbor replication log --execution-id 12345 --task-id 67890
+		  harbor replication log --execution-id 12345
   harbor replication log
 ```
 
 ### Options
 
 ```sh
-  -h, --help   help for log
+  -e, --execution-id int   Replication execution ID
+  -h, --help               help for log
+  -t, --task-id int        Replication task ID
 ```
 
 ### Options inherited from parent commands

--- a/doc/cli-docs/harbor-replication.md
+++ b/doc/cli-docs/harbor-replication.md
@@ -29,6 +29,8 @@ Manage replications in Harbor context
 ### SEE ALSO
 
 * [harbor](harbor.md)	 - Official Harbor CLI
+* [harbor replication executions](harbor-replication-executions.md)	 - Manage replication executions
+* [harbor replication log](harbor-replication-log.md)	 - get replication execution logs by execution and task id
 * [harbor replication policies](harbor-replication-policies.md)	 - Manage replication policies
 * [harbor replication start](harbor-replication-start.md)	 - start replication
 * [harbor replication stop](harbor-replication-stop.md)	 - stop replication

--- a/doc/man-docs/man1/harbor-replication-executions-list.1
+++ b/doc/man-docs/man1/harbor-replication-executions-list.1
@@ -1,0 +1,58 @@
+.nh
+.TH "HARBOR" "1"  "Harbor Community" "Harbor User Manuals"
+
+.SH NAME
+harbor-replication-executions-list - List replication executions
+
+
+.SH SYNOPSIS
+\fBharbor replication executions list [flags]\fP
+
+
+.SH DESCRIPTION
+List all replication executions for a given replication policy. If no policy ID is provided, it will prompt the user to select one interactively.
+
+
+.SH OPTIONS
+\fB-h\fP, \fB--help\fP[=false]
+	help for list
+
+.PP
+\fB--page\fP=1
+	Page number
+
+.PP
+\fB--page-size\fP=0
+	Size of per page (0 to fetch all)
+
+.PP
+\fB-q\fP, \fB--query\fP=""
+	Query string to query resources
+
+.PP
+\fB--sort\fP=""
+	Sort the resource list in ascending or descending order
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+\fB-c\fP, \fB--config\fP=""
+	config file (default is $HOME/.config/harbor-cli/config.yaml)
+
+.PP
+\fB-o\fP, \fB--output-format\fP=""
+	Output format. One of: json|yaml
+
+.PP
+\fB-v\fP, \fB--verbose\fP[=false]
+	verbose output
+
+
+.SH EXAMPLE
+.EX
+  harbor replication executions list 12345
+  harbor replication executions list
+.EE
+
+
+.SH SEE ALSO
+\fBharbor-replication-executions(1)\fP

--- a/doc/man-docs/man1/harbor-replication-executions-view.1
+++ b/doc/man-docs/man1/harbor-replication-executions-view.1
@@ -1,0 +1,46 @@
+.nh
+.TH "HARBOR" "1"  "Harbor Community" "Harbor User Manuals"
+
+.SH NAME
+harbor-replication-executions-view - get replication execution by id
+
+
+.SH SYNOPSIS
+\fBharbor replication executions view [ID] [flags]\fP
+
+
+.SH DESCRIPTION
+Get a specific replication execution by its ID. If no ID is provided, it will prompt the user to select one interactively. If the --no-tasks flag is set, it will not list associated tasks.
+
+
+.SH OPTIONS
+\fB-h\fP, \fB--help\fP[=false]
+	help for view
+
+.PP
+\fB--no-tasks\fP[=false]
+	Do not list associated tasks
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+\fB-c\fP, \fB--config\fP=""
+	config file (default is $HOME/.config/harbor-cli/config.yaml)
+
+.PP
+\fB-o\fP, \fB--output-format\fP=""
+	Output format. One of: json|yaml
+
+.PP
+\fB-v\fP, \fB--verbose\fP[=false]
+	verbose output
+
+
+.SH EXAMPLE
+.EX
+  harbor replication executions view 12345
+  harbor replication executions view --no-tasks
+.EE
+
+
+.SH SEE ALSO
+\fBharbor-replication-executions(1)\fP

--- a/doc/man-docs/man1/harbor-replication-executions.1
+++ b/doc/man-docs/man1/harbor-replication-executions.1
@@ -2,20 +2,20 @@
 .TH "HARBOR" "1"  "Harbor Community" "Harbor User Manuals"
 
 .SH NAME
-harbor-replication - Manage replications
+harbor-replication-executions - Manage replication executions
 
 
 .SH SYNOPSIS
-\fBharbor replication [flags]\fP
+\fBharbor replication executions [flags]\fP
 
 
 .SH DESCRIPTION
-Manage replications in Harbor context
+Manage replication executions in Harbor context
 
 
 .SH OPTIONS
 \fB-h\fP, \fB--help\fP[=false]
-	help for replication
+	help for executions
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
@@ -32,4 +32,4 @@ Manage replications in Harbor context
 
 
 .SH SEE ALSO
-\fBharbor(1)\fP, \fBharbor-replication-executions(1)\fP, \fBharbor-replication-log(1)\fP, \fBharbor-replication-policies(1)\fP, \fBharbor-replication-start(1)\fP, \fBharbor-replication-stop(1)\fP
+\fBharbor-replication(1)\fP, \fBharbor-replication-executions-list(1)\fP, \fBharbor-replication-executions-view(1)\fP

--- a/doc/man-docs/man1/harbor-replication-log.1
+++ b/doc/man-docs/man1/harbor-replication-log.1
@@ -2,20 +2,20 @@
 .TH "HARBOR" "1"  "Harbor Community" "Harbor User Manuals"
 
 .SH NAME
-harbor-replication - Manage replications
+harbor-replication-log - get replication execution logs by execution and task id
 
 
 .SH SYNOPSIS
-\fBharbor replication [flags]\fP
+\fBharbor replication log [EXECUTION_ID] [TASK_ID] [flags]\fP
 
 
 .SH DESCRIPTION
-Manage replications in Harbor context
+Get the logs of a specific replication execution and task by their IDs. If no IDs are provided, it will prompt the user to select them interactively.
 
 
 .SH OPTIONS
 \fB-h\fP, \fB--help\fP[=false]
-	help for replication
+	help for log
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
@@ -31,5 +31,12 @@ Manage replications in Harbor context
 	verbose output
 
 
+.SH EXAMPLE
+.EX
+  harbor replication log 12345 67890
+  harbor replication log
+.EE
+
+
 .SH SEE ALSO
-\fBharbor(1)\fP, \fBharbor-replication-executions(1)\fP, \fBharbor-replication-log(1)\fP, \fBharbor-replication-policies(1)\fP, \fBharbor-replication-start(1)\fP, \fBharbor-replication-stop(1)\fP
+\fBharbor-replication(1)\fP

--- a/doc/man-docs/man1/harbor-replication-log.1
+++ b/doc/man-docs/man1/harbor-replication-log.1
@@ -14,8 +14,16 @@ Get the logs of a specific replication execution and task by their IDs. If no ID
 
 
 .SH OPTIONS
+\fB-e\fP, \fB--execution-id\fP=0
+	Replication execution ID
+
+.PP
 \fB-h\fP, \fB--help\fP[=false]
 	help for log
+
+.PP
+\fB-t\fP, \fB--task-id\fP=0
+	Replication task ID
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
@@ -33,7 +41,9 @@ Get the logs of a specific replication execution and task by their IDs. If no ID
 
 .SH EXAMPLE
 .EX
-  harbor replication log 12345 67890
+  harbor replication log -e 12345 -t 67890
+		  harbor replication log --execution-id 12345 --task-id 67890
+		  harbor replication log --execution-id 12345
   harbor replication log
 .EE
 

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
+	github.com/go-viper/mapstructure/v2 v2.3.0 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+Gr
 github.com/go-openapi/swag v0.23.0/go.mod h1:esZ8ITTYEsH1V2trKHjAN8Ai7xHb8RV+YSZ577vPjgQ=
 github.com/go-openapi/validate v0.24.0 h1:LdfDKwNbpB6Vn40xhTdNZAnfLECL81w+VX3BumrGD58=
 github.com/go-openapi/validate v0.24.0/go.mod h1:iyeX1sEufmv3nPbBdX3ieNviWnOZaJ1+zquzJEf2BAQ=
-github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
-github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/go-viper/mapstructure/v2 v2.3.0 h1:27XbWsHIqhbdR5TIC911OfYvgSaW93HM+dX7970Q7jk=
+github.com/go-viper/mapstructure/v2 v2.3.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/goharbor/go-client v0.213.1 h1:bohLwNog8uv8FKhIZ0SHiaDbYr3X/1hovgo5fqZWMdo=

--- a/pkg/api/replication_handler.go
+++ b/pkg/api/replication_handler.go
@@ -94,8 +94,9 @@ func UpdateReplicationPolicy(policyID int64, policy *models.ReplicationPolicy) (
 	}
 
 	response, err := client.Replication.UpdateReplicationPolicy(ctx, &replication.UpdateReplicationPolicyParams{
-		ID:     policyID,
-		Policy: policy,
+		Context: ctx,
+		ID:      policyID,
+		Policy:  policy,
 	})
 	if err != nil {
 		return nil, err
@@ -130,7 +131,8 @@ func StopReplication(policyID int64) (*replication.StopReplicationOK, error) {
 	}
 
 	response, err := client.Replication.StopReplication(ctx, &replication.StopReplicationParams{
-		ID: policyID,
+		Context: ctx,
+		ID:      policyID,
 	})
 	if err != nil {
 		return nil, err
@@ -152,6 +154,7 @@ func ListReplicationExecutions(policyID int64, opts ...ListFlags) (*replication.
 	}
 
 	response, err := client.Replication.ListReplicationExecutions(ctx, &replication.ListReplicationExecutionsParams{
+		Context:  ctx,
 		PolicyID: &policyID,
 		Page:     &listFlags.Page,
 		PageSize: &listFlags.PageSize,
@@ -170,11 +173,55 @@ func GetReplicationExecution(executionID int64) (*replication.GetReplicationExec
 	}
 
 	response, err := client.Replication.GetReplicationExecution(ctx, &replication.GetReplicationExecutionParams{
-		ID: executionID,
+		Context: ctx,
+		ID:      executionID,
 	})
 	if err != nil {
 		return nil, err
 	}
 
+	return response, nil
+}
+
+func GetReplicationLog(executionID int64, taskID int64) (*replication.GetReplicationLogOK, error) {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := client.Replication.GetReplicationLog(ctx, &replication.GetReplicationLogParams{
+		Context: ctx,
+		ID:      executionID,
+		TaskID:  taskID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func ListReplicationTasks(executionID int64, opts ...ListFlags) (*replication.ListReplicationTasksOK, error) {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return nil, err
+	}
+
+	var listFlags ListFlags
+
+	if len(opts) > 0 {
+		listFlags = opts[0]
+	}
+
+	response, err := client.Replication.ListReplicationTasks(ctx, &replication.ListReplicationTasksParams{
+		Context:  ctx,
+		ID:       executionID,
+		Page:     &listFlags.Page,
+		PageSize: &listFlags.PageSize,
+		Sort:     &listFlags.Sort,
+	})
+	if err != nil {
+		return nil, err
+	}
 	return response, nil
 }

--- a/pkg/api/replication_handler.go
+++ b/pkg/api/replication_handler.go
@@ -139,14 +139,23 @@ func StopReplication(policyID int64) (*replication.StopReplicationOK, error) {
 	return response, nil
 }
 
-func GetReplicationExecutions(policyID int64) (*replication.ListReplicationExecutionsOK, error) {
+func ListReplicationExecutions(policyID int64, opts ...ListFlags) (*replication.ListReplicationExecutionsOK, error) {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {
 		return nil, err
 	}
 
+	var listFlags ListFlags
+
+	if len(opts) > 0 {
+		listFlags = opts[0]
+	}
+
 	response, err := client.Replication.ListReplicationExecutions(ctx, &replication.ListReplicationExecutionsParams{
 		PolicyID: &policyID,
+		Page:     &listFlags.Page,
+		PageSize: &listFlags.PageSize,
+		Sort:     &listFlags.Sort,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -300,7 +300,7 @@ func GetReplicationExecutionIDFromUser(rpolicyID int64) int64 {
 	executionID := make(chan int64)
 
 	go func() {
-		response, err := api.GetReplicationExecutions(rpolicyID)
+		response, err := api.ListReplicationExecutions(rpolicyID)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -35,6 +35,7 @@ import (
 	rview "github.com/goharbor/harbor-cli/pkg/views/registry/select"
 	rexecutions "github.com/goharbor/harbor-cli/pkg/views/replication/execution/select"
 	rpolicies "github.com/goharbor/harbor-cli/pkg/views/replication/policies/select"
+	rtasks "github.com/goharbor/harbor-cli/pkg/views/replication/task/select"
 
 	repoView "github.com/goharbor/harbor-cli/pkg/views/repository/select"
 	robotView "github.com/goharbor/harbor-cli/pkg/views/robot/select"
@@ -308,6 +309,23 @@ func GetReplicationExecutionIDFromUser(rpolicyID int64) int64 {
 			log.Fatal("no replication executions found")
 		}
 		rexecutions.ReplicationExecutionList(response.Payload, executionID)
+	}()
+
+	return <-executionID
+}
+
+func GetReplicationTaskIDFromUser(execID int64) int64 {
+	executionID := make(chan int64)
+
+	go func() {
+		response, err := api.ListReplicationTasks(execID)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if len(response.Payload) == 0 {
+			log.Fatal("no replication tasks found")
+		}
+		rtasks.ReplicationTasksList(response.Payload, executionID)
 	}()
 
 	return <-executionID

--- a/pkg/views/replication/execution/list/view.go
+++ b/pkg/views/replication/execution/list/view.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package view
+package list
 
 import (
 	"fmt"
@@ -26,39 +26,37 @@ import (
 )
 
 var columns = []table.Column{
-	{Title: "ID", Width: tablelist.WidthM},
+	{Title: "Exec ID", Width: tablelist.WidthS},
+	{Title: "Pol ID", Width: tablelist.WidthS},
 	{Title: "Status", Width: tablelist.WidthL},
-	{Title: "Trigger", Width: tablelist.WidthL},
-	{Title: "Succed", Width: tablelist.WidthM},
+	{Title: "Succeed", Width: tablelist.WidthM},
 	{Title: "Stopped", Width: tablelist.WidthM},
 	{Title: "Total", Width: tablelist.WidthM},
+	{Title: "Trigger", Width: tablelist.WidthL},
 	{Title: "Start Time", Width: tablelist.WidthL},
 	{Title: "End Time", Width: tablelist.WidthL},
 }
 
-func ViewExecution(exec *models.ReplicationExecution) {
+func ListExecutions(executions []*models.ReplicationExecution) {
 	var rows []table.Row
-	startTime, err := utils.FormatCreatedTime(exec.StartTime.String())
-	if err != nil {
-		fmt.Println("Error formatting start time:", err)
-		startTime = exec.StartTime.String()
+	for _, exec := range executions {
+		createdTime, _ := utils.FormatCreatedTime(exec.StartTime.String())
+		var endTime string = "-"
+		if exec.Status != "InProgress" {
+			endTime, _ = utils.FormatCreatedTime(exec.EndTime.String())
+		}
+		rows = append(rows, table.Row{
+			strconv.FormatInt(exec.ID, 10),
+			strconv.FormatInt(exec.PolicyID, 10),
+			exec.Status,
+			strconv.FormatInt(exec.Succeed, 10),
+			strconv.FormatInt(exec.Stopped, 10),
+			strconv.FormatInt(exec.Total, 10),
+			exec.Trigger,
+			createdTime,
+			endTime,
+		})
 	}
-	endTime, err := utils.FormatCreatedTime(exec.EndTime.String())
-	if err != nil {
-		fmt.Println("Error formatting end time:", err)
-		endTime = exec.EndTime.String()
-	}
-	rows = append(rows, table.Row{
-		strconv.FormatInt(exec.ID, 10),
-		exec.Status,
-		exec.Trigger,
-		strconv.FormatInt(exec.Succeed, 10),
-		strconv.FormatInt(exec.Stopped, 10),
-		strconv.FormatInt(exec.Total, 10),
-		startTime,
-		endTime,
-	})
-
 	m := tablelist.NewModel(columns, rows, len(rows))
 	if _, err := tea.NewProgram(m).Run(); err != nil {
 		fmt.Println("Error running program:", err)

--- a/pkg/views/replication/execution/view/view.go
+++ b/pkg/views/replication/execution/view/view.go
@@ -26,7 +26,7 @@ import (
 )
 
 var columns = []table.Column{
-	{Title: "ID", Width: tablelist.WidthM},
+	{Title: "Execution ID", Width: tablelist.WidthM},
 	{Title: "Status", Width: tablelist.WidthL},
 	{Title: "Trigger", Width: tablelist.WidthL},
 	{Title: "Succed", Width: tablelist.WidthM},

--- a/pkg/views/replication/task/list/view.go
+++ b/pkg/views/replication/task/list/view.go
@@ -1,0 +1,122 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package view
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/goharbor/harbor-cli/pkg/views/base/tablelist"
+)
+
+var columns = []table.Column{
+	{Title: "Property", Width: tablelist.WidthL},
+	{Title: "Value", Width: tablelist.Width3XL},
+}
+
+var order = []string{
+	"ID",
+	"Status",
+	"Resource Type",
+	"Source Resource",
+	"Destination Resource",
+	"Operation",
+	"Job ID",
+	"Execution ID",
+	"Start Time",
+	"End Time",
+}
+
+func ViewTask(task *models.ReplicationTask) {
+	startTime, _ := utils.FormatCreatedTime(task.StartTime.String())
+	var endTime string = "-"
+	if task.Status != "InProgress" {
+		endTime, _ = utils.FormatCreatedTime(task.EndTime.String())
+	}
+
+	taskMap := map[string]string{
+		"ID":                   strconv.FormatInt(task.ID, 10),
+		"Status":               task.Status,
+		"Resource Type":        task.ResourceType,
+		"Source Resource":      task.SrcResource,
+		"Destination Resource": task.DstResource,
+		"Operation":            task.Operation,
+		"Job ID":               task.JobID,
+		"Execution ID":         strconv.FormatInt(task.ExecutionID, 10),
+		"Start Time":           startTime,
+		"End Time":             endTime,
+	}
+
+	var rows []table.Row
+	for _, key := range order {
+		rows = append(rows, table.Row{
+			key,
+			taskMap[key],
+		})
+	}
+
+	m := tablelist.NewModel(columns, rows, len(rows))
+	if _, err := tea.NewProgram(m).Run(); err != nil {
+		fmt.Println("Error running program:", err)
+		os.Exit(1)
+	}
+}
+
+func ListTasks(tasks []*models.ReplicationTask) {
+	if len(tasks) == 0 {
+		fmt.Println("No replication tasks found")
+		return
+	}
+
+	if len(tasks) == 1 {
+		ViewTask(tasks[0])
+		return
+	}
+
+	var listColumns = []table.Column{
+		{Title: "ID", Width: tablelist.WidthS},
+		{Title: "Status", Width: tablelist.WidthM},
+		{Title: "Resource Type", Width: tablelist.WidthM},
+		{Title: "Source Resource", Width: tablelist.WidthXL},
+		{Title: "Destination Resource", Width: tablelist.WidthXL},
+		{Title: "Operation", Width: tablelist.WidthM},
+		{Title: "Start Time", Width: tablelist.WidthL},
+	}
+
+	var rows []table.Row
+	for _, task := range tasks {
+		startTime, _ := utils.FormatCreatedTime(task.StartTime.String())
+
+		rows = append(rows, table.Row{
+			strconv.FormatInt(task.ID, 10),
+			task.Status,
+			task.ResourceType,
+			task.SrcResource,
+			task.DstResource,
+			task.Operation,
+			startTime,
+		})
+	}
+
+	m := tablelist.NewModel(listColumns, rows, len(rows))
+	if _, err := tea.NewProgram(m).Run(); err != nil {
+		fmt.Println("Error running program:", err)
+		os.Exit(1)
+	}
+}

--- a/pkg/views/replication/task/select/view.go
+++ b/pkg/views/replication/task/select/view.go
@@ -1,0 +1,52 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package task
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/views/base/selection"
+)
+
+func ReplicationTasksList(tasks []*models.ReplicationTask, choice chan<- int64) {
+	itemsList := make([]list.Item, len(tasks))
+	for i, p := range tasks {
+		displayName := fmt.Sprintf("ID: %d, Status: %s, Operation: %s, Src: %s, Dst: %s, Start Time: %s",
+			p.ID, p.Status, p.Operation, p.SrcResource, p.DstResource, p.StartTime.String())
+		itemsList[i] = selection.Item(displayName)
+	}
+
+	m := selection.NewModel(itemsList, "Select a Replication Task")
+
+	p, err := tea.NewProgram(m, tea.WithAltScreen()).Run()
+	if err != nil {
+		fmt.Println("Error running program:", err)
+		os.Exit(1)
+	}
+
+	if p, ok := p.(selection.Model); ok {
+		// Extract the ID from p.Choice
+		var taskID int64
+		_, err = fmt.Sscanf(p.Choice, "ID: %d", &taskID)
+		if err != nil {
+			fmt.Println("error parsing task ID:", err)
+			os.Exit(1)
+		}
+		choice <- taskID
+	}
+}


### PR DESCRIPTION
## Overview

Fixes #102
Fixes #497

This PR adds comprehensive **replication execution management** to **harbor-cli**, introducing commands to list, view, and retrieve logs for replication executions and their associated tasks.

## New Commands

### List Replication Executions

* **`harbor replication executions list [POLICY_ID]`** - Lists all replication executions for a policy
* Interactive policy selection when no ID is provided
* Supports standard pagination, filtering, and sorting options
* JSON output format support for programmatic use

### View Replication Execution

* **`harbor replication executions view [EXECUTION_ID]`** - Shows detailed execution information
* Property-value table format for single execution display
* Automatically displays associated tasks unless `--no-tasks` flag is used
* Interactive execution selection when no ID is provided

### Replication Logs

* **`harbor replication log [EXECUTION_ID] [TASK_ID]`** - Retrieves formatted task logs
* Interactive task selection when IDs are not provided

## Screenshots / Screenrecordings


https://github.com/user-attachments/assets/bb16291d-9a2d-4be0-bb53-9bd294cbe7f2

_Part of umbrella issue #497 for full replication CLI support._