### PR TITLE
fix: reject negative page-size values in list commands

### DIFF
--- a/cmd/harbor/root/artifact/list.go
+++ b/cmd/harbor/root/artifact/list.go
@@ -43,6 +43,10 @@ Supports pagination, search queries, and sorting using flags.`,
 
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.PageSize < 0 {
+				return fmt.Errorf("page size must be greater than or equal to 0")
+			}
+
 			if opts.PageSize > 100 {
 				return fmt.Errorf("page size should be less than or equal to 100")
 			}

--- a/cmd/harbor/root/instance/list.go
+++ b/cmd/harbor/root/instance/list.go
@@ -14,6 +14,8 @@
 package instance
 
 import (
+	"fmt"
+
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/instance/list"
@@ -33,7 +35,14 @@ filter them using a query string, and sort them in ascending or descending order
 This command provides an easy way to view all instances along with their details.`,
 		Example: `  harbor-cli instance list --page 1 --page-size 10
   harbor-cli instance list --query "name=my-instance" --sort "asc"`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.PageSize < 0 {
+				return fmt.Errorf("page size must be greater than or equal to 0")
+			}
+			if opts.PageSize > 100 {
+				return fmt.Errorf("page size should be less than or equal to 100")
+			}
+
 			instance, err := api.ListInstance(opts)
 
 			if err != nil {
@@ -48,6 +57,7 @@ This command provides an easy way to view all instances along with their details
 			} else {
 				list.ListInstance(instance.Payload)
 			}
+			return nil
 		},
 	}
 

--- a/cmd/harbor/root/labels/list.go
+++ b/cmd/harbor/root/labels/list.go
@@ -39,6 +39,10 @@ func ListLabelCommand() *cobra.Command {
 		Short: "list labels",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.PageSize < 0 {
+				return fmt.Errorf("page size must be greater than or equal to 0")
+			}
+
 			if opts.PageSize > 100 {
 				return fmt.Errorf("page size should be less than or equal to 100")
 			}

--- a/cmd/harbor/root/logs.go
+++ b/cmd/harbor/root/logs.go
@@ -48,6 +48,12 @@ harbor-cli logs --follow --refresh-interval 2s
 
 harbor-cli logs --output-format json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.PageSize < 0 {
+				return fmt.Errorf("page size must be greater than or equal to 0")
+			}
+			if opts.PageSize > 100 {
+				return fmt.Errorf("page size should be less than or equal to 100")
+			}
 			if refreshInterval != "" && !follow {
 				fmt.Println("The --refresh-interval flag is only applicable when using --follow. It will be ignored.")
 			}

--- a/cmd/harbor/root/project/list.go
+++ b/cmd/harbor/root/project/list.go
@@ -45,6 +45,10 @@ func ListProjectCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Debug("Starting project list command")
 
+			if opts.PageSize < 0 {
+				return fmt.Errorf("page size must be greater than or equal to 0")
+			}
+
 			if opts.PageSize > 100 {
 				return fmt.Errorf("page size should be less than or equal to 100")
 			}

--- a/cmd/harbor/root/project/logs.go
+++ b/cmd/harbor/root/project/logs.go
@@ -35,6 +35,13 @@ func LogsProjectCommmand() *cobra.Command {
 		Short: "get project logs",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.PageSize < 0 {
+				return fmt.Errorf("page size must be greater than or equal to 0")
+			}
+			if opts.PageSize > 100 {
+				return fmt.Errorf("page size should be less than or equal to 100")
+			}
+
 			log.Debug("Starting execution of 'logs' command")
 			var err error
 			var resp *proj.GetLogExtsOK

--- a/cmd/harbor/root/project/member/list.go
+++ b/cmd/harbor/root/project/member/list.go
@@ -40,6 +40,13 @@ func ListMemberCommand() *cobra.Command {
 		Example: "  harbor project member list my-project",
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.PageSize < 0 {
+				return fmt.Errorf("page size must be greater than or equal to 0")
+			}
+			if opts.PageSize > 100 {
+				return fmt.Errorf("page size should be less than or equal to 100")
+			}
+
 			var err error
 			if len(args) > 0 {
 				opts.ProjectNameOrID = args[0]

--- a/cmd/harbor/root/project/robot/list.go
+++ b/cmd/harbor/root/project/robot/list.go
@@ -14,6 +14,7 @@
 package robot
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
@@ -69,6 +70,13 @@ Examples:
   harbor-cli project robot list`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.PageSize < 0 {
+				return fmt.Errorf("page size must be greater than or equal to 0")
+			}
+			if opts.PageSize > 100 {
+				return fmt.Errorf("page size should be less than or equal to 100")
+			}
+
 			if len(args) > 0 {
 				project, err := api.GetProject(args[0], false)
 				if err != nil {

--- a/cmd/harbor/root/quota/list.go
+++ b/cmd/harbor/root/quota/list.go
@@ -31,6 +31,11 @@ func ListQuotaCommand() *cobra.Command {
 		Short: "list quotas",
 		Long:  "list quotas specified for each project",
 		Run: func(cmd *cobra.Command, args []string) {
+			if opts.PageSize < 0 {
+				log.Errorf("page size must be greater than or equal to 0")
+				return
+			}
+
 			if opts.PageSize > 100 {
 				log.Errorf("page size should be less than or equal to 100")
 				return

--- a/cmd/harbor/root/registry/list.go
+++ b/cmd/harbor/root/registry/list.go
@@ -33,6 +33,10 @@ func ListRegistryCommand() *cobra.Command {
 		Short: "list registry",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.PageSize < 0 {
+				return fmt.Errorf("page size must be greater than or equal to 0")
+			}
+
 			if opts.PageSize > 100 {
 				return fmt.Errorf("page size should be less than or equal to 100")
 			}

--- a/cmd/harbor/root/replication/executions/list.go
+++ b/cmd/harbor/root/replication/executions/list.go
@@ -50,6 +50,10 @@ func ListCommand() *cobra.Command {
 				rpolicyID = prompt.GetReplicationPolicyFromUser()
 			}
 
+			if opts.PageSize < 0 {
+				return fmt.Errorf("page size must be greater than or equal to 0")
+			}
+
 			if opts.PageSize > 100 {
 				return fmt.Errorf("page size should be less than or equal to 100")
 			}

--- a/cmd/harbor/root/replication/policies/list.go
+++ b/cmd/harbor/root/replication/policies/list.go
@@ -33,6 +33,10 @@ func ListCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Debug("Starting replications list command")
 
+			if opts.PageSize < 0 {
+				return fmt.Errorf("page size must be greater than or equal to 0")
+			}
+
 			if opts.PageSize > 100 {
 				return fmt.Errorf("page size should be less than or equal to 100")
 			}

--- a/cmd/harbor/root/repository/list.go
+++ b/cmd/harbor/root/repository/list.go
@@ -36,6 +36,10 @@ func ListRepositoryCommand() *cobra.Command {
 		Long:    `Get information of all repositories in a project`,
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.PageSize < 0 {
+				return fmt.Errorf("page size must be greater than or equal to 0")
+			}
+
 			if opts.PageSize > 100 {
 				return fmt.Errorf("page size should be less than or equal to 100")
 			}

--- a/cmd/harbor/root/robot/list.go
+++ b/cmd/harbor/root/robot/list.go
@@ -14,6 +14,8 @@
 package robot
 
 import (
+	"fmt"
+
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/robot/list"
@@ -61,7 +63,14 @@ Examples:
   # Get robot details in JSON format
   harbor-cli robot list --output-format json`,
 		Args: cobra.MaximumNArgs(0),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.PageSize < 0 {
+				return fmt.Errorf("page size must be greater than or equal to 0")
+			}
+			if opts.PageSize > 100 {
+				return fmt.Errorf("page size should be less than or equal to 100")
+			}
+
 			robots, err := api.ListRobot(opts)
 			if err != nil {
 				log.Errorf("failed to get robots list: %v", utils.ParseHarborErrorMsg(err))
@@ -76,6 +85,7 @@ Examples:
 			} else {
 				list.ListRobots(robots.Payload)
 			}
+			return nil
 		},
 	}
 

--- a/cmd/harbor/root/schedule/list.go
+++ b/cmd/harbor/root/schedule/list.go
@@ -30,6 +30,10 @@ func ListScheduleCommand() *cobra.Command {
 		Use:   "list",
 		Short: "show all schedule jobs in Harbor",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.PageSize < 0 {
+				return fmt.Errorf("page size must be greater than or equal to 0")
+			}
+
 			if opts.PageSize > 100 {
 				return fmt.Errorf("page size should be less than or equal to 100")
 			}

--- a/cmd/harbor/root/user/list.go
+++ b/cmd/harbor/root/user/list.go
@@ -35,6 +35,10 @@ func UserListCmd() *cobra.Command {
 		Args:    cobra.ExactArgs(0),
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.PageSize < 0 {
+				return fmt.Errorf("page size must be greater than or equal to 0")
+			}
+
 			if opts.PageSize > 100 {
 				return fmt.Errorf("page size should be less than or equal to 100")
 			}


### PR DESCRIPTION
Fixes #627 
Previously, negative page-size values (e.g., `--page-size -1`) were accepted without validation. This fix adds validation to reject negative values.

**Affected commands:**
- `project list`
- `user list`
- `repository list`
- `schedule list`
- `registry list`
- `quota list`
- `replication policies list`
- `replication executions list`
- `artifact list`
- `labels list`
- `instance list`
- `project member list`
- `robot list`
- `project robot list`
- `logs` (not a list command, but it also has the page-size flag.)