### PR TITLE
Fix: Vulnerability Check Should Not Fail Pipeline

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -95,11 +95,8 @@ jobs:
         run: |
           echo "<h2> 🔒 Vulnerability Check Results</h2>" >> $GITHUB_STEP_SUMMARY
           cat vulnerability-check.report >> $GITHUB_STEP_SUMMARY
-          # Check if the lint report contains any content (error or issues)
           if ! grep -q "No vulnerabilities found." vulnerability-check.report; then
-              # If the file contains content, output an error message and exit with code 1
-              echo "⚠️ Vulnerability issues found!" >> $GITHUB_STEP_SUMMARY
-              exit 1
+              echo "⚠️ Vulnerability issues found! Please review." >> $GITHUB_STEP_SUMMARY
           fi
 
   test-code:


### PR DESCRIPTION
  ## Description:
  Fixes #609

  ## Changes Made
  - Remove `exit 1` from vulnerability check step
