### PR TITLE
fix: pluralise time units in created time output

### DIFF
--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -25,6 +25,13 @@ import (
 	"unicode"
 )
 
+func pluralise(value int, unit string) string {
+	if value == 1 {
+		return fmt.Sprintf("%d %s ago", value, unit)
+	}
+	return fmt.Sprintf("%d %ss ago", value, unit)
+}
+
 func FormatCreatedTime(timestamp string) (string, error) {
 	t, err := time.Parse(time.RFC3339Nano, timestamp)
 	if err != nil {
@@ -38,11 +45,11 @@ func FormatCreatedTime(timestamp string) (string, error) {
 	days := int(duration.Hours() / 24)
 
 	if minutes < 60 {
-		return fmt.Sprintf("%d minute ago", minutes), nil
+		return pluralise(minutes, "minute"), nil
 	} else if hours < 24 {
-		return fmt.Sprintf("%d hour ago", hours), nil
+		return pluralise(hours, "hour"), nil
 	} else {
-		return fmt.Sprintf("%d day ago", days), nil
+		return pluralise(days, "day"), nil
 	}
 }
 


### PR DESCRIPTION
- Fixes  #709 
**Overview**
This PR improves the UX of by fixing the pluralisation of time units in the Created Time output (for example, displaying “2 hours ago” instead of “2 hour ago”). 

**Changes**
Before: 
<img width="1478" height="422" alt="before" src="https://github.com/user-attachments/assets/29827f97-d31e-4edf-bc32-97beb28ea0a3" />
After:
<img width="1488" height="424" alt="after" src="https://github.com/user-attachments/assets/502697cc-967b-4f90-bf4b-7d1ef0c13f63" />

- Updated time formatting logic to correctly pluralise time units (minute, hour, day) based on their values.
- Verified the behaviour by building and running the Harbor CLI locally and checking the updated output.

**Note**
This is a small UX improvement so i addressed it directly in a PR rather than opening a separate issue first.
