### PR TITLE
fix(logs): Replace legacy logs API with new API

### DIFF
--- a/cmd/harbor/root/project/logs.go
+++ b/cmd/harbor/root/project/logs.go
@@ -37,7 +37,7 @@ func LogsProjectCommmand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Debug("Starting execution of 'logs' command")
 			var err error
-			var resp *proj.GetLogsOK
+			var resp *proj.GetLogExtsOK
 			var projectName string
 
 			if len(args) > 0 {

--- a/pkg/api/project_handler.go
+++ b/pkg/api/project_handler.go
@@ -187,13 +187,12 @@ func SearchProject(query string) (search.SearchOK, error) {
 	return *response, nil
 }
 
-func LogsProject(projectName string) (*project.GetLogsOK, error) {
+func LogsProject(projectName string) (*project.GetLogExtsOK, error) {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {
 		return nil, err
 	}
-
-	response, err := client.Project.GetLogs(ctx, &project.GetLogsParams{
+	response, err := client.Project.GetLogExts(ctx, &project.GetLogExtsParams{
 		ProjectName: projectName,
 		Context:     ctx,
 	})

--- a/pkg/views/project/logs/view.go
+++ b/pkg/views/project/logs/view.go
@@ -32,7 +32,7 @@ var columns = []table.Column{
 	{Title: "Timestamp", Width: tablelist.WidthL * 2},
 }
 
-func LogsProject(logs []*models.AuditLog) {
+func LogsProject(logs []*models.AuditLogExt) {
 	var rows []table.Row
 	for _, log := range logs {
 		createTime, _ := utils.FormatCreatedTime(log.OpTime.String())


### PR DESCRIPTION
# Summary 

> **This PR fixes #620**

The `harbor project logs` command is updated to use the newer API `/project/{project_name}/auditlog-exts`, instead of using the deprecated API `/project/{project_name}/logs`.

This is done by replacing the [`GetLogs`](https://pkg.go.dev/github.com/goharbor/go-client@v0.213.1/pkg/sdk/v2.0/client/project#Client.GetLogs) with the [`GetLogExts`](https://pkg.go.dev/github.com/goharbor/go-client@v0.213.1/pkg/sdk/v2.0/client/project#Client.GetLogExts) method and the corresponding payload and HTTP status structs.

## Example
 ![Preview](https://vhs.charm.sh/vhs-yZSWLTbIlhR7RP4CObdtV.gif)