### PR TITLE
feat(ci):create sbom generate and attest functions

### DIFF
--- a/.dagger/publishimage.go
+++ b/.dagger/publishimage.go
@@ -342,7 +342,7 @@ func (m *HarborCli) AttestSBOM(
 		"--type", "spdxjson",
 		"--predicate", "/sbom.spdx.json",
 		"--registry-username", registryUsername,
-		"--registry-password", "env://REGISTRY_PASSWORD",
+		"--registry-password", registryPassword,
 		imageAddr,
 		"--timeout", "1m",
 	}).Stdout(ctx)

--- a/.dagger/publishimage.go
+++ b/.dagger/publishimage.go
@@ -336,14 +336,12 @@ func (m *HarborCli) AttestSBOM(
 	}
 
 	// Use cosign attest to create in-toto attestation with SPDX JSON predicate
+	// The registry password is already available as REGISTRY_PASSWORD env var
 	return cosignCtr.WithExec([]string{
-		"cosign", "attest",
-		"--yes",
-		"--type", "spdxjson",
-		"--predicate", "/sbom.spdx.json",
-		"--registry-username", registryUsername,
-		"--registry-password", registryPassword,
-		imageAddr,
-		"--timeout", "1m",
+		"sh", "-c",
+		fmt.Sprintf(
+			"cosign attest --yes --type spdxjson --predicate /sbom.spdx.json --registry-username %s --registry-password $REGISTRY_PASSWORD %s --timeout 1m",
+			registryUsername, imageAddr,
+		),
 	}).Stdout(ctx)
 }

--- a/.dagger/publishimage.go
+++ b/.dagger/publishimage.go
@@ -40,6 +40,29 @@ func (m *HarborCli) PublishImageAndSign(
 	}
 
 	for _, addr := range imageAddrs {
+		// Generate SBOM (SPDX JSON) for the published image
+		sbom := m.GenerateSBOM(
+			ctx,
+			addr, 
+			registryUsername, 
+			registryPassword,
+		);
+
+		// Attest SBOM to the image using Cosign in-toto attestation
+		if _, err := m.AttestSBOM(
+			ctx,
+			sbom,
+			addr,
+			registryUsername,
+			registryPassword,
+			githubToken,
+			actionsIdTokenRequestUrl,
+			actionsIdTokenRequestToken,
+		); err != nil {
+			return "", fmt.Errorf("failed to attest SBOM for image %s: %w", addr, err)
+		}
+		fmt.Printf("Attested SBOM for image: %s\n", addr)
+
 		_, err = m.Sign(
 			ctx,
 			githubToken,
@@ -263,4 +286,64 @@ func getVersion(tags []string) string {
 		}
 	}
 	return "latest"
+}
+
+// GenerateSBOM uses Syft to create an SPDX JSON SBOM for a given image and returns it as a file
+func (m *HarborCli) GenerateSBOM(
+	ctx context.Context,
+	imageAddr string,
+	registryUsername string,
+	registryPassword *dagger.Secret,
+) *dagger.File {
+	syftCtr := dag.Container().
+		From("anchore/syft:latest").
+		WithSecretVariable("SYFT_REGISTRY_AUTH_PASSWORD", registryPassword).
+		WithEnvVariable("SYFT_REGISTRY_AUTH_USERNAME", registryUsername).
+		// Output SPDX JSON to a known path
+		WithExec([]string{"syft", imageAddr, "-o", "spdx-json=/sbom.spdx.json"})
+
+	return syftCtr.File("/sbom.spdx.json")
+}
+
+// AttestSBOM attaches an in-toto attestation (SBOM predicate) to the image using Cosign
+func (m *HarborCli) AttestSBOM(
+	ctx context.Context,
+	sbomFile *dagger.File,
+	imageAddr string,
+	registryUsername string,
+	registryPassword *dagger.Secret,
+	// +optional
+	githubToken *dagger.Secret,
+	// +optional
+	actionsIdTokenRequestUrl *dagger.Secret,
+	// +optional
+	actionsIdTokenRequestToken *dagger.Secret,
+) (string, error) {
+	cosignCtr := dag.Container().
+		From("cgr.dev/chainguard/cosign").
+		WithMountedFile("/sbom.spdx.json", sbomFile).
+		WithSecretVariable("REGISTRY_PASSWORD", registryPassword)
+
+	// If githubToken is provided, configure OIDC for keyless signing
+	if githubToken != nil {
+		if actionsIdTokenRequestUrl == nil || actionsIdTokenRequestToken == nil {
+			return "", fmt.Errorf("actionsIdTokenRequestUrl (exist=%v) and actionsIdTokenRequestToken (exist=%t) must be provided when githubToken is provided", actionsIdTokenRequestUrl != nil, actionsIdTokenRequestToken != nil)
+		}
+		cosignCtr = cosignCtr.
+			WithSecretVariable("GITHUB_TOKEN", githubToken).
+			WithSecretVariable("ACTIONS_ID_TOKEN_REQUEST_URL", actionsIdTokenRequestUrl).
+			WithSecretVariable("ACTIONS_ID_TOKEN_REQUEST_TOKEN", actionsIdTokenRequestToken)
+	}
+
+	// Use cosign attest to create in-toto attestation with SPDX JSON predicate
+	return cosignCtr.WithExec([]string{
+		"cosign", "attest",
+		"--yes",
+		"--type", "spdxjson",
+		"--predicate", "/sbom.spdx.json",
+		"--registry-username", registryUsername,
+		"--registry-password", "env://REGISTRY_PASSWORD",
+		imageAddr,
+		"--timeout", "1m",
+	}).Stdout(ctx)
 }


### PR DESCRIPTION
# Overview

This pr fixes #229 
The github actions ci is modified to 
1. Generate the sbom of the image using syft
2. Attest the sbom using in-toto attestation done using cosign attestations

- Dagger functions are created for each step which can be run indivisually as well. 

# Verifications
- SBOM generation : 
<img width="2512" height="509" alt="image" src="https://github.com/user-attachments/assets/5346bafb-989e-4435-9a43-f94c128df3d5" />

This show that the sbom is successfully generating using the syft command, and we can see the generated sbom in the `sbom.spdx.json` file

- Cosign attestation of the generated sbom for the image : 
<img width="2517" height="1131" alt="image" src="https://github.com/user-attachments/assets/c51dcc90-3747-4e9d-abe9-f6e602c45655" />


This shows that the cosign command used to attest the sbom to the image is successful. 

In the CI, we use the `githubToken` instead of verification using OTP, which is taken care of in the implementation