### PR TITLE
fix: pin golangci-lint version to v2.9.0-alpine

### DIFF
--- a/.dagger/lint.go
+++ b/.dagger/lint.go
@@ -35,7 +35,7 @@ func (m *HarborCli) Lint(ctx context.Context, source *dagger.Directory) (string,
 func (m *HarborCli) lint(_ context.Context) *dagger.Container {
 	fmt.Println("👀 Running linter and printing results to file golangci-lint.txt.")
 	linter := dag.Container().
-		From("golangci/golangci-lint:v2.9.0-alpine").
+		From("golangci/golangci-lint:v2.10.0-alpine").
 		WithMountedCache("/lint-cache", dag.CacheVolume("/lint-cache")).
 		WithEnvVariable("GOLANGCI_LINT_CACHE", "/lint-cache").
 		WithMountedDirectory("/src", m.Source).


### PR DESCRIPTION
fixes #711 

**Overview**
The Dagger lint pipeline currently uses `golangci/golangci-lint:latest-alpine`. 
Using the `latest` tag can lead to unexpected CI failures when a new version of golangci-lint is released.

**Changes**
Pinned golangci-lint image to `v2.9.0-alpine`, which is the previously working version observed in CI logs.

**Reason**
Pinning the version ensures consistent and stable lint behaviour across CI runs and prevents breaking changes introduced by newer releases.

No functional code changes were made.
