### PR TITLE
Calculate git commit SHA once for all builds

### DIFF
--- a/.dagger/build.go
+++ b/.dagger/build.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"dagger/harbor-cli/internal/dagger"
@@ -20,6 +21,16 @@ func (m *HarborCli) Build(ctx context.Context,
 			return nil, err
 		}
 	}
+
+	temp := dag.Container().
+		From("alpine:latest").
+		WithMountedDirectory("/src", source).
+		WithExec([]string{"apk", "add", "--no-cache", "git"}).
+		WithWorkdir("/src")
+
+	gitCommit, _ := temp.WithExec([]string{"git", "rev-parse", "--short", "HEAD", "--always"}).Stdout(ctx)
+	gitCommit = strings.TrimSpace(gitCommit)
+	buildTime := time.Now().UTC().Format(time.RFC3339)
 
 	goos := []string{"linux", "darwin", "windows"}
 	goarch := []string{"amd64", "arm64"}
@@ -42,9 +53,6 @@ func (m *HarborCli) Build(ctx context.Context,
 				WithWorkdir("/src").
 				WithEnvVariable("GOOS", os).
 				WithEnvVariable("GOARCH", arch)
-
-			gitCommit, _ := builder.WithExec([]string{"git", "rev-parse", "--short", "HEAD", "--always"}).Stdout(ctx)
-			buildTime := time.Now().UTC().Format(time.RFC3339)
 
 			ldflagsArgs := LDFlags(ctx, m.AppVersion, m.GoVersion, buildTime, gitCommit)
 

--- a/.dagger/buildDev.go
+++ b/.dagger/buildDev.go
@@ -27,6 +27,16 @@ func (m *HarborCli) BuildDev(ctx context.Context, platform string,
 		log.Fatalf("Error parsing platform: %v", err)
 	}
 
+	temp := dag.Container().
+		From("alpine:latest").
+		WithMountedDirectory("/src", m.Source).
+		WithExec([]string{"apk", "add", "--no-cache", "git"}).
+		WithWorkdir("/src")
+
+	gitCommit, _ := temp.WithExec([]string{"git", "rev-parse", "--short", "HEAD", "--always"}).Stdout(ctx)
+	gitCommit = strings.TrimSpace(gitCommit)
+	buildTime := time.Now().UTC().Format(time.RFC3339)
+
 	builder := dag.Container().
 		From("golang:"+m.GoVersion).
 		WithMountedCache("/go/pkg/mod", dag.CacheVolume("go-mod-"+m.GoVersion)).
@@ -37,9 +47,6 @@ func (m *HarborCli) BuildDev(ctx context.Context, platform string,
 		WithWorkdir("/src").
 		WithEnvVariable("GOOS", os).
 		WithEnvVariable("GOARCH", arch)
-
-	gitCommit, _ := builder.WithExec([]string{"git", "rev-parse", "--short", "HEAD", "--always"}).Stdout(ctx)
-	buildTime := time.Now().UTC().Format(time.RFC3339)
 
 	ldflagsArgs := LDFlags(ctx, m.AppVersion, m.GoVersion, buildTime, gitCommit)
 


### PR DESCRIPTION
Fixes #726

Moved git commit SHA calculation out of the build loop and into a temp container. This way we get it once and reuse it for all platform builds. Should fix the missing git commit in the binary.