### PR TITLE
Fix Typo in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ docker run -ti --rm -v $HOME/.config/harbor-cli/config.yaml:/root/.config/harbor
 ```
 Use the `HARBOR_ENCRYPTION_KEY` container environment variable as a base64-encoded 32-byte key for AES-256 encryption. This securely stores your harbor login password.
 
-I you intend
+If you intend
 to run the CLI as a container,it is advised
 to set the following environment variables and to create an alias
 and append the alias to your .zshrc or .bashrc file


### PR DESCRIPTION
This pull request fixes a minor typo in readme.md
  - **Before:** I you intend to run the CLI as a container...
  - **After:** If you intend to run the CLI as a container...

### **Checklist**
- [x] Typo fixed
- [x] No other changes made