### PR TITLE
Validate refresh-interval to be greater than 0

### DIFF
--- a/cmd/harbor/root/logs.go
+++ b/cmd/harbor/root/logs.go
@@ -60,6 +60,10 @@ harbor-cli logs --output-format json`,
 					if err != nil {
 						log.Fatalf("invalid refresh interval: %v", err)
 					}
+
+					if interval <= 0 {
+						log.Fatalf("refresh-interval must be greater than 0")
+					}
 				}
 				followLogs(opts, interval)
 			} else {


### PR DESCRIPTION
### What this PR does,
- Adds validation to ensure `--refresh-interval` is greater than 0
- Prevents invalid values (like `0` or negative durations) that could cause tight loops

### Related issue
- Fixes #668
