### PR TITLE
docs: add community meeting details to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,12 @@ Harbor <2.0.0 is not supported.
 * **Developer Group:** Join Harbor developer group: [harbor-dev@lists.cncf.io](https://lists.cncf.io/g/harbor-dev) for discussion on Harbor development and contribution.
 * **Slack:** Join Harbor's community for discussion and ask questions: [Cloud Native Computing Foundation](https://slack.cncf.io/), channel: [#harbor](https://cloud-native.slack.com/messages/harbor/), [#harbor-dev](https://cloud-native.slack.com/messages/harbor-dev/) and [#harbor-cli](https://cloud-native.slack.com/messages/harbor-cli/).
 
+
+# Community Meetings
+ 
+- **Schedule:** Every Tuesday at **7:30 PM IST**  
+- **Meeting Link:** https://zoom.us/j/99658352431
+
 # License
 
 This project is licensed under the Apache 2.0 License. See the [LICENSE](https://github.com/goharbor/harbor-cli/blob/main/LICENSE) file for details.


### PR DESCRIPTION
### What this PR does

Adds community meeting information to the README, including:

- Dedicated Slack channel for Harbor CLI discussions
- Weekly meeting schedule
- Zoom meeting link

### Why

This helps new contributors and community members easily discover
where discussions and regular meetings take place.

### Related Issue

Fixes: #600
