### PR TITLE
enhancement: Support and / or in query flags and doc gen for query

### DIFF
--- a/cmd/harbor/root/labels/list.go
+++ b/cmd/harbor/root/labels/list.go
@@ -33,7 +33,12 @@ func ListLabelCommand() *cobra.Command {
 		fuzzy  []string
 		match  []string
 		ranges []string
+		all    []string
+		any    []string
+
+		validKeys = []string{"name", "id", "label_id", "creation_time", "owner_id", "color", "description"}
 	)
+
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "list labels",
@@ -65,9 +70,7 @@ func ListLabelCommand() *cobra.Command {
 			}
 
 			if len(fuzzy) != 0 || len(match) != 0 || len(ranges) != 0 { // Only Building Query if a param exists
-				q, qErr := utils.BuildQueryParam(fuzzy, match, ranges,
-					[]string{"name", "id", "label_id", "creation_time", "owner_id", "color", "description"},
-				)
+				q, qErr := utils.BuildQueryParam(fuzzy, match, ranges, all, any, validKeys)
 				if qErr != nil {
 					return qErr
 				}
@@ -94,6 +97,15 @@ func ListLabelCommand() *cobra.Command {
 		},
 	}
 
+	// Adding Query Description
+	var qDesc string
+	if cmd.Long != "" {
+		qDesc = "\n\n" + utils.GenerateQueryDocs(validKeys)
+	} else {
+		qDesc = utils.GenerateQueryDocs(validKeys)
+	}
+	cmd.Long += qDesc
+
 	flags := cmd.Flags()
 	flags.Int64VarP(&opts.Page, "page", "", 1, "Page number")
 	flags.Int64VarP(&opts.PageSize, "page-size", "", 20, "Size of per page")
@@ -102,9 +114,7 @@ func ListLabelCommand() *cobra.Command {
 	flags.Int64VarP(&opts.ProjectID, "project-id", "i", 0, "project ID when query project labels")
 	flags.BoolVarP(&isGlobal, "global", "", false, "whether to list global or project scope labels. (default scope is global)")
 	flags.StringVarP(&opts.Sort, "sort", "", "", "Sort the label list in ascending or descending order")
-	flags.StringSliceVar(&fuzzy, "fuzzy", nil, "Fuzzy match filter (key=value)")
-	flags.StringSliceVar(&match, "match", nil, "exact match filter (key=value)")
-	flags.StringSliceVar(&ranges, "range", nil, "range filter (key=min~max)")
+	utils.SetQueryFlags(flags, &match, &fuzzy, &ranges, &all, &any)
 
 	return cmd
 }

--- a/cmd/harbor/root/project/list.go
+++ b/cmd/harbor/root/project/list.go
@@ -37,8 +37,8 @@ func ListProjectCommand() *cobra.Command {
 		fuzzy     []string
 		match     []string
 		ranges    []string
-		and       []string
-		or        []string
+		all       []string
+		any       []string
 		validKeys = []string{"name", "project_id", "public", "creation_time", "owner_id"}
 	)
 
@@ -76,7 +76,7 @@ func ListProjectCommand() *cobra.Command {
 			}
 
 			if len(fuzzy) != 0 || len(match) != 0 || len(ranges) != 0 { // Only Building Query if a param exists
-				q, qErr := utils.BuildQueryParam(fuzzy, match, ranges, validKeys)
+				q, qErr := utils.BuildQueryParam(fuzzy, match, ranges, all, any, validKeys)
 				if qErr != nil {
 					return qErr
 				}
@@ -126,7 +126,7 @@ func ListProjectCommand() *cobra.Command {
 	flags.BoolVarP(&private, "private", "", false, "Show only private projects")
 	flags.BoolVarP(&public, "public", "", false, "Show only public projects")
 	flags.StringVarP(&opts.Sort, "sort", "", "", "Sort the resource list in ascending or descending order")
-	utils.SetQueryFlags(flags, &match, &fuzzy, &ranges, &and, &or) // Adds the 5 query flags
+	utils.SetQueryFlags(flags, &match, &fuzzy, &ranges, &all, &any) // Adds the 5 query flags
 
 	return cmd
 }

--- a/pkg/utils/query.go
+++ b/pkg/utils/query.go
@@ -20,56 +20,116 @@ import (
 	"github.com/spf13/pflag"
 )
 
-// Builds the `q` param for List API's
-func BuildQueryParam(fuzzy, match, ranges []string, validKeys []string) (string, error) {
+// BuildQueryParam builds the `q` param for List API's
+func BuildQueryParam(fuzzy, match, ranges, all, any []string, validKeys []string) (string, error) {
 	var parts []string
+	m := map[string]bool{} // existence map for key mapping
 
 	// Fuzzy
 	for _, v := range fuzzy {
 		kv := strings.Split(v, "=")
 		if len(kv) != 2 {
-			return "", fmt.Errorf("invalid fuzzy arg: %s ", v)
+			return "", fmt.Errorf("invalid fuzzy arg: %s", v)
 		}
 
 		if err := validateKey(kv[0], validKeys); err != nil {
 			return "", err
 		}
 
+		// Checking if key already exists
+		if m[kv[0]] {
+			return "", fmt.Errorf("found duplicate key: %s", kv[0])
+		}
+
+		m[kv[0]] = true
 		parts = append(parts, fmt.Sprintf("%s=~%s", kv[0], kv[1]))
 	}
 
-	// Exact Match's
+	// Exact match
 	for _, v := range match {
 		kv := strings.Split(v, "=")
 		if len(kv) != 2 {
-			return "", fmt.Errorf("invalid match arg: %s ", v)
+			return "", fmt.Errorf("invalid match arg: %s", v)
 		}
 
 		if err := validateKey(kv[0], validKeys); err != nil {
 			return "", err
 		}
 
+		// Checking if key already exists
+		if m[kv[0]] {
+			return "", fmt.Errorf("found duplicate key: %s", kv[0])
+		}
+
+		m[kv[0]] = true
 		parts = append(parts, fmt.Sprintf("%s=%s", kv[0], kv[1]))
 	}
 
-	// Ranges
+	// Range (min~max)
 	for _, v := range ranges {
 		kv := strings.Split(v, "=")
 		if len(kv) != 2 {
-			return "", fmt.Errorf("invalid range arg: %s ", v)
+			return "", fmt.Errorf("invalid range arg: %s", v)
 		}
 
 		if err := validateKey(kv[0], validKeys); err != nil {
 			return "", err
 		}
 
-		// Validating that range is in format min~max
-		rng := strings.Split(kv[1], "~")
-		if len(rng) != 2 {
-			return "", fmt.Errorf("invalid range arg: %s ", v)
+		// Checking if key already exists
+		if m[kv[0]] {
+			return "", fmt.Errorf("found duplicate key: %s", kv[0])
 		}
 
+		rng := strings.Split(kv[1], "~")
+		if len(rng) != 2 {
+			return "", fmt.Errorf("invalid range arg: %s", v)
+		}
+
+		m[kv[0]] = true
 		parts = append(parts, fmt.Sprintf("%s=[%s~%s]", kv[0], rng[0], rng[1]))
+	}
+
+	// All
+	for _, v := range all {
+		kv := strings.Split(v, "=")
+		if len(kv) != 2 {
+			return "", fmt.Errorf("invalid all arg: %s", v)
+		}
+
+		if err := validateKey(kv[0], validKeys); err != nil {
+			return "", err
+		}
+
+		// Checking if key already exists
+		if m[kv[0]] {
+			return "", fmt.Errorf("found duplicate key: %s", kv[0])
+		}
+
+		m[kv[0]] = true
+		vals := strings.Split(kv[1], ",") // Splitting and replacing "," with " ", Harbor syntax is {v1 v2 v3}
+		parts = append(parts, fmt.Sprintf("%s={%s}", kv[0], strings.Join(vals, " ")))
+	}
+
+	// Any
+	for _, v := range any {
+		kv := strings.Split(v, "=")
+		if len(kv) != 2 {
+			return "", fmt.Errorf("invalid any arg: %s", v)
+		}
+
+		if err := validateKey(kv[0], validKeys); err != nil {
+			return "", err
+		}
+
+		// Checking if key already exists
+		if m[kv[0]] {
+			return "", fmt.Errorf("found duplicate key: %s", kv[0])
+		}
+
+		m[kv[0]] = true
+		vals := strings.Split(kv[1], ",") // Splitting and replacing "," with " ", Harbor syntax is {v1 v2 v3}
+		parts = append(parts, fmt.Sprintf("%s=(%s)", kv[0], strings.Join(vals, " ")))
 	}
 
 	return strings.Join(parts, ","), nil
@@ -104,7 +164,7 @@ Examples:
 
   --match project_id=12
   --fuzzy name=test
-  --range update_time=2024-01-01:2024-02-01
+  --range update_time=2024-01-01~2024-02-01
   --any tag=v1,v2
   --all label=prod,stable
 


### PR DESCRIPTION
resolves #718 

## Docs

<img width="952" height="727" alt="image" src="https://github.com/user-attachments/assets/089c3ffd-df66-4839-a25d-d75733ac5ecc" />

## Changes

- [X] Adds a `SetQueryFlags` function that take the flagset and adds the relevant flags to it
- [X] Adds a `GenerateQueryDocs` function that generates the relevant command specific docs from the validKeys
- [ ] Modify the `BuildQueryParam` to support and / or operations. (Waiting for #682)
- [ ] Refactor commands to use the new and / or support and query gen (Waiting for #682)