### PR TITLE
fix(ci): fix vulnerability check failure in dagger pipeline

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -384,9 +384,10 @@ func (m *HarborCli) VulnerabilityCheck(ctx context.Context) (string, error) {
 // Runs a vulnerability check using govulncheck and writes results to vulnerability-check.report
 func (m *HarborCli) VulnerabilityCheckReport(ctx context.Context) *dagger.File {
 	report := "vulnerability-check.report"
+	cmd := fmt.Sprintf("govulncheck ./... > %s || true", report)
 	return m.vulnerabilityCheck(ctx).
 		WithExec([]string{
-			"sh", "-c", fmt.Sprintf("govulncheck ./... > %s", report),
+			"sh", "-c", cmd,
 		}).File(report)
 }
 
@@ -397,6 +398,7 @@ func parsePlatform(platform string) (string, string, error) {
 		return "", "", fmt.Errorf("invalid platform format: %s. Should be os/arch. E.g. darwin/amd64", platform)
 	}
 	return parts[0], parts[1], nil
+
 }
 
 func getVersion(tags []string) string {

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -95,7 +95,7 @@ jobs:
           # Check if the lint report contains any content (error or issues)
           if ! grep -q "No vulnerabilities found." vulnerability-check.report; then
               # If the file contains content, output an error message and exit with code 1
-              echo "⚠️ Linting issues found!" >> $GITHUB_STEP_SUMMARY
+              echo "⚠️ Vulnerability issues found!" >> $GITHUB_STEP_SUMMARY
               exit 1
           fi
 


### PR DESCRIPTION
## Related Issue
Fixes #552 
## Description
Currently, the vulnerability check fails inside Dagger when bugs are found, preventing the report from being exported. This change adds error handling (|| true) to the govulncheck command to ensure the report is always generated. Vulnerability check ultimately results in a failure at github actions stage.

Attached is the video of the fixed bug

https://github.com/user-attachments/assets/8df60ae9-46af-4b5c-90c4-8856a002bd3b

