### PR TITLE
readme: say that Homebrew is now available

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ echo "alias harbor='docker run -ti --rm -v \$HARBOR_CLI_CONFIG:/root/.config/har
 source ~/.zshrc # or restart your terminal
 ```
 
-## Linux, MacOS and Windows
+## Linux, macOS and Windows
 
 On Linux and macOS, you can use Homebrew:
 


### PR DESCRIPTION
Looks like `harbor-cli` now exists in Homebrew. The README says it's soon to be published in Homebrew, so I thought it would be good to update the README.