### PR TITLE
docs: add MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,10 @@
+# Maintainers
+
+This file lists the current sub-project maintainers for `harbor-cli`.
+
+## Current maintainers
+
+- Vadim Bauer (`@Vad1mo`)
+- Prasanth Baskar (`@bupd`)
+- Patrick Eschenbach (`@qcserestipy`)
+- Nucleo Fusion (`@NucleoFusion`)


### PR DESCRIPTION
## Summary
- add a root `MAINTAINERS.md`
- list current harbor-cli maintainers
- make maintainership explicit in the repo

Related: #740