### PR TITLE
[WIP] feature: rebasing and working on LDAP commands

### DIFF
--- a/cmd/harbor/root/cmd.go
+++ b/cmd/harbor/root/cmd.go
@@ -24,6 +24,7 @@ import (
 	"github.com/goharbor/harbor-cli/cmd/harbor/root/cve"
 	"github.com/goharbor/harbor-cli/cmd/harbor/root/instance"
 	"github.com/goharbor/harbor-cli/cmd/harbor/root/labels"
+	"github.com/goharbor/harbor-cli/cmd/harbor/root/ldap"
 	"github.com/goharbor/harbor-cli/cmd/harbor/root/project"
 	"github.com/goharbor/harbor-cli/cmd/harbor/root/quota"
 	"github.com/goharbor/harbor-cli/cmd/harbor/root/registry"
@@ -140,6 +141,10 @@ harbor help
 	root.AddCommand(cmd)
 
 	cmd = robot.Robot()
+	cmd.GroupID = "core"
+	root.AddCommand(cmd)
+
+	cmd = ldap.Ldap()
 	cmd.GroupID = "core"
 	root.AddCommand(cmd)
 

--- a/cmd/harbor/root/ldap/cmd.go
+++ b/cmd/harbor/root/ldap/cmd.go
@@ -1,4 +1,3 @@
-
 package ldap
 
 import (
@@ -12,7 +11,8 @@ func Ldap() *cobra.Command {
 		Example: `  harbor ldap ping`,
 	}
 	cmd.AddCommand(
-    LdapSearchUserCmd(),
+		LdapSearchUserCmd(),
+		LdapPingCmd(),
 	)
 
 	return cmd

--- a/cmd/harbor/root/ldap/cmd.go
+++ b/cmd/harbor/root/ldap/cmd.go
@@ -1,0 +1,19 @@
+
+package ldap
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func Ldap() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "ldap",
+		Short:   "Manage ldap users and groups",
+		Example: `  harbor ldap ping`,
+	}
+	cmd.AddCommand(
+    LdapSearchUserCmd(),
+	)
+
+	return cmd
+}

--- a/cmd/harbor/root/ldap/ping.go
+++ b/cmd/harbor/root/ldap/ping.go
@@ -1,0 +1,41 @@
+package ldap
+
+import (
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/api"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+// Ping ldap server command
+func LdapPingCmd() *cobra.Command {
+	opts := &models.LdapConf{}
+	cmd := &cobra.Command{
+		Use:   "ping",
+		Short: "ping ldap server",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			response, err := api.LdapPingServer(opts)
+			if err != nil {
+				log.Fatalf("failed to ping ldap server: %v", err)
+			}
+			if response.Payload.Success {
+				log.Info("Connection to LDAP Server Success")
+			} else {
+				log.Fatalf("connection to ldap server failed: %v", response.Payload.Message)
+			}
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.LdapURL, "ldap-url", "", "", "URL of the ldap service")
+	flags.StringVarP(&opts.LdapSearchPassword, "ldap-password", "", "", "search password of the ldap service")
+	flags.StringVarP(&opts.LdapSearchDn, "ldap-search-dn", "", "", "User's dn who has the permission to search the ldap server")
+	flags.StringVarP(&opts.LdapBaseDn, "ldap-base-dn", "", "", "The base dn from which to lookup the user")
+	flags.StringVarP(&opts.LdapUID, "ldap-uid", "", "", "attribute used in search to match the user. It could be cn, uid based on your LDAP/AD.")
+	flags.Int64VarP(&opts.LdapScope, "ldap-scope", "", 0, "search scope of ldap service default 0 base, 1 OneLevel, 2 Subtree.")
+	flags.StringVarP(&opts.LdapFilter, "ldap-filter", "", "", "Search Filter of ldap service")
+	flags.BoolVarP(&opts.LdapVerifyCert, "ldap-verify", "", false, "Verify Ldap server certificate")
+
+	return cmd
+}

--- a/cmd/harbor/root/ldap/search.go
+++ b/cmd/harbor/root/ldap/search.go
@@ -1,7 +1,6 @@
 package ldap
 
 import (
-	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/ldap"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	log "github.com/sirupsen/logrus"
@@ -15,12 +14,7 @@ func LdapSearchUserCmd() *cobra.Command {
 		Short: "search ldap user by registered userid",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			var (
-				err      error
-				response *ldap.SearchLdapUserOK
-			)
-
-			response, err = api.LdapSearchUser(args[0])
+			response, err := api.LdapSearchUser(args[0])
 			if err != nil {
 				log.Fatalf("failed to search ldap user: %v", err)
 			}

--- a/cmd/harbor/root/ldap/search.go
+++ b/cmd/harbor/root/ldap/search.go
@@ -1,0 +1,33 @@
+package ldap
+
+import (
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/ldap"
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+// Search ldap users command
+func LdapSearchUserCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "search [userID]",
+		Short: "search ldap user by registered userid",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			var (
+				err      error
+				response *ldap.SearchLdapUserOK
+			)
+
+			response, err = api.LdapSearchUser(args[0])
+			if err != nil {
+				log.Fatalf("failed to search ldap user: %v", err)
+			}
+
+			utils.PrintPayloadInJSONFormat(response.Payload)
+		},
+	}
+
+	return cmd
+}

--- a/pkg/api/ldap_handler.go
+++ b/pkg/api/ldap_handler.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/ldap"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 )
 
@@ -13,6 +14,22 @@ func LdapSearchUser(username string) (*ldap.SearchLdapUserOK, error) {
 
 	res, err := client.Ldap.SearchLdapUser(ctx, &ldap.SearchLdapUserParams{
 		Username: &username,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func LdapPingServer(ldapConf *models.LdapConf) (*ldap.PingLdapOK, error) {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := client.Ldap.PingLdap(ctx, &ldap.PingLdapParams{
+		Ldapconf: ldapConf,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/api/ldap_handler.go
+++ b/pkg/api/ldap_handler.go
@@ -1,0 +1,22 @@
+package api
+
+import (
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/ldap"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+)
+
+func LdapSearchUser(username string) (*ldap.SearchLdapUserOK, error) {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := client.Ldap.SearchLdapUser(ctx, &ldap.SearchLdapUserParams{
+		Username: &username,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}


### PR DESCRIPTION
## Summary

This PR introduces LDAP commands to the CLI, enhancing Harbor's capabilities by allowing the management and import of LDAP users directly through the command line interface.

The addition of LDAP commands follows the recent integration of configuration commands https://github.com/goharbor/harbor-cli/pull/114 into the CLI. The configuration commands provide a foundational framework that allows administrators to set and manage Harbor configurations from the command line. By building on this foundation, the LDAP commands leverage the existing configuration setup, ensuring that user management aligns seamlessly with the configured LDAP settings.

## Added Commands:

- [ ] ldap ping -- ping the ldap server testing the connection.
- [ ] ldap search -- search the ldap users with id.
- [ ] ldap import -- import users with their id.
- [ ] ldap search group -- search ldap groups.

## Conclusion:

This enhancement significantly improves the operational efficiency and capabilities of Harbor's CLI. It makes LDAP user management more accessible, quicker, and more integrated.