### PR TITLE
fix: make comment field optional in user create command

### DIFF
--- a/cmd/harbor/root/user/create.go
+++ b/cmd/harbor/root/user/create.go
@@ -40,7 +40,7 @@ func UserCreateCmd() *cobra.Command {
 				Username: opts.Username,
 			}
 
-			if opts.Email != "" && opts.Realname != "" && opts.Comment != "" && opts.Password != "" && opts.Username != "" {
+			if opts.Email != "" && opts.Realname != "" && opts.Password != "" && opts.Username != "" {
 				err = api.CreateUser(opts)
 			} else {
 				err = createUserView(createView)
@@ -61,7 +61,7 @@ func UserCreateCmd() *cobra.Command {
 	flags := cmd.Flags()
 	flags.StringVarP(&opts.Email, "email", "", "", "Email")
 	flags.StringVarP(&opts.Realname, "realname", "", "", "Realname")
-	flags.StringVarP(&opts.Comment, "comment", "", "", "Comment")
+	flags.StringVarP(&opts.Comment, "comment", "", "", "Comment (optional)")
 	flags.StringVarP(&opts.Password, "password", "", "", "Password")
 	flags.StringVarP(&opts.Username, "username", "", "", "Username")
 

--- a/doc/cli-docs/harbor-user-create.md
+++ b/doc/cli-docs/harbor-user-create.md
@@ -15,7 +15,7 @@ harbor user create [flags]
 ### Options
 
 ```sh
-      --comment string    Comment
+      --comment string    Comment (optional)
       --email string      Email
   -h, --help              help for create
       --password string   Password

--- a/doc/man-docs/man1/harbor-user-create.1
+++ b/doc/man-docs/man1/harbor-user-create.1
@@ -15,7 +15,7 @@ create user
 
 .SH OPTIONS
 \fB--comment\fP=""
-	Comment
+	Comment (optional)
 
 .PP
 \fB--email\fP=""

--- a/pkg/views/user/create/view.go
+++ b/pkg/views/user/create/view.go
@@ -99,7 +99,7 @@ func CreateUserView(createView *CreateView) {
 					return nil
 				}),
 			huh.NewInput().
-				Title("Comment").
+				Title("Comment (optional)").
 				Value(&createView.Comment),
 		),
 	).WithTheme(theme).Run()


### PR DESCRIPTION
Fixes #628 
The `user create` command previously required ALL fields including the optional `comment` field for non-interactive mode. Now users can create accounts with only the required fields