### PR TITLE
fix: add missing error returns in command handlers

### DIFF
--- a/cmd/harbor/root/artifact/delete.go
+++ b/cmd/harbor/root/artifact/delete.go
@@ -19,7 +19,6 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -39,7 +38,7 @@ func DeleteArtifactCommand() *cobra.Command {
 			} else {
 				projectName, err = prompt.GetProjectNameFromUser()
 				if err != nil {
-					log.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
+					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
 				}
 				repoName = prompt.GetRepoNameFromUser(projectName)
 				reference = prompt.GetReferenceFromUser(repoName, projectName)

--- a/cmd/harbor/root/artifact/scan.go
+++ b/cmd/harbor/root/artifact/scan.go
@@ -19,7 +19,6 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -79,20 +78,19 @@ func StopScanArtifactCommand() *cobra.Command {
 		Short:   "Stop a scan of an artifact",
 		Long:    `Stop a scan of an artifact in Harbor Repository`,
 		Example: `harbor artifact scan stop <project>/<repository>/<reference>`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			var projectName, repoName, reference string
 
 			if len(args) > 0 {
 				projectName, repoName, reference, err = utils.ParseProjectRepoReference(args[0])
 				if err != nil {
-					log.Errorf("failed to parse project/repo/reference: %v", err)
+					return fmt.Errorf("failed to parse project/repo/reference: %v", err)
 				}
 			} else {
-				var projectName string
 				projectName, err = prompt.GetProjectNameFromUser()
 				if err != nil {
-					log.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
+					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
 				}
 				repoName = prompt.GetRepoNameFromUser(projectName)
 				reference = prompt.GetReferenceFromUser(repoName, projectName)
@@ -100,8 +98,9 @@ func StopScanArtifactCommand() *cobra.Command {
 
 			err = api.StopScanArtifact(projectName, repoName, reference)
 			if err != nil {
-				log.Errorf("failed to stop scan of artifact: %v", err)
+				return fmt.Errorf("failed to stop scan of artifact: %v", err)
 			}
+			return nil
 		},
 	}
 	return cmd

--- a/cmd/harbor/root/artifact/tags.go
+++ b/cmd/harbor/root/artifact/tags.go
@@ -14,13 +14,14 @@
 package artifact
 
 import (
+	"fmt"
+
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/artifact"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/artifact/tags/create"
 	"github.com/goharbor/harbor-cli/pkg/views/artifact/tags/list"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -46,20 +47,20 @@ func CreateTagsCmd() *cobra.Command {
 		Use:     "create",
 		Short:   "Create a tag of an artifact",
 		Example: `harbor artifact tags create <project>/<repository>/<reference> <tag>`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			var projectName, repoName, reference string
 			var tagName string
 			if len(args) > 0 {
 				projectName, repoName, reference, err = utils.ParseProjectRepoReference(args[0])
 				if err != nil {
-					log.Errorf("failed to parse project/repo/reference: %v", err)
+					return fmt.Errorf("failed to parse project/repo/reference: %v", err)
 				}
 				tagName = args[1]
 			} else {
 				projectName, err = prompt.GetProjectNameFromUser()
 				if err != nil {
-					log.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
+					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
 				}
 				repoName = prompt.GetRepoNameFromUser(projectName)
 				reference = prompt.GetReferenceFromUser(repoName, projectName)
@@ -67,8 +68,9 @@ func CreateTagsCmd() *cobra.Command {
 			}
 			err = api.CreateTag(projectName, repoName, reference, tagName)
 			if err != nil {
-				log.Errorf("failed to create tag: %v", err)
+				return fmt.Errorf("failed to create tag: %v", err)
 			}
+			return nil
 		},
 	}
 
@@ -80,7 +82,7 @@ func ListTagsCmd() *cobra.Command {
 		Use:     "list",
 		Short:   "List tags of an artifact",
 		Example: `harbor artifact tags list <project>/<repository>/<reference>`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			var tags *artifact.ListTagsOK
 			var projectName, repoName, reference string
@@ -88,16 +90,16 @@ func ListTagsCmd() *cobra.Command {
 			if len(args) > 0 {
 				projectName, repoName, reference, err = utils.ParseProjectRepoReference(args[0])
 				if err != nil {
-					log.Errorf("failed to parse project/repo/reference: %v", err)
+					return fmt.Errorf("failed to parse project/repo/reference: %v", err)
 				}
 			} else {
 				projectName, err = prompt.GetProjectNameFromUser()
 				if err != nil {
-					log.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
+					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
 				}
 				repoName = prompt.GetRepoNameFromUser(projectName)
 				if repoName == "" {
-					return
+					return nil
 				}
 				reference = prompt.GetReferenceFromUser(repoName, projectName)
 			}
@@ -105,20 +107,19 @@ func ListTagsCmd() *cobra.Command {
 			tags, err = api.ListTags(projectName, repoName, reference)
 
 			if err != nil {
-				log.Errorf("failed to list tags: %v", err)
-				return
+				return fmt.Errorf("failed to list tags: %v", err)
 			}
 
 			FormatFlag := viper.GetString("output-format")
 			if FormatFlag != "" {
 				err = utils.PrintFormat(tags, FormatFlag)
 				if err != nil {
-					log.Error(err)
-					return
+					return err
 				}
 			} else {
 				list.ListTags(tags.Payload)
 			}
+			return nil
 		},
 	}
 
@@ -130,20 +131,20 @@ func DeleteTagsCmd() *cobra.Command {
 		Use:     "delete",
 		Short:   "Delete a tag of an artifact",
 		Example: `harbor artifact tags delete <project>/<repository>/<reference> <tag>`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			var projectName, repoName, reference string
 			var tagName string
 			if len(args) > 0 {
 				projectName, repoName, reference, err = utils.ParseProjectRepoReference(args[0])
 				if err != nil {
-					log.Errorf("failed to parse project/repo/reference: %v", err)
+					return fmt.Errorf("failed to parse project/repo/reference: %v", err)
 				}
 				tagName = args[1]
 			} else {
 				projectName, err = prompt.GetProjectNameFromUser()
 				if err != nil {
-					log.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
+					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
 				}
 				repoName = prompt.GetRepoNameFromUser(projectName)
 				reference = prompt.GetReferenceFromUser(repoName, projectName)
@@ -151,8 +152,9 @@ func DeleteTagsCmd() *cobra.Command {
 			}
 			err = api.DeleteTag(projectName, repoName, reference, tagName)
 			if err != nil {
-				log.Errorf("failed to delete tag: %v", err)
+				return fmt.Errorf("failed to delete tag: %v", err)
 			}
+			return nil
 		},
 	}
 

--- a/cmd/harbor/root/artifact/view.go
+++ b/cmd/harbor/root/artifact/view.go
@@ -14,12 +14,13 @@
 package artifact
 
 import (
+	"fmt"
+
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/artifact"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/artifact/view"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -30,7 +31,7 @@ func ViewArtifactCommmand() *cobra.Command {
 		Short:   "Get information of an artifact",
 		Long:    `Get information of an artifact`,
 		Example: `harbor artifact view <project>/<repository>:<tag> OR harbor artifact view <project>/<repository>@<digest>`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			var projectName, repoName, reference string
 			var artifact *artifact.GetArtifactOK
@@ -38,13 +39,12 @@ func ViewArtifactCommmand() *cobra.Command {
 			if len(args) > 0 {
 				projectName, repoName, reference, err = utils.ParseProjectRepoReference(args[0])
 				if err != nil {
-					log.Errorf("failed to parse project/repo/reference: %v", err)
+					return fmt.Errorf("failed to parse project/repo/reference: %v", err)
 				}
 			} else {
 				projectName, err = prompt.GetProjectNameFromUser()
 				if err != nil {
-					log.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
-					return
+					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
 				}
 				repoName = prompt.GetRepoNameFromUser(projectName)
 				reference = prompt.GetReferenceFromUser(repoName, projectName)
@@ -52,29 +52,27 @@ func ViewArtifactCommmand() *cobra.Command {
 
 			if reference == "" {
 				if len(args) > 0 {
-					log.Errorf("Invalid artifact reference format: %s", args[0])
-				} else {
-					log.Error("Invalid artifact reference format: no arguments provided")
+					return fmt.Errorf("invalid artifact reference format: %s", args[0])
 				}
+				return fmt.Errorf("invalid artifact reference format: no arguments provided")
 			}
 
 			artifact, err = api.ViewArtifact(projectName, repoName, reference, false)
 
 			if err != nil {
-				log.Errorf("failed to get info of an artifact: %v", err)
-				return
+				return fmt.Errorf("failed to get info of an artifact: %v", err)
 			}
 
 			FormatFlag := viper.GetString("output-format")
 			if FormatFlag != "" {
 				err = utils.PrintFormat(artifact, FormatFlag)
 				if err != nil {
-					log.Error(err)
-					return
+					return err
 				}
 			} else {
 				view.ViewArtifact(artifact.Payload)
 			}
+			return nil
 		},
 	}
 

--- a/cmd/harbor/root/repository/delete.go
+++ b/cmd/harbor/root/repository/delete.go
@@ -14,10 +14,11 @@
 package repository
 
 import (
+	"fmt"
+
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -27,27 +28,27 @@ func RepoDeleteCmd() *cobra.Command {
 		Short:   "Delete a repository",
 		Example: `  harbor repository delete [project_name]/[repository_name]`,
 		Long:    `Delete a repository within a project in Harbor`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			var projectName string
 			var repoName string
 			if len(args) > 0 {
 				projectName, repoName, err = utils.ParseProjectRepo(args[0])
 				if err != nil {
-					log.Errorf("failed to parse project/repo: %v", err)
-					return
+					return fmt.Errorf("failed to parse project/repo: %v", err)
 				}
 			} else {
 				projectName, err = prompt.GetProjectNameFromUser()
 				if err != nil {
-					log.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
+					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
 				}
 				repoName = prompt.GetRepoNameFromUser(projectName)
 			}
 			err = api.RepoDelete(projectName, repoName, false)
 			if err != nil {
-				log.Errorf("failed to delete repository: %v", err)
+				return fmt.Errorf("failed to delete repository: %v", err)
 			}
+			return nil
 		},
 	}
 	return cmd


### PR DESCRIPTION
fixed #455 
This pull request fixes a recurring issue in the CLI where errors were being logged but execution continued as if nothing went wrong. In several commands, log.Errorf() was used without returning the error, which caused the CLI to proceed with invalid or empty values and fail silently.

To address this, the PR replaces error logging with explicit error returns using fmt.Errorf, ensuring that failures immediately stop execution and are correctly surfaced to the user. To support this flow, affected commands were updated to use Cobra’s RunE instead of Run, which is the recommended pattern when commands can fail.

As part of this cleanup, the unused logrus imports were removed from the affected files, since error reporting is now handled through returned errors rather than logging.

Overall, this change makes CLI behavior more predictable, prevents silent failures, and aligns error handling across commands with standard Cobra and Go best practices.