### PR TITLE
fix: return errors in user elevate command to prevent silent failures

### DIFF
--- a/cmd/harbor/main.go
+++ b/cmd/harbor/main.go
@@ -14,14 +14,15 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/goharbor/harbor-cli/cmd/harbor/root"
 )
 
 func main() {
-	err := root.RootCmd().Execute()
-	if err != nil {
+	if err := root.RootCmd().Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
### What this PR does

This PR fixes improper error handling in the `user elevate` command.

Previously, errors were logged using `log.Errorf` without returning, causing the CLI to continue execution with invalid state and exit successfully even after critical failures.

The command now uses Cobra’s `RunE` pattern and returns errors immediately, ensuring correct exit behavior and preventing silent failures.

### Related issue
Fixes #655
