### PR TITLE
feat: Add WinGet publishing automation via Dagger

### DIFF
--- a/.dagger/README.md
+++ b/.dagger/README.md
@@ -94,6 +94,28 @@ dagger call run-doc export --path=docs/cli
 - If you modify or add new pipeline steps, document them under **Dagger Functions Overview** to maintain clarity.
 - Always validate pipelines with `dagger call pipeline` locally before merging into main.
 
+### 🚀 `PublishImage(registry, imageTags)`
+
+Publishes the Harbor CLI container image to a registry.
+
+```bash
+dagger call publish-image \
+  --registry=demo.goharbor.io \
+  --registry-username=harbor-cli \
+  --registry-password=env:REGPASS \
+  --imageTags=v0.1.0,latest
+```
+
+### 📦 `PublishToScoop(version, githubToken)`
+
+Updates the Scoop manifest (`scoop/harbor-cli.json`) for Windows users. Uses the **same repo approach** — only needs the built-in `GITHUB_TOKEN`, no external secrets.
+
+```bash
+dagger call publish-to-scoop \
+  --version="0.6.0" \
+  --github-token=env:GITHUB_TOKEN
+```
+
 ---
 
 ## 📚 References

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -45,3 +45,123 @@ func (m *HarborCli) init(ctx context.Context, source *dagger.Directory) error {
 
 	return nil
 }
+
+// PublishToScoopDryRun shows what would be published to Scoop without making changes
+// This is useful for testing and validation
+func (m *HarborCli) PublishToScoopDryRun(
+	ctx context.Context,
+	version string,
+) string {
+	baseUrl := fmt.Sprintf("https://github.com/goharbor/harbor-cli/releases/download/v%s", version)
+
+	output := fmt.Sprintf(`Scoop Publishing Dry Run
+========================================
+Version: %s
+Manifest: scoop/harbor-cli.json
+
+Installer URLs:
+- 64bit: %s/harbor-cli_%s_windows_amd64.zip
+- arm64: %s/harbor-cli_%s_windows_arm64.zip
+
+This will:
+1. Download Windows release assets
+2. Compute SHA256 hashes
+3. Update scoop/harbor-cli.json with new version and hashes
+4. Commit and push changes to goharbor/harbor-cli
+
+Note: This is a dry run. Use publish-to-scoop to actually publish.
+`, version, baseUrl, version, baseUrl, version)
+
+	return output
+}
+
+// PublishToScoop updates the Scoop manifest in the harbor-cli repo
+// This uses the same repo approach - no external secrets needed, just GITHUB_TOKEN
+func (m *HarborCli) PublishToScoop(
+	ctx context.Context,
+	version string,
+	githubToken *dagger.Secret,
+) (string, error) {
+	fmt.Println("Publishing to Scoop...")
+
+	// Construct URLs
+	baseUrl := fmt.Sprintf("https://github.com/goharbor/harbor-cli/releases/download/v%s", version)
+	amd64Url := fmt.Sprintf("%s/harbor-cli_%s_windows_amd64.zip", baseUrl, version)
+	arm64Url := fmt.Sprintf("%s/harbor-cli_%s_windows_arm64.zip", baseUrl, version)
+
+	script := fmt.Sprintf(`
+set -e
+
+# Download files and compute hashes
+echo "Downloading and computing hashes..."
+AMD64_HASH=$(curl -sL "%s" | sha256sum | cut -d' ' -f1)
+ARM64_HASH=$(curl -sL "%s" | sha256sum | cut -d' ' -f1)
+
+echo "AMD64 Hash: $AMD64_HASH"
+echo "ARM64 Hash: $ARM64_HASH"
+
+# Clone the repo
+echo "Cloning repository..."
+git clone https://x-access-token:${GITHUB_TOKEN}@github.com/goharbor/harbor-cli.git repo
+cd repo
+
+# Create a new branch for the update
+BRANCH="scoop/update-v%s"
+git checkout -b "$BRANCH"
+
+# Update manifest using jq
+echo "Updating manifest..."
+jq --arg ver "%s" \
+   --arg amd64url "%s" \
+   --arg arm64url "%s" \
+   --arg amd64hash "$AMD64_HASH" \
+   --arg arm64hash "$ARM64_HASH" \
+   '.version = $ver |
+    .architecture."64bit".url = $amd64url |
+    .architecture."64bit".hash = $amd64hash |
+    .architecture.arm64.url = $arm64url |
+    .architecture.arm64.hash = $arm64hash' \
+   scoop/harbor-cli.json > scoop/harbor-cli.json.tmp
+mv scoop/harbor-cli.json.tmp scoop/harbor-cli.json
+
+# Show updated manifest
+echo "Updated manifest:"
+cat scoop/harbor-cli.json
+
+# Commit and push the branch
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+git add scoop/harbor-cli.json
+git commit -m "scoop: update harbor-cli to v%s" || { echo "No changes to commit"; exit 0; }
+git push origin "$BRANCH"
+
+# Create a PR using GitHub API
+echo "Creating pull request..."
+curl -s -X POST \
+  -H "Authorization: token ${GITHUB_TOKEN}" \
+  -H "Accept: application/vnd.github+json" \
+  https://api.github.com/repos/goharbor/harbor-cli/pulls \
+  -d "{
+    \"title\": \"scoop: update harbor-cli to v%s\",
+    \"body\": \"Automated Scoop manifest update for v%s.\",
+    \"head\": \"$BRANCH\",
+    \"base\": \"main\"
+  }"
+
+echo "Pull request created successfully!"
+`, amd64Url, arm64Url, version, version, amd64Url, arm64Url, version, version, version)
+
+	output, err := dag.Container().
+		From("alpine:latest").
+		WithSecretVariable("GITHUB_TOKEN", githubToken).
+		WithExec([]string{"apk", "add", "--no-cache", "git", "curl", "bash", "jq"}).
+		WithExec([]string{"bash", "-c", script}).
+		Stdout(ctx)
+
+	if err != nil {
+		return "", fmt.Errorf("failed to publish to Scoop: %v", err)
+	}
+
+	fmt.Println("Scoop manifest updated successfully")
+	return output, nil
+}

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -391,3 +391,33 @@ jobs:
           REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS }}
           REGISTRY_USERNAME: ${{ vars.REGISTRY_USERNAME }}
           BUILD_DIR: "dist"
+
+  publish-to-scoop:
+    needs:
+      - publish-release
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from tag
+        id: extract_version
+        run: |
+          VERSION=${{ github.ref_name }}
+          VERSION_WITHOUT_V=${VERSION#v}
+          echo "version=${VERSION_WITHOUT_V}" >> $GITHUB_OUTPUT
+
+      - name: Publish to Scoop
+        uses: dagger/dagger-for-github@v7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          version: "latest"
+          verb: call
+          args: "publish-to-scoop --version=${{ steps.extract_version.outputs.version }} --github-token=env:GITHUB_TOKEN"

--- a/scoop/harbor-cli.json
+++ b/scoop/harbor-cli.json
@@ -1,0 +1,31 @@
+{
+    "version": "0.6.0",
+    "description": "Command-line interface for Harbor container registry",
+    "homepage": "https://github.com/goharbor/harbor-cli",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/goharbor/harbor-cli/releases/download/v0.6.0/harbor-cli_0.6.0_windows_amd64.zip",
+            "hash": "SHA256_HASH_HERE",
+            "bin": "harbor-cli.exe"
+        },
+        "arm64": {
+            "url": "https://github.com/goharbor/harbor-cli/releases/download/v0.6.0/harbor-cli_0.6.0_windows_arm64.zip",
+            "hash": "SHA256_HASH_HERE",
+            "bin": "harbor-cli.exe"
+        }
+    },
+    "checkver": {
+        "github": "https://github.com/goharbor/harbor-cli"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/goharbor/harbor-cli/releases/download/v$version/harbor-cli_$version_windows_amd64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/goharbor/harbor-cli/releases/download/v$version/harbor-cli_$version_windows_arm64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implements automated Scoop package publishing for Windows users, replacing the WinGet approach proposed in #530 due to security concerns around external tokens/GitHub Apps.
* #530 

## Changes
- Add `PublishToScoop()` Dagger function for automated manifest updates
- Add `PublishToScoopDryRun()` for local testing and validation
- Add `publish-to-scoop` job to GitHub Actions workflow
- Add `scoop/harbor-cli.json` manifest with `checkver` and `autoupdate` support
- Update Dagger README with usage instructions

## Why Scoop over WinGet?
- **No external secrets** uses only the built-in `GITHUB_TOKEN`
- **No GitHub App / PAT required** eliminates security risks raised in maintainer review
- **Same repo approach** manifest lives in `harbor-cli` repo, no fork of external repos needed
- **Runs on `ubuntu-latest`** no Windows containers or runners required

## Implementation Details
- Downloads release assets and computes SHA256 hashes at publish time
- Updates `scoop/harbor-cli.json` via `jq` in an Alpine container
- Commits and pushes manifest changes automatically
- Triggered on tag push, runs after `publish-release` job

## Testing
-  Dagger function loads successfully
-  Dry-run tested with version `0.6.0`
-  Correct installer URLs generated for amd64 and arm64
-  Workflow job validated

## Usage
**Dry-run testing:** dagger call publish-to-scoop-dry-run --version="0.6.0"