### PR TITLE
fix: handle nil CopyByChunk in replication policy view

### DIFF
--- a/pkg/views/replication/policies/view/view.go
+++ b/pkg/views/replication/policies/view/view.go
@@ -69,7 +69,7 @@ func ViewPolicy(rpolicy *models.ReplicationPolicy) {
 		"Description":        rpolicy.Description,
 		"Replicate Deletion": strconv.FormatBool(rpolicy.ReplicateDeletion),
 		"Copy By Chunk":      formatCopyByChunk(rpolicy.CopyByChunk),
-		"Speed":              strconv.FormatInt(int64(*rpolicy.Speed), 10) + " B/s",
+		"Speed":              formatSpeed(rpolicy.Speed),
 	}
 
 	var rows []table.Row
@@ -141,6 +141,13 @@ func getRegistryName(registry *models.Registry) string {
 		return "Local"
 	}
 	return registry.Name
+}
+
+func formatSpeed(speed *int32) string {
+	if speed == nil {
+		return "N/A"
+	}
+	return strconv.FormatInt(int64(*speed), 10) + " B/s"
 }
 
 func formatCopyByChunk(copyByChunk *bool) string {

--- a/pkg/views/replication/policies/view/view_test.go
+++ b/pkg/views/replication/policies/view/view_test.go
@@ -25,9 +25,28 @@ func TestFormatCopyByChunk(t *testing.T) {
 		assert.Equal(t, "N/A", got)
 	})
 
-	t.Run("non-nil CopyByChunk", func(t *testing.T) {
+	t.Run("true CopyByChunk", func(t *testing.T) {
 		v := true
 		got := formatCopyByChunk(&v)
 		assert.Equal(t, "true", got)
+	})
+
+	t.Run("false CopyByChunk", func(t *testing.T) {
+		v := false
+		got := formatCopyByChunk(&v)
+		assert.Equal(t, "false", got)
+	})
+}
+
+func TestFormatSpeed(t *testing.T) {
+	t.Run("nil Speed", func(t *testing.T) {
+		got := formatSpeed(nil)
+		assert.Equal(t, "N/A", got)
+	})
+
+	t.Run("non-nil Speed", func(t *testing.T) {
+		v := int32(1024)
+		got := formatSpeed(&v)
+		assert.Equal(t, "1024 B/s", got)
 	})
 }


### PR DESCRIPTION
### What this PR does

- Add a helper function to safely format `CopyByChunk`
- Avoid potential nil pointer dereference when `CopyByChunk` is not set

### Why

`ReplicationPolicy.CopyByChunk` is optional and may be nil for some replication policies.
Calling `strconv.FormatBool(*CopyByChunk)` in such cases causes a panic.

This issue was observed when using Harbor server version 2.5.5.

This issue can be reproduced by running:

```shell
harbor-cli replication policies view 1 -v
````

Which results in:

```text
INFO[2026-01-14T04:01:54-05:00] System keyring not available, using file-based keyring 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xa1ed09]

goroutine 1 [running]:
github.com/goharbor/harbor-cli/pkg/views/replication/policies/view.ViewPolicy(0xc0002b2d00)
        /src/pkg/views/replication/policies/view/view.go:71 +0x669
github.com/goharbor/harbor-cli/cmd/harbor/root/replication.ReplicationPoliciesCommand.ViewCommand.func1(0xc000255300?, {0xc0001cd060?, 0x4?, 0xc4b36f?})
        /src/cmd/harbor/root/replication/policies/view.go:59 +0x13d
github.com/spf13/cobra.(*Command).execute(0xc00024f808, {0xc0001cd040, 0x2, 0x2})
        /go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1015 +0xb02
github.com/spf13/cobra.(*Command).ExecuteC(0xc000220008)
        /go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1148 +0x465
github.com/spf13/cobra.(*Command).Execute(0xc000002380?)
        /go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1071 +0x13
main.main()
        /src/cmd/harbor/main.go:23 +0x18
```

### How

- Extract formatting logic into `formatCopyByChunk`
- Return `"N/A"` when the value is nil

### Notes

- No behavior change for non-nil values
- Improves code readability and robustness
