### PR TITLE
fix: use os.Root to resolve gosec G122 lint in man page generation

### DIFF
--- a/doc/man-docs/man_doc.go
+++ b/doc/man-docs/man_doc.go
@@ -106,7 +106,7 @@ func cleanManPages(docDir string) error {
 			cleanedContent := strings.Split(updatedContent, "\n.SH HISTORY")[0]
 			cleanedContent = strings.TrimRight(cleanedContent, "\n")
 
-			wf, err := root.OpenFile(relPath, os.O_WRONLY|os.O_TRUNC, 0600)
+			wf, err := root.OpenFile(relPath, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0600)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Fixes #729 

In `doc/man-docs/man-doc.go` to avoid **TOCTOU** race condition the following changes were made,
### Before
* Used `filepath.Walk` with `os.ReadFile` and `os.WriteFile` using full file paths directly
* These file operations could be tricked into reading/writing unintended files if symlinks were swapped in between
### After
* Used `os.OpenRoot` to scope all file operations to the doc directory
* Replaced `filepath.Walk` with `filepath.WalkDir`
* File reads and writes now go through the root handle `(root.Open, root.OpenFile)`, which prevents symlink escapes
* No change in output, generated docs are identical