### PR TITLE
fix: correct typos across codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The project's first goal is to reach WebUI parity.
 
 ❌ GC
 
-❌ Job Service   Dashbaord
+❌ Job Service   Dashboard
 
 ❌ Auditlog      Auditlogs dashboard
 
@@ -71,8 +71,7 @@ docker run -ti --rm -v $HOME/.config/harbor-cli/config.yaml:/root/.config/harbor
 ```
 Use the `HARBOR_ENCRYPTION_KEY` container environment variable as a base64-encoded 32-byte key for AES-256 encryption. This securely stores your harbor login password.
 
-If you intend
-to run the CLI as a container,it is advised
+If you intend to run the CLI as a container, it is advised
 to set the following environment variables and to create an alias
 and append the alias to your .zshrc or .bashrc file
 

--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -104,7 +104,7 @@ func ValidateFL(name string) bool {
 	return re.MatchString(name)
 }
 
-// check if the password format is vaild
+// check if the password format is valid
 func ValidatePassword(password string) error {
 	password = strings.TrimSpace(password)
 	if password == "" {
@@ -112,21 +112,21 @@ func ValidatePassword(password string) error {
 	}
 
 	if len(password) < 8 || len(password) > 256 {
-		return errors.New("worong! the password length must be at least 8 characters and at most 256 characters")
+		return errors.New("wrong! the password length must be at least 8 characters and at most 256 characters")
 	}
 	// checking the password has a minimum of one lower case letter
 	if done, _ := regexp.MatchString("([a-z])+", password); !done {
-		return errors.New("worong! the password doesn't have a lowercase letter")
+		return errors.New("wrong! the password doesn't have a lowercase letter")
 	}
 
-	// checking the password has a minimmum of one upper case letter
+	// checking the password has a minimum of one upper case letter
 	if done, _ := regexp.MatchString("([A-Z])+", password); !done {
-		return errors.New("worong! the password doesn't have an upppercase letter")
+		return errors.New("wrong! the password doesn't have an uppercase letter")
 	}
 
 	// checking if the password has a minimum of one digit
 	if done, _ := regexp.Match("([0-9])+", []byte(password)); !done {
-		return errors.New("worong! the password doesn't have a digit number")
+		return errors.New("wrong! the password doesn't have a digit number")
 	}
 
 	return nil

--- a/pkg/views/artifact/tags/create/view.go
+++ b/pkg/views/artifact/tags/create/view.go
@@ -34,7 +34,7 @@ func CreateTagView(tagName *string) {
 					if strings.TrimSpace(str) == "" {
 						return errors.New("tag name cannot be empty or only spaces")
 					}
-					if isVaild := utils.ValidateTagName(str); !isVaild {
+					if isValid := utils.ValidateTagName(str); !isValid {
 						return errors.New("please enter the correct tag name format")
 					}
 					return nil

--- a/pkg/views/registry/create/view.go
+++ b/pkg/views/registry/create/view.go
@@ -77,7 +77,7 @@ func CreateRegistryView(createView *api.CreateRegView) {
 					if strings.TrimSpace(str) == "" {
 						return errors.New("name cannot be empty or only spaces")
 					}
-					if isVaild := utils.ValidateRegistryName(str); !isVaild {
+					if isValid := utils.ValidateRegistryName(str); !isValid {
 						return errors.New("please enter the correct name format")
 					}
 					return nil

--- a/pkg/views/user/create/view.go
+++ b/pkg/views/user/create/view.go
@@ -41,7 +41,7 @@ func CreateUserView(createView *CreateView) {
 					if strings.TrimSpace(str) == "" {
 						return errors.New("user name cannot be empty")
 					}
-					if isVaild := utils.ValidateUserName(str); !isVaild {
+					if isValid := utils.ValidateUserName(str); !isValid {
 						return errors.New("username cannot contain special characters")
 					}
 					return nil
@@ -53,7 +53,7 @@ func CreateUserView(createView *CreateView) {
 					if strings.TrimSpace(str) == "" {
 						return errors.New("email cannot be empty or only spaces")
 					}
-					if isVaild := utils.ValidateEmail(str); !isVaild {
+					if isValid := utils.ValidateEmail(str); !isValid {
 						return errors.New("please enter correct email format")
 					}
 					return nil


### PR DESCRIPTION
Fixes #626 

- Fixed `Dashbaord` → `Dashboard` in README.md
- Fixed `vaild` → `valid` in helper.go comment
- Fixed `worong` → `wrong` in password validation error messages
- Fixed `minimmum` → `minimum` in helper.go comment
- Fixed `upppercase` → `uppercase` in error message
- Fixed `isVaild` → `isValid` variable names in create views
