### PR TITLE
fix(ci): add temp container for git commit SHA in build

### DIFF
--- a/.dagger/build.go
+++ b/.dagger/build.go
@@ -24,6 +24,14 @@ func (m *HarborCli) Build(ctx context.Context,
 	goos := []string{"linux", "darwin", "windows"}
 	goarch := []string{"amd64", "arm64"}
 
+	temp := dag.Container().
+		From("alpine:latest").
+		WithExec([]string{"apk", "add", "--no-cache", "git"}).
+		WithMountedDirectory("/src", source).
+		WithWorkdir("/src")
+	gitCommit, _ := temp.WithExec([]string{"git", "rev-parse", "--short", "HEAD", "--always"}).Stdout(ctx)
+	buildTime := time.Now().UTC().Format(time.RFC3339)
+
 	for _, os := range goos {
 		for _, arch := range goarch {
 			// Defining binary file name
@@ -42,9 +50,6 @@ func (m *HarborCli) Build(ctx context.Context,
 				WithWorkdir("/src").
 				WithEnvVariable("GOOS", os).
 				WithEnvVariable("GOARCH", arch)
-
-			gitCommit, _ := builder.WithExec([]string{"git", "rev-parse", "--short", "HEAD", "--always"}).Stdout(ctx)
-			buildTime := time.Now().UTC().Format(time.RFC3339)
 
 			ldflagsArgs := LDFlags(ctx, m.AppVersion, m.GoVersion, buildTime, gitCommit)
 


### PR DESCRIPTION
Fixes #726 

* The `Build` function uses the Alpine version of the Go container, which does not have git installed.
* One option was to install git inside the build container, but that would run redundantly in the loop for all cross-platform builds.
* Instead, a temporary container is used outside the loop to resolve the git commit SHA once and reuse it for all builds.

<img width="760" height="109" alt="image" src="https://github.com/user-attachments/assets/94193db7-acb7-4931-90f4-ac0073cf8f81" />