### PR TITLE
tests: Add unit tests for project create command

### DIFF
--- a/cmd/harbor/root/project/create.go
+++ b/cmd/harbor/root/project/create.go
@@ -39,7 +39,7 @@ func (d *DefaultProjectCreator) FillProjectView(createView *create.CreateView) e
 }
 
 func CreateProject(w io.Writer, projectCreator ProjectCreator, opts *create.CreateView, args []string) error {
-	var ProjectName string
+	var projectName string
 	var createView *create.CreateView
 	if len(args) > 0 {
 		opts.ProjectName = args[0]
@@ -71,11 +71,11 @@ func CreateProject(w io.Writer, projectCreator ProjectCreator, opts *create.Crea
 		createView = opts
 	}
 
-	ProjectName = createView.ProjectName
+	projectName = createView.ProjectName
 	if err := projectCreator.CreateProject(*createView); err != nil {
 		return fmt.Errorf("failed to create project: %v", utils.ParseHarborErrorMsg(err))
 	}
-	fmt.Fprintf(w, "Project '%s' created successfully\n", ProjectName)
+	fmt.Fprintf(w, "Project '%s' created successfully\n", projectName)
 	return nil
 }
 // CreateProjectCommand creates a new `harbor create project` command

--- a/cmd/harbor/root/project/create.go
+++ b/cmd/harbor/root/project/create.go
@@ -44,7 +44,7 @@ func CreateProject(w io.Writer, projectCreator ProjectCreator, opts *create.Crea
 	if len(args) > 0 {
 		opts.ProjectName = args[0]
 	}
-	
+
 	if opts.ProxyCache && opts.RegistryID == "" {
 		return fmt.Errorf("proxy cache selected but no registry ID provided. Use --registry-id")
 	}
@@ -52,7 +52,7 @@ func CreateProject(w io.Writer, projectCreator ProjectCreator, opts *create.Crea
 	if !opts.ProxyCache && opts.RegistryID != "" {
 		return fmt.Errorf("registry ID should only be provided when proxy-cache is enabled")
 	}
-	
+
 	if opts.ProjectName == "" || opts.StorageLimit == "" {
 		log.Debug("Switching to interactive view...")
 		createView = &create.CreateView{
@@ -78,6 +78,7 @@ func CreateProject(w io.Writer, projectCreator ProjectCreator, opts *create.Crea
 	fmt.Fprintf(w, "Project '%s' created successfully\n", projectName)
 	return nil
 }
+
 // CreateProjectCommand creates a new `harbor create project` command
 func CreateProjectCommand() *cobra.Command {
 	opts := &create.CreateView{}

--- a/cmd/harbor/root/project/create.go
+++ b/cmd/harbor/root/project/create.go
@@ -65,7 +65,7 @@ func CreateProject(w io.Writer, projectCreator ProjectCreator, opts *create.Crea
 
 		err := projectCreator.FillProjectView(createView)
 		if err != nil {
-			return fmt.Errorf("Failed to get the required params to create project:%w", err)
+			return fmt.Errorf("failed to get the required params to create project: %w", err)
 		}
 	} else {
 		createView = opts

--- a/cmd/harbor/root/project/create.go
+++ b/cmd/harbor/root/project/create.go
@@ -25,7 +25,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// CreateProjectCommand creates a new `harbor create project` command
 type ProjectCreator interface {
 	CreateProject(opts create.CreateView) error
 	FillProjectView(createView *create.CreateView) error
@@ -45,7 +44,7 @@ func CreateProject(w io.Writer, projectCreator ProjectCreator, opts *create.Crea
 	if len(args) > 0 {
 		opts.ProjectName = args[0]
 	}
-
+	
 	if opts.ProxyCache && opts.RegistryID == "" {
 		return fmt.Errorf("proxy cache selected but no registry ID provided. Use --registry-id")
 	}
@@ -53,7 +52,7 @@ func CreateProject(w io.Writer, projectCreator ProjectCreator, opts *create.Crea
 	if !opts.ProxyCache && opts.RegistryID != "" {
 		return fmt.Errorf("registry ID should only be provided when proxy-cache is enabled")
 	}
-
+	
 	if opts.ProjectName == "" || opts.StorageLimit == "" {
 		log.Debug("Switching to interactive view...")
 		createView = &create.CreateView{
@@ -79,6 +78,7 @@ func CreateProject(w io.Writer, projectCreator ProjectCreator, opts *create.Crea
 	fmt.Fprintf(w, "Project '%s' created successfully\n", ProjectName)
 	return nil
 }
+// CreateProjectCommand creates a new `harbor create project` command
 func CreateProjectCommand() *cobra.Command {
 	opts := &create.CreateView{}
 

--- a/cmd/harbor/root/project/create.go
+++ b/cmd/harbor/root/project/create.go
@@ -64,7 +64,7 @@ func CreateProject(w io.Writer, projectCreator ProjectCreator, opts *create.Crea
 			ProxyCache:   opts.ProxyCache,
 		}
 
-		err := fillCreateView(projectCreator, createView)
+		err := projectCreator.FillProjectView(createView)
 		if err != nil {
 			return fmt.Errorf("Failed to get the required params to create project:%w", err)
 		}
@@ -97,17 +97,4 @@ func CreateProjectCommand() *cobra.Command {
 	flags.BoolVarP(&opts.ProxyCache, "proxy-cache", "", false, "Whether the project is a proxy cache project")
 
 	return cmd
-}
-
-func fillCreateView(projectCreator ProjectCreator, createView *create.CreateView) error {
-	if createView == nil {
-		createView = &create.CreateView{
-			ProjectName:  "",
-			Public:       false,
-			RegistryID:   "",
-			StorageLimit: "-1",
-		}
-	}
-	err := projectCreator.FillProjectView(createView)
-	return err
 }

--- a/cmd/harbor/root/project/create.go
+++ b/cmd/harbor/root/project/create.go
@@ -15,8 +15,6 @@ package project
 
 import (
 	"fmt"
-	"io"
-	"os"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
@@ -25,34 +23,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type ProjectCreator interface {
-	CreateProject(opts create.CreateView) error
-	FillProjectView(createView *create.CreateView) error
-}
-type DefaultProjectCreator struct{}
+var fillProjectView = create.CreateProjectView
 
-func (d *DefaultProjectCreator) CreateProject(opts create.CreateView) error {
-	return api.CreateProject(opts)
-}
-func (d *DefaultProjectCreator) FillProjectView(createView *create.CreateView) error {
-	return create.CreateProjectView(createView)
-}
-
-func CreateProject(w io.Writer, projectCreator ProjectCreator, opts *create.CreateView, args []string) error {
-	var projectName string
-	var createView *create.CreateView
+func buildCreateView(opts *create.CreateView, args []string) (*create.CreateView, error) {
 	if len(args) > 0 {
 		opts.ProjectName = args[0]
 	}
 
 	if opts.ProxyCache && opts.RegistryID == "" {
-		return fmt.Errorf("proxy cache selected but no registry ID provided. Use --registry-id")
+		return nil, fmt.Errorf("proxy cache selected but no registry ID provided. Use --registry-id")
 	}
 
 	if !opts.ProxyCache && opts.RegistryID != "" {
-		return fmt.Errorf("registry ID should only be provided when proxy-cache is enabled")
+		return nil, fmt.Errorf("registry ID should only be provided when proxy-cache is enabled")
 	}
 
+	var createView *create.CreateView
 	if opts.ProjectName == "" || opts.StorageLimit == "" {
 		log.Debug("Switching to interactive view...")
 		createView = &create.CreateView{
@@ -63,32 +49,40 @@ func CreateProject(w io.Writer, projectCreator ProjectCreator, opts *create.Crea
 			ProxyCache:   opts.ProxyCache,
 		}
 
-		err := projectCreator.FillProjectView(createView)
+		err := fillProjectView(createView)
 		if err != nil {
-			return fmt.Errorf("failed to get the required params to create project: %w", err)
+			return nil, fmt.Errorf("failed to get the required params to create project: %w", err)
 		}
 	} else {
 		createView = opts
 	}
 
-	projectName = createView.ProjectName
-	if err := projectCreator.CreateProject(*createView); err != nil {
+	return createView, nil
+}
+
+func createProject(createProjectAPI func(opts create.CreateView) error, opts *create.CreateView, args []string) error {
+	createView, err := buildCreateView(opts, args)
+	if err != nil {
+		return err
+	}
+
+	if err := createProjectAPI(*createView); err != nil {
 		return fmt.Errorf("failed to create project: %v", utils.ParseHarborErrorMsg(err))
 	}
-	fmt.Fprintf(w, "Project '%s' created successfully\n", projectName)
+	fmt.Printf("project '%s' created successfully\n", createView.ProjectName)
 	return nil
 }
 
 // CreateProjectCommand creates a new `harbor create project` command
 func CreateProjectCommand() *cobra.Command {
 	opts := &create.CreateView{}
-
+	createProjectAPI := api.CreateProject
 	cmd := &cobra.Command{
 		Use:   "create [project name]",
 		Short: "create project",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return CreateProject(os.Stdout, &DefaultProjectCreator{}, opts, args)
+			return createProject(createProjectAPI, opts, args)
 		}}
 
 	flags := cmd.Flags()

--- a/cmd/harbor/root/project/create_test.go
+++ b/cmd/harbor/root/project/create_test.go
@@ -1,0 +1,330 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package project
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/goharbor/harbor-cli/pkg/views/project/create"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockProjectCreator struct {
+	projectName  map[string]struct{}
+	errInFilling bool
+}
+
+// FillProjectView simulates a user filling the project details through the TUI
+func (m *mockProjectCreator) FillProjectView(createView *create.CreateView) error {
+	if m.errInFilling {
+		return fmt.Errorf("unexpected error while filling the project view")
+	}
+	randomProjectName := "testProject999"
+	createView.ProjectName = randomProjectName
+	createView.StorageLimit = "-1"
+	return nil
+}
+func (m *mockProjectCreator) CreateProject(opts create.CreateView) error {
+	if _, found := m.projectName[opts.ProjectName]; found {
+		return fmt.Errorf("project with same name already exists")
+	}
+	m.projectName[opts.ProjectName] = struct{}{}
+	return nil
+}
+func TestFillCreateView(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        *create.CreateView
+		errInFilling bool
+		expectError  bool
+		expectName   string
+		expectLimit  string
+	}{
+		{
+			name:        "nil createView gets defaults then filled",
+			input:       nil,
+			expectName:  "testProject999",
+			expectLimit: "-1",
+		},
+		{
+			name: "empty createView gets filled",
+			input: &create.CreateView{
+				ProjectName:  "",
+				StorageLimit: "",
+			},
+			expectName:  "testProject999",
+			expectLimit: "-1",
+		},
+		{
+			name:         "error in FillProjectView propagates",
+			input:        &create.CreateView{},
+			errInFilling: true,
+			expectError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockProjectCreator{
+				projectName:  make(map[string]struct{}),
+				errInFilling: tt.errInFilling,
+			}
+
+			err := fillCreateView(mock, tt.input)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				if tt.input != nil {
+					assert.Equal(t, tt.expectName, tt.input.ProjectName)
+					assert.Equal(t, tt.expectLimit, tt.input.StorageLimit)
+				}
+			}
+		})
+	}
+}
+func TestCreateProject(t *testing.T) {
+	projectsAreEqual := func(u1, u2 []*create.CreateView) bool {
+		if len(u1) != len(u2) {
+			return false
+		}
+		mp := make(map[string]int)
+		for _, proj := range u1 {
+			mp[proj.ProjectName]++
+		}
+		for _, proj := range u2 {
+			mp[proj.ProjectName]--
+		}
+		for _, val := range mp {
+			if val != 0 {
+				return false
+			}
+		}
+		return true
+	}
+
+	type input struct {
+		opts *create.CreateView
+		args []string
+	}
+	tests := []struct {
+		name             string
+		setup            func() ([]input, *mockProjectCreator)
+		expectedErr      string
+		expectedProjects []*create.CreateView
+	}{
+		{
+			name: "successfully create project with all flags",
+			setup: func() ([]input, *mockProjectCreator) {
+				return []input{
+					{
+						opts: &create.CreateView{
+							Public:       true,
+							StorageLimit: "100",
+						},
+						args: []string{"my-project"},
+					},
+				}, &mockProjectCreator{projectName: make(map[string]struct{})}
+			},
+			expectedProjects: []*create.CreateView{
+				{ProjectName: "my-project"},
+			},
+		},
+		{
+			name: "missing fields triggers interactive view",
+			setup: func() ([]input, *mockProjectCreator) {
+				return []input{
+					{
+						opts: &create.CreateView{},
+					},
+				}, &mockProjectCreator{projectName: make(map[string]struct{})}
+			},
+			expectedProjects: []*create.CreateView{
+				{ProjectName: "testProject999"},
+			},
+		},
+		{
+			name: "project name from args with empty storage triggers interactive view",
+			setup: func() ([]input, *mockProjectCreator) {
+				return []input{
+					{
+						opts: &create.CreateView{},
+						args: []string{"arg-project"},
+					},
+				}, &mockProjectCreator{projectName: make(map[string]struct{})}
+			},
+			expectedProjects: []*create.CreateView{
+				{ProjectName: "testProject999"},
+			},
+		},
+		{
+			name: "proxy cache without registry id returns error",
+			setup: func() ([]input, *mockProjectCreator) {
+				return []input{
+					{
+						opts: &create.CreateView{
+							StorageLimit: "100",
+							ProxyCache:   true,
+						},
+						args: []string{"proxy-project"},
+					},
+				}, &mockProjectCreator{projectName: make(map[string]struct{})}
+			},
+			expectedErr:      "proxy cache selected but no registry ID provided",
+			expectedProjects: []*create.CreateView{},
+		},
+		{
+			name: "registry id without proxy cache returns error",
+			setup: func() ([]input, *mockProjectCreator) {
+				return []input{
+					{
+						opts: &create.CreateView{
+							StorageLimit: "100",
+							RegistryID:   "5",
+						},
+						args: []string{"bad-config"},
+					},
+				}, &mockProjectCreator{projectName: make(map[string]struct{})}
+			},
+			expectedErr:      "registry ID should only be provided when proxy-cache is enabled",
+			expectedProjects: []*create.CreateView{},
+		},
+		{
+			name: "proxy cache with registry id succeeds",
+			setup: func() ([]input, *mockProjectCreator) {
+				return []input{
+					{
+						opts: &create.CreateView{
+							StorageLimit: "200",
+							ProxyCache:   true,
+							RegistryID:   "10",
+						},
+						args: []string{"cache-project"},
+					},
+				}, &mockProjectCreator{projectName: make(map[string]struct{})}
+			},
+			expectedProjects: []*create.CreateView{
+				{ProjectName: "cache-project"},
+			},
+		},
+		{
+			name: "duplicate project name fails second create",
+			setup: func() ([]input, *mockProjectCreator) {
+				return []input{
+					{opts: &create.CreateView{StorageLimit: "100"}, args: []string{"dup"}},
+					{opts: &create.CreateView{StorageLimit: "100"}, args: []string{"dup"}},
+				}, &mockProjectCreator{projectName: make(map[string]struct{})}
+			},
+			expectedErr: "failed to create project",
+			expectedProjects: []*create.CreateView{
+				{ProjectName: "dup"},
+			},
+		},
+		{
+			name: "create multiple projects",
+			setup: func() ([]input, *mockProjectCreator) {
+				return []input{
+					{opts: &create.CreateView{StorageLimit: "10"}, args: []string{"proj-a"}},
+					{opts: &create.CreateView{StorageLimit: "20"}, args: []string{"proj-b"}},
+					{opts: &create.CreateView{StorageLimit: "30"}, args: []string{"proj-c"}},
+				}, &mockProjectCreator{projectName: make(map[string]struct{})}
+			},
+			expectedProjects: []*create.CreateView{
+				{ProjectName: "proj-a"},
+				{ProjectName: "proj-b"},
+				{ProjectName: "proj-c"},
+			},
+		},
+		{
+			name: "interactive view error propagates",
+			setup: func() ([]input, *mockProjectCreator) {
+				return []input{
+						{opts: &create.CreateView{}},
+					}, &mockProjectCreator{
+						projectName:  make(map[string]struct{}),
+						errInFilling: true,
+					}
+			},
+			expectedErr:      "Failed to get the required params to create project",
+			expectedProjects: []*create.CreateView{},
+		},
+		{
+			name: "no projects to create",
+			setup: func() ([]input, *mockProjectCreator) {
+				return []input{}, &mockProjectCreator{projectName: make(map[string]struct{})}
+			},
+			expectedProjects: []*create.CreateView{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inputs, m := tt.setup()
+			var lastErr error
+			for _, in := range inputs {
+				var buf bytes.Buffer
+				err := CreateProject(&buf, m, in.opts, in.args)
+				if err != nil {
+					lastErr = err
+				}
+			}
+
+			if tt.expectedErr != "" {
+				assert.Error(t, lastErr)
+				assert.Contains(t, lastErr.Error(), tt.expectedErr)
+			} else {
+				assert.NoError(t, lastErr)
+			}
+
+			// Build the list of created projects from the mock's map
+			var created []*create.CreateView
+			for name := range m.projectName {
+				created = append(created, &create.CreateView{ProjectName: name})
+			}
+
+			if !projectsAreEqual(created, tt.expectedProjects) {
+				t.Errorf("Projects mismatch.\nExpected: %+v\nGot: %+v", tt.expectedProjects, created)
+			}
+		})
+	}
+}
+
+func TestCreateProjectCommand(t *testing.T) {
+	cmd := CreateProjectCommand()
+
+	assert.Equal(t, "create [project name]", cmd.Use)
+	assert.Equal(t, "create project", cmd.Short)
+	assert.NotNil(t, cmd.Args, "Args validator should be set")
+	assert.NotNil(t, cmd.RunE, "RunE should be set")
+
+	publicFlag := cmd.Flags().Lookup("public")
+	assert.NotNil(t, publicFlag)
+	assert.Equal(t, "false", publicFlag.DefValue)
+
+	registryIDFlag := cmd.Flags().Lookup("registry-id")
+	assert.NotNil(t, registryIDFlag)
+	assert.Equal(t, "", registryIDFlag.DefValue)
+
+	storageLimitFlag := cmd.Flags().Lookup("storage-limit")
+	assert.NotNil(t, storageLimitFlag)
+	assert.Equal(t, "", storageLimitFlag.DefValue)
+
+	proxyCacheFlag := cmd.Flags().Lookup("proxy-cache")
+	assert.NotNil(t, proxyCacheFlag)
+	assert.Equal(t, "false", proxyCacheFlag.DefValue)
+}

--- a/cmd/harbor/root/project/create_test.go
+++ b/cmd/harbor/root/project/create_test.go
@@ -46,15 +46,15 @@ func (m *mockProjectCreator) CreateProject(opts create.CreateView) error {
 	return nil
 }
 func TestCreateProject(t *testing.T) {
-	projectsAreEqual := func(u1, u2 []*create.CreateView) bool {
-		if len(u1) != len(u2) {
+	projectsAreEqual := func(p1, p2 []*create.CreateView) bool {
+		if len(p1) != len(p2) {
 			return false
 		}
 		mp := make(map[string]int)
-		for _, proj := range u1 {
+		for _, proj := range p1 {
 			mp[proj.ProjectName]++
 		}
-		for _, proj := range u2 {
+		for _, proj := range p2 {
 			mp[proj.ProjectName]--
 		}
 		for _, val := range mp {
@@ -207,7 +207,7 @@ func TestCreateProject(t *testing.T) {
 						errInFilling: true,
 					}
 			},
-			expectedErr:      "Failed to get the required params to create project",
+			expectedErr:      "failed to get the required params to create project",
 			expectedProjects: []*create.CreateView{},
 		},
 		{

--- a/cmd/harbor/root/project/create_test.go
+++ b/cmd/harbor/root/project/create_test.go
@@ -15,7 +15,6 @@
 package project
 
 import (
-	"bytes"
 	"fmt"
 	"testing"
 
@@ -28,8 +27,7 @@ type mockProjectCreator struct {
 	errInFilling bool
 }
 
-// FillProjectView simulates a user filling the project details through the TUI
-func (m *mockProjectCreator) FillProjectView(createView *create.CreateView) error {
+func (m *mockProjectCreator) fillProjectView(createView *create.CreateView) error {
 	if m.errInFilling {
 		return fmt.Errorf("unexpected error while filling the project view")
 	}
@@ -38,7 +36,8 @@ func (m *mockProjectCreator) FillProjectView(createView *create.CreateView) erro
 	createView.StorageLimit = "-1"
 	return nil
 }
-func (m *mockProjectCreator) CreateProject(opts create.CreateView) error {
+
+func (m *mockProjectCreator) createProjectAPI(opts create.CreateView) error {
 	if _, found := m.projectName[opts.ProjectName]; found {
 		return fmt.Errorf("project with same name already exists")
 	}
@@ -46,6 +45,9 @@ func (m *mockProjectCreator) CreateProject(opts create.CreateView) error {
 	return nil
 }
 func TestCreateProject(t *testing.T) {
+	origFillProjectView := fillProjectView
+	defer func() { fillProjectView = origFillProjectView }()
+
 	projectsAreEqual := func(p1, p2 []*create.CreateView) bool {
 		if len(p1) != len(p2) {
 			return false
@@ -71,111 +73,40 @@ func TestCreateProject(t *testing.T) {
 	}
 	tests := []struct {
 		name             string
-		setup            func() ([]input, *mockProjectCreator)
+		inputs           []input
+		errInFilling     bool
 		expectedErr      string
 		expectedProjects []*create.CreateView
 	}{
 		{
-			name: "successfully create project with all flags",
-			setup: func() ([]input, *mockProjectCreator) {
-				return []input{
-					{
-						opts: &create.CreateView{
-							Public:       true,
-							StorageLimit: "100",
-						},
-						args: []string{"my-project"},
+			name: "project creation with user provided project name and storage should succeed",
+			inputs: []input{
+				{
+					opts: &create.CreateView{
+						Public:       true,
+						StorageLimit: "100",
 					},
-				}, &mockProjectCreator{projectName: make(map[string]struct{})}
+					args: []string{"my-project"},
+				},
 			},
 			expectedProjects: []*create.CreateView{
 				{ProjectName: "my-project"},
 			},
 		},
 		{
-			name: "missing fields triggers interactive view",
-			setup: func() ([]input, *mockProjectCreator) {
-				return []input{
-					{
-						opts: &create.CreateView{},
-					},
-				}, &mockProjectCreator{projectName: make(map[string]struct{})}
+			name: "project creation should succeed if no error in interactive view",
+			inputs: []input{
+				{opts: &create.CreateView{}},
 			},
 			expectedProjects: []*create.CreateView{
 				{ProjectName: "testProject999"},
-			},
-		},
-		{
-			name: "project name from args with empty storage triggers interactive view",
-			setup: func() ([]input, *mockProjectCreator) {
-				return []input{
-					{
-						opts: &create.CreateView{},
-						args: []string{"arg-project"},
-					},
-				}, &mockProjectCreator{projectName: make(map[string]struct{})}
-			},
-			expectedProjects: []*create.CreateView{
-				{ProjectName: "testProject999"},
-			},
-		},
-		{
-			name: "proxy cache without registry id returns error",
-			setup: func() ([]input, *mockProjectCreator) {
-				return []input{
-					{
-						opts: &create.CreateView{
-							StorageLimit: "100",
-							ProxyCache:   true,
-						},
-						args: []string{"proxy-project"},
-					},
-				}, &mockProjectCreator{projectName: make(map[string]struct{})}
-			},
-			expectedErr:      "proxy cache selected but no registry ID provided",
-			expectedProjects: []*create.CreateView{},
-		},
-		{
-			name: "registry id without proxy cache returns error",
-			setup: func() ([]input, *mockProjectCreator) {
-				return []input{
-					{
-						opts: &create.CreateView{
-							StorageLimit: "100",
-							RegistryID:   "5",
-						},
-						args: []string{"bad-config"},
-					},
-				}, &mockProjectCreator{projectName: make(map[string]struct{})}
-			},
-			expectedErr:      "registry ID should only be provided when proxy-cache is enabled",
-			expectedProjects: []*create.CreateView{},
-		},
-		{
-			name: "proxy cache with registry id succeeds",
-			setup: func() ([]input, *mockProjectCreator) {
-				return []input{
-					{
-						opts: &create.CreateView{
-							StorageLimit: "200",
-							ProxyCache:   true,
-							RegistryID:   "10",
-						},
-						args: []string{"cache-project"},
-					},
-				}, &mockProjectCreator{projectName: make(map[string]struct{})}
-			},
-			expectedProjects: []*create.CreateView{
-				{ProjectName: "cache-project"},
 			},
 		},
 		{
 			name: "duplicate project name fails second create",
-			setup: func() ([]input, *mockProjectCreator) {
-				return []input{
-					{opts: &create.CreateView{StorageLimit: "100"}, args: []string{"dup"}},
-					{opts: &create.CreateView{StorageLimit: "100"}, args: []string{"dup"}},
-				}, &mockProjectCreator{projectName: make(map[string]struct{})}
+			inputs: []input{
+				{opts: &create.CreateView{StorageLimit: "100"}, args: []string{"dup"}},
+				{opts: &create.CreateView{StorageLimit: "100"}, args: []string{"dup"}},
 			},
 			expectedErr: "failed to create project",
 			expectedProjects: []*create.CreateView{
@@ -184,12 +115,10 @@ func TestCreateProject(t *testing.T) {
 		},
 		{
 			name: "create multiple projects",
-			setup: func() ([]input, *mockProjectCreator) {
-				return []input{
-					{opts: &create.CreateView{StorageLimit: "10"}, args: []string{"proj-a"}},
-					{opts: &create.CreateView{StorageLimit: "20"}, args: []string{"proj-b"}},
-					{opts: &create.CreateView{StorageLimit: "30"}, args: []string{"proj-c"}},
-				}, &mockProjectCreator{projectName: make(map[string]struct{})}
+			inputs: []input{
+				{opts: &create.CreateView{StorageLimit: "10"}, args: []string{"proj-a"}},
+				{opts: &create.CreateView{StorageLimit: "20"}, args: []string{"proj-b"}},
+				{opts: &create.CreateView{StorageLimit: "30"}, args: []string{"proj-c"}},
 			},
 			expectedProjects: []*create.CreateView{
 				{ProjectName: "proj-a"},
@@ -198,34 +127,32 @@ func TestCreateProject(t *testing.T) {
 			},
 		},
 		{
-			name: "interactive view error propagates",
-			setup: func() ([]input, *mockProjectCreator) {
-				return []input{
-						{opts: &create.CreateView{}},
-					}, &mockProjectCreator{
-						projectName:  make(map[string]struct{}),
-						errInFilling: true,
-					}
+			name: "buildCreateView error propagates without calling API",
+			inputs: []input{
+				{opts: &create.CreateView{}},
 			},
+			errInFilling:     true,
 			expectedErr:      "failed to get the required params to create project",
 			expectedProjects: []*create.CreateView{},
 		},
 		{
-			name: "no projects to create",
-			setup: func() ([]input, *mockProjectCreator) {
-				return []input{}, &mockProjectCreator{projectName: make(map[string]struct{})}
-			},
+			name:             "no projects to create",
+			inputs:           []input{},
 			expectedProjects: []*create.CreateView{},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			inputs, m := tt.setup()
+			m := &mockProjectCreator{
+				projectName:  make(map[string]struct{}),
+				errInFilling: tt.errInFilling,
+			}
+			fillProjectView = m.fillProjectView
+
 			var lastErr error
-			for _, in := range inputs {
-				var buf bytes.Buffer
-				err := CreateProject(&buf, m, in.opts, in.args)
+			for _, in := range tt.inputs {
+				err := createProject(m.createProjectAPI, in.opts, in.args)
 				if err != nil {
 					lastErr = err
 				}
@@ -238,7 +165,6 @@ func TestCreateProject(t *testing.T) {
 				assert.NoError(t, lastErr)
 			}
 
-			// Build the list of created projects from the mock's map
 			var created []*create.CreateView
 			for name := range m.projectName {
 				created = append(created, &create.CreateView{ProjectName: name})
@@ -274,4 +200,116 @@ func TestCreateProjectCommand(t *testing.T) {
 	proxyCacheFlag := cmd.Flags().Lookup("proxy-cache")
 	assert.NotNil(t, proxyCacheFlag)
 	assert.Equal(t, "false", proxyCacheFlag.DefValue)
+}
+
+func TestBuildCreateView(t *testing.T) {
+	origFillProjectView := fillProjectView
+	defer func() { fillProjectView = origFillProjectView }()
+
+	tests := []struct {
+		name         string
+		opts         *create.CreateView
+		args         []string
+		errInFilling bool
+		expectedErr  string
+		expectedView *create.CreateView
+	}{
+		{
+			name: "all flags provided returns opts directly",
+			opts: &create.CreateView{
+				ProjectName:  "full-project",
+				Public:       true,
+				StorageLimit: "500",
+			},
+			args: nil,
+			expectedView: &create.CreateView{
+				ProjectName:  "full-project",
+				Public:       true,
+				StorageLimit: "500",
+			},
+		},
+		{
+			name: "missing storage triggers interactive view",
+			opts: &create.CreateView{},
+			args: []string{"some-project"},
+			expectedView: &create.CreateView{
+				ProjectName:  "testProject999",
+				StorageLimit: "-1",
+			},
+		},
+		{
+			name: "missing project name triggers interactive view",
+			opts: &create.CreateView{
+				StorageLimit: "100",
+			},
+			expectedView: &create.CreateView{
+				ProjectName:  "testProject999",
+				StorageLimit: "-1",
+			},
+		},
+		{
+			name: "proxy cache without registry id returns error",
+			opts: &create.CreateView{
+				StorageLimit: "100",
+				ProxyCache:   true,
+			},
+			args:        []string{"proxy-proj"},
+			expectedErr: "proxy cache selected but no registry ID provided",
+		},
+		{
+			name: "registry id without proxy cache returns error",
+			opts: &create.CreateView{
+				StorageLimit: "100",
+				RegistryID:   "5",
+			},
+			args:        []string{"bad-proj"},
+			expectedErr: "registry ID should only be provided when proxy-cache is enabled",
+		},
+		{
+			name: "proxy cache with registry id succeeds",
+			opts: &create.CreateView{
+				ProjectName:  "cache-proj",
+				StorageLimit: "200",
+				ProxyCache:   true,
+				RegistryID:   "10",
+			},
+			expectedView: &create.CreateView{
+				ProjectName:  "cache-proj",
+				StorageLimit: "200",
+				ProxyCache:   true,
+				RegistryID:   "10",
+			},
+		},
+		{
+			name:         "interactive view error propagates",
+			opts:         &create.CreateView{},
+			errInFilling: true,
+			expectedErr:  "failed to get the required params to create project",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &mockProjectCreator{
+				projectName:  make(map[string]struct{}),
+				errInFilling: tt.errInFilling,
+			}
+			fillProjectView = m.fillProjectView
+
+			view, err := buildCreateView(tt.opts, tt.args)
+
+			if tt.expectedErr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+				assert.Nil(t, view)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, view)
+				assert.Equal(t, tt.expectedView.ProjectName, view.ProjectName)
+				assert.Equal(t, tt.expectedView.StorageLimit, view.StorageLimit)
+				assert.Equal(t, tt.expectedView.ProxyCache, view.ProxyCache)
+				assert.Equal(t, tt.expectedView.RegistryID, view.RegistryID)
+			}
+		})
+	}
 }

--- a/cmd/harbor/root/project/create_test.go
+++ b/cmd/harbor/root/project/create_test.go
@@ -45,59 +45,6 @@ func (m *mockProjectCreator) CreateProject(opts create.CreateView) error {
 	m.projectName[opts.ProjectName] = struct{}{}
 	return nil
 }
-func TestFillCreateView(t *testing.T) {
-	tests := []struct {
-		name         string
-		input        *create.CreateView
-		errInFilling bool
-		expectError  bool
-		expectName   string
-		expectLimit  string
-	}{
-		{
-			name:        "nil createView gets defaults then filled",
-			input:       nil,
-			expectName:  "testProject999",
-			expectLimit: "-1",
-		},
-		{
-			name: "empty createView gets filled",
-			input: &create.CreateView{
-				ProjectName:  "",
-				StorageLimit: "",
-			},
-			expectName:  "testProject999",
-			expectLimit: "-1",
-		},
-		{
-			name:         "error in FillProjectView propagates",
-			input:        &create.CreateView{},
-			errInFilling: true,
-			expectError:  true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mock := &mockProjectCreator{
-				projectName:  make(map[string]struct{}),
-				errInFilling: tt.errInFilling,
-			}
-
-			err := fillCreateView(mock, tt.input)
-
-			if tt.expectError {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-				if tt.input != nil {
-					assert.Equal(t, tt.expectName, tt.input.ProjectName)
-					assert.Equal(t, tt.expectLimit, tt.input.StorageLimit)
-				}
-			}
-		})
-	}
-}
 func TestCreateProject(t *testing.T) {
 	projectsAreEqual := func(u1, u2 []*create.CreateView) bool {
 		if len(u1) != len(u2) {


### PR DESCRIPTION
## Description
This PR introduces unit tests for the user create command (`cmd/harbor/root/project/create.go`)

Solves a part of #591 

## Functions covered:

- [x] CreateProject()
- [x] fillCreateView()
- [x] CreateProjectCommand() 

