### PR TITLE
fix(user): pass populated PasswordChangeView to ResetPassword

### DIFF
--- a/cmd/harbor/root/user/password.go
+++ b/cmd/harbor/root/user/password.go
@@ -59,7 +59,7 @@ func UserPasswordChangeCmd() *cobra.Command {
 
 			reset.ChangePasswordView(resetView)
 
-			err = api.ResetPassword(userId, opts)
+			err = api.ResetPassword(userId, *resetView)
 			if err != nil {
 				if isUnauthorizedError(err) {
 					log.Error("Permission denied: Admin privileges are required to execute this command.")

--- a/cmd/harbor/root/user/password_test.go
+++ b/cmd/harbor/root/user/password_test.go
@@ -1,0 +1,52 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package user
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestUserPasswordChangeCmd_Metadata(t *testing.T) {
+	cmd := UserPasswordChangeCmd()
+
+	if cmd == nil {
+		t.Fatal("command should not be nil")
+	}
+
+	if cmd.Use != "password" {
+		t.Fatalf("expected command 'password', got %s", cmd.Use)
+	}
+
+	if cmd.Short == "" {
+		t.Fatal("Short description should not be empty")
+	}
+}
+
+func TestUserPasswordChangeCmd_RunExists(t *testing.T) {
+	cmd := UserPasswordChangeCmd()
+
+	if cmd.Run == nil {
+		t.Fatal("Run function should be defined")
+	}
+}
+
+func TestUserPasswordChangeCmd_IsCobraCommand(t *testing.T) {
+	cmd := UserPasswordChangeCmd()
+
+	if _, ok := interface{}(cmd).(*cobra.Command); !ok {
+		t.Fatal("expected cobra command")
+	}
+}


### PR DESCRIPTION
Fix a bug where `resetView` was not passed to `api.ResetPassword`.

The interactive password input populates `resetView`, but the API call used `opts`, which may not contain the updated password.

This PR passes the populated `resetView` to the API instead.