### PR TITLE
fix: removing dependency on ansi and using lipgloss

### DIFF
--- a/pkg/views/health/view.go
+++ b/pkg/views/health/view.go
@@ -51,9 +51,9 @@ func styleStatus(status string) string {
 	var colored string
 
 	if status == "healthy" {
-		colored = views.GreenANSI + status + views.ResetANSI
+		colored = views.GreenStyle.Render(status)
 	} else {
-		colored = views.RedANSI + status + views.ResetANSI
+		colored = views.RedStyle.Render(status)
 	}
 	return colored
 }

--- a/pkg/views/robot/list/view.go
+++ b/pkg/views/robot/list/view.go
@@ -44,9 +44,9 @@ func ListRobots(robots []*models.Robot) {
 		var expires string
 
 		if robot.Disable {
-			enabledStatus = views.GreenANSI + "Disabled" + views.ResetANSI
+			enabledStatus = views.GreenStyle.Render("Disabled")
 		} else {
-			enabledStatus = views.GreenANSI + "Enabled" + views.ResetANSI
+			enabledStatus = views.GreenStyle.Render("Enabled")
 		}
 
 		var TotalPermissions int = 0

--- a/pkg/views/robot/view/view.go
+++ b/pkg/views/robot/view/view.go
@@ -82,9 +82,9 @@ func ViewRobot(robot *models.Robot) {
 	var expires string
 
 	if robot.Disable {
-		enabledStatus = views.GreenANSI + "Disabled" + views.ResetANSI
+		enabledStatus = views.GreenStyle.Render("Disabled")
 	} else {
-		enabledStatus = views.GreenANSI + "Enabled" + views.ResetANSI
+		enabledStatus = views.GreenStyle.Render("Enabled")
 	}
 
 	TotalPermissions := strconv.FormatInt(int64(len(robot.Permissions[0].Access)), 10)
@@ -112,7 +112,7 @@ func ViewRobot(robot *models.Robot) {
 		os.Exit(1)
 	}
 
-	fmt.Printf("\n%sRobot Permissions:%s\n\n", views.BoldANSI, views.ResetANSI)
+	fmt.Printf("\n%s\n\n", views.BoldStyle.Render("Robot Permissions:"))
 
 	var permissionsColumns []table.Column
 	var resourceStrings []string
@@ -122,12 +122,12 @@ func ViewRobot(robot *models.Robot) {
 		permissionsColumns = systemPermissionsColumns
 		resourceStrings = systemResourceStrings
 		systemLevel = true
-		fmt.Printf("%sSystem-level robot with access across projects%s\n\n", views.BoldANSI, views.ResetANSI)
+		fmt.Printf("\n%s\n\n", views.BoldStyle.Render("System-level robot with access across projects"))
 	} else {
 		permissionsColumns = projectPermissionsColumns
 		resourceStrings = projectResourceStrings
 		systemLevel = false
-		fmt.Printf("%sProject-level robot for project: %s%s\n\n", views.BoldANSI, robot.Permissions[0].Namespace, views.ResetANSI)
+		fmt.Printf("\n%s\n\n", views.BoldStyle.Render(fmt.Sprintf("System-level robot with access across projects: %s", robot.Permissions[0].Namespace)))
 	}
 
 	var permissionRows []table.Row
@@ -194,11 +194,11 @@ func ViewRobot(robot *models.Robot) {
 			os.Exit(1)
 		}
 
-		fmt.Printf("\n%sProject-specific Permissions:%s\n", views.BoldANSI, views.ResetANSI)
+		fmt.Printf("\n%s\n\n", views.BoldStyle.Render("Project-specific Permissions:"))
 
 		for _, perm := range robot.Permissions {
 			if perm.Kind == "project" && perm.Namespace != "/" {
-				fmt.Printf("\n%sProject: %s%s\n\n", views.BoldANSI, perm.Namespace, views.ResetANSI)
+				fmt.Printf("\n%s\n\n", views.BoldStyle.Render(fmt.Sprintf("Project: %s", perm.Namespace)))
 				projectRows := createProjectPermissionRows(perm, perms.Project)
 				pt := tablelist.NewModel(projectPermissionsColumns, projectRows, len(projectRows))
 				if _, err := tea.NewProgram(pt).Run(); err != nil {

--- a/pkg/views/styles.go
+++ b/pkg/views/styles.go
@@ -26,6 +26,9 @@ var (
 	SelectedItemStyle = lipgloss.NewStyle().PaddingLeft(2).Foreground(lipgloss.Color("170"))
 	PaginationStyle   = list.DefaultStyles().PaginationStyle.PaddingLeft(4)
 	HelpStyle         = list.DefaultStyles().HelpStyle.PaddingLeft(4).PaddingBottom(1)
+	GreenStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("2")) // ANSI 32
+	RedStyle          = lipgloss.NewStyle().Foreground(lipgloss.Color("1")) // ANSI 31
+	BoldStyle         = lipgloss.NewStyle().Bold(true)                      // ANSI 1
 )
 
 var BaseStyle = lipgloss.NewStyle().
@@ -36,12 +39,5 @@ func RedText(strs ...string) string {
 	for _, str := range strs {
 		msg.WriteString(str)
 	}
-	return RedANSI + msg.String() + ResetANSI
+	return RedStyle.Render(msg.String())
 }
-
-const (
-	GreenANSI = "\033[32m"
-	RedANSI   = "\033[31m"
-	BoldANSI  = "\033[1m"
-	ResetANSI = "\033[0m"
-)


### PR DESCRIPTION
## Description

- Fixes # NA

## Type of Change
Please select the relevant type.

- [x] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
- Removes dependency on the ANSI styling in `/pkg/views/styles.go`
- Uses lipgloss instead of hardcoded ANSI
