### PR TITLE
feat(user): add confirm password field to user create command

### DIFF
--- a/pkg/views/user/create/view.go
+++ b/pkg/views/user/create/view.go
@@ -23,11 +23,12 @@ import (
 )
 
 type CreateView struct {
-	Username string
-	Email    string
-	Realname string
-	Comment  string
-	Password string
+	Username        string
+	Email           string
+	Realname        string
+	Comment         string
+	Password        string
+	ConfirmPassword string
 }
 
 func CreateUserView(createView *CreateView) {
@@ -81,6 +82,19 @@ func CreateUserView(createView *CreateView) {
 					}
 					if err := utils.ValidatePassword(str); err != nil {
 						return err
+					}
+					return nil
+				}),
+			huh.NewInput().
+				Title("Confirm Password").
+				EchoMode(huh.EchoModePassword).
+				Value(&createView.ConfirmPassword).
+				Validate(func(str string) error {
+					if strings.TrimSpace(str) == "" {
+						return errors.New("confirm password cannot be empty")
+					}
+					if str != createView.Password {
+						return errors.New("passwords do not match")
 					}
 					return nil
 				}),


### PR DESCRIPTION

<img width="558" height="321" alt="image" src="https://github.com/user-attachments/assets/677d0a46-69c3-442f-b3db-66f96533da00" />

Fixes #673 
 1. Confirm password field added to the user create command 
 2. the comment field optional indicator is handled in #629 
 3. For the toggle,
views use `charmbracelet/huh` library. The `EchoMode` is set at form creation time and cannot be dynamically toggled during input.