### PR TITLE
feat/vuln list command

### DIFF
--- a/cmd/harbor/root/cmd.go
+++ b/cmd/harbor/root/cmd.go
@@ -85,7 +85,7 @@ harbor help
 		},
 	}
 
-	root.PersistentFlags().StringVarP(&output, "output-format", "o", "", "Output format. One of: json|yaml")
+	root.PersistentFlags().StringVarP(&output, "output-format", "o", "", "Output format. One of: json|yaml|csv")
 	root.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/.config/harbor-cli/config.yaml)")
 	root.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
 

--- a/cmd/harbor/root/vulnerability/cmd.go
+++ b/cmd/harbor/root/vulnerability/cmd.go
@@ -26,6 +26,7 @@ func Vulnerability() *cobra.Command {
 
 	cmd.AddCommand(
 		GetVulnerabilitySummaryCommand(),
+		ListVulnerabilitiesCommand(),
 	)
 
 	return cmd

--- a/cmd/harbor/root/vulnerability/list.go
+++ b/cmd/harbor/root/vulnerability/list.go
@@ -16,6 +16,7 @@ package vulnerability
 import (
 	"fmt"
 
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	vulnlist "github.com/goharbor/harbor-cli/pkg/views/vulnerability/list"
@@ -42,24 +43,24 @@ func ListVulnerabilitiesCommand() *cobra.Command {
 				return fmt.Errorf("page size should be less than or equal to 100")
 			}
 
-			response, err := api.ListVulnerabilities(opts)
+			allVulnerabilities, hasNext, err := fetchVulnerabilities(opts)
 			if err != nil {
 				return fmt.Errorf("failed to list vulnerabilities: %v", utils.ParseHarborErrorMsg(err))
 			}
 
-			if len(response.Payload) == 0 {
+			if len(allVulnerabilities) == 0 {
 				log.Info("No vulnerabilities found")
 				return nil
 			}
 
 			formatFlag := viper.GetString("output-format")
 			if formatFlag != "" {
-				err = utils.PrintFormat(response.Payload, formatFlag)
+				err = utils.PrintFormat(allVulnerabilities, formatFlag)
 				if err != nil {
 					return err
 				}
 			} else {
-				vulnlist.ViewVulnerabilityList(response.Payload)
+				vulnlist.ViewVulnerabilityList(allVulnerabilities, hasNext)
 			}
 
 			return nil
@@ -71,7 +72,7 @@ func ListVulnerabilitiesCommand() *cobra.Command {
 	flags.Int64VarP(&opts.PageSize, "page-size", "", 10, "Size of per page")
 	flags.StringVarP(&opts.Q, "query", "q", "", "Filter vulnerabilities with a ',' separated query string like exact k=v and range k=[min~max]")
 	flags.StringVarP(&opts.CVEID, "cve-id", "", "", "Filter by exact CVE ID")
-	flags.StringVarP(&opts.CVSSScore, "cvss-score", "", "", "Filter by CVSS v3 score range (e.g. [7.0~10.0])")
+	flags.StringVarP(&opts.CVSSScore, "cvss-score", "", "", "Filter by CVSS v3 score range (e.g. 7.0~10.0) or exact score (e.g. 7.0)")
 	flags.StringVarP(&opts.Severity, "severity", "", "", "Filter by severity level")
 	flags.StringVarP(&opts.Repository, "repository", "", "", "Filter by exact repository name")
 	flags.StringVarP(&opts.ProjectName, "project-name", "", "", "Filter by exact project name")
@@ -82,4 +83,34 @@ func ListVulnerabilitiesCommand() *cobra.Command {
 	flags.BoolVarP(&opts.Fixable, "fixable", "", false, "Only show fixable vulnerabilities")
 
 	return cmd
+}
+
+func fetchVulnerabilities(opts api.ListVulnerabilityOptions) ([]*models.VulnerabilityItem, bool, error) {
+	var allVuln []*models.VulnerabilityItem
+	if opts.PageSize == 0 {
+		log.Debug("Page size is 0, will fetch all vulnerabilities")
+		opts.PageSize = 100
+		opts.Page = 1
+		for {
+			response, err := api.ListVulnerabilities(opts)
+			if err != nil {
+				return nil, false, fmt.Errorf("failed to list vulnerabilities: %v", utils.ParseHarborErrorMsg(err))
+			}
+			if len(response.Payload) == 0 {
+				break
+			}
+			allVuln = append(allVuln, response.Payload...)
+			opts.Page++
+			if opts.Page > 10 {
+				return allVuln, true, nil
+			}
+		}
+	} else {
+		response, err := api.ListVulnerabilities(opts)
+		if err != nil {
+			return nil, false, fmt.Errorf("failed to list vulnerabilities: %v", utils.ParseHarborErrorMsg(err))
+		}
+		allVuln = append(allVuln, response.Payload...)
+	}
+	return allVuln, false, nil
 }

--- a/cmd/harbor/root/vulnerability/list.go
+++ b/cmd/harbor/root/vulnerability/list.go
@@ -35,12 +35,8 @@ func ListVulnerabilitiesCommand() *cobra.Command {
 		Example: `  harbor vulnerability list`,
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if opts.PageSize < 0 {
-				return fmt.Errorf("page size must be greater than or equal to 0")
-			}
-
-			if opts.PageSize > 100 {
-				return fmt.Errorf("page size should be less than or equal to 100")
+			if opts.PageSize <= 0 || opts.PageSize > 100 {
+				return fmt.Errorf("page size must be greater than 0 and less than or equal to 100")
 			}
 
 			allVulnerabilities, hasNext, err := fetchVulnerabilities(opts)
@@ -81,14 +77,15 @@ func ListVulnerabilitiesCommand() *cobra.Command {
 	flags.StringVarP(&opts.Digest, "digest", "", "", "Filter by exact artifact digest")
 	flags.StringVarP(&opts.Exclude, "exclude", "", "", "Exclude vulnerabilities using a ',' separated query string (e.g., k=v or k=[min~max])")
 	flags.BoolVarP(&opts.Fixable, "fixable", "", false, "Only show fixable vulnerabilities")
+	flags.BoolVarP(&opts.All, "all", "", false, "Show all vulnerabilities (up to 1000)")
 
 	return cmd
 }
 
 func fetchVulnerabilities(opts api.ListVulnerabilityOptions) ([]*models.VulnerabilityItem, bool, error) {
 	var allVuln []*models.VulnerabilityItem
-	if opts.PageSize == 0 {
-		log.Debug("Page size is 0, will fetch all vulnerabilities")
+	if opts.All {
+		log.Debug("Fetching all vulnerabilities")
 		opts.PageSize = 100
 		opts.Page = 1
 		for {

--- a/cmd/harbor/root/vulnerability/list.go
+++ b/cmd/harbor/root/vulnerability/list.go
@@ -35,6 +35,10 @@ func ListVulnerabilitiesCommand() *cobra.Command {
 		Example: `  harbor vulnerability list`,
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.Page < 1 {
+				return fmt.Errorf("page number must be greater than or equal to 1")
+			}
+
 			if opts.PageSize <= 0 || opts.PageSize > 100 {
 				return fmt.Errorf("page size must be greater than 0 and less than or equal to 100")
 			}
@@ -82,31 +86,38 @@ func ListVulnerabilitiesCommand() *cobra.Command {
 }
 
 func fetchVulnerabilities(opts api.ListVulnerabilityOptions) ([]*models.VulnerabilityItem, bool, error) {
-	var allVuln []*models.VulnerabilityItem
 	if opts.All {
+		var allVulnerabilities []*models.VulnerabilityItem
+
 		log.Debug("Fetching all vulnerabilities")
 		opts.PageSize = 100
 		opts.Page = 1
+
 		for {
-			response, err := api.ListVulnerabilities(opts)
+			vulnerabilities, err := api.ListVulnerabilities(opts)
 			if err != nil {
 				return nil, false, err
 			}
-			if len(response.Payload) == 0 {
+
+			if len(vulnerabilities) == 0 {
 				break
 			}
-			allVuln = append(allVuln, response.Payload...)
+
+			allVulnerabilities = append(allVulnerabilities, vulnerabilities...)
 			opts.Page++
+
 			if opts.Page > 10 {
-				return allVuln, true, nil
+				return allVulnerabilities, true, nil
 			}
 		}
-	} else {
-		response, err := api.ListVulnerabilities(opts)
-		if err != nil {
-			return nil, false, err
-		}
-		allVuln = append(allVuln, response.Payload...)
+
+		return allVulnerabilities, false, nil
 	}
-	return allVuln, false, nil
+
+	vulnerabilities, err := api.ListVulnerabilities(opts)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return vulnerabilities, false, nil
 }

--- a/cmd/harbor/root/vulnerability/list.go
+++ b/cmd/harbor/root/vulnerability/list.go
@@ -66,7 +66,6 @@ func ListVulnerabilitiesCommand() *cobra.Command {
 	flags := cmd.Flags()
 	flags.Int64VarP(&opts.Page, "page", "", 1, "Page number")
 	flags.Int64VarP(&opts.PageSize, "page-size", "", 10, "Size of per page")
-	flags.StringVarP(&opts.Q, "query", "q", "", "Filter vulnerabilities with a ',' separated query string like exact k=v and range k=[min~max]")
 	flags.StringVarP(&opts.CVEID, "cve-id", "", "", "Filter by exact CVE ID")
 	flags.StringVarP(&opts.CVSSScore, "cvss-score", "", "", "Filter by CVSS v3 score range (e.g. 7.0~10.0) or exact score (e.g. 7.0)")
 	flags.StringVarP(&opts.Severity, "severity", "", "", "Filter by severity level")
@@ -91,7 +90,7 @@ func fetchVulnerabilities(opts api.ListVulnerabilityOptions) ([]*models.Vulnerab
 		for {
 			response, err := api.ListVulnerabilities(opts)
 			if err != nil {
-				return nil, false, fmt.Errorf("failed to list vulnerabilities: %v", utils.ParseHarborErrorMsg(err))
+				return nil, false, err
 			}
 			if len(response.Payload) == 0 {
 				break
@@ -105,7 +104,7 @@ func fetchVulnerabilities(opts api.ListVulnerabilityOptions) ([]*models.Vulnerab
 	} else {
 		response, err := api.ListVulnerabilities(opts)
 		if err != nil {
-			return nil, false, fmt.Errorf("failed to list vulnerabilities: %v", utils.ParseHarborErrorMsg(err))
+			return nil, false, err
 		}
 		allVuln = append(allVuln, response.Payload...)
 	}

--- a/cmd/harbor/root/vulnerability/list.go
+++ b/cmd/harbor/root/vulnerability/list.go
@@ -1,0 +1,85 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package vulnerability
+
+import (
+	"fmt"
+
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	vulnlist "github.com/goharbor/harbor-cli/pkg/views/vulnerability/list"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func ListVulnerabilitiesCommand() *cobra.Command {
+	var opts api.ListVulnerabilityOptions
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List vulnerabilities in Security Hub",
+		Long:    "List vulnerabilities from Harbor Security Hub",
+		Example: `  harbor vulnerability list`,
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.PageSize < 0 {
+				return fmt.Errorf("page size must be greater than or equal to 0")
+			}
+
+			if opts.PageSize > 100 {
+				return fmt.Errorf("page size should be less than or equal to 100")
+			}
+
+			response, err := api.ListVulnerabilities(opts)
+			if err != nil {
+				return fmt.Errorf("failed to list vulnerabilities: %v", utils.ParseHarborErrorMsg(err))
+			}
+
+			if len(response.Payload) == 0 {
+				log.Info("No vulnerabilities found")
+				return nil
+			}
+
+			formatFlag := viper.GetString("output-format")
+			if formatFlag != "" {
+				err = utils.PrintFormat(response.Payload, formatFlag)
+				if err != nil {
+					return err
+				}
+			} else {
+				vulnlist.ViewVulnerabilityList(response.Payload)
+			}
+
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.Int64VarP(&opts.Page, "page", "", 1, "Page number")
+	flags.Int64VarP(&opts.PageSize, "page-size", "", 10, "Size of per page")
+	flags.StringVarP(&opts.Q, "query", "q", "", "Filter vulnerabilities with a ',' separated query string like exact k=v and range k=[min~max]")
+	flags.StringVarP(&opts.CVEID, "cve-id", "", "", "Filter by exact CVE ID")
+	flags.StringVarP(&opts.CVSSScore, "cvss-score", "", "", "Filter by CVSS v3 score range (e.g. [7.0~10.0])")
+	flags.StringVarP(&opts.Severity, "severity", "", "", "Filter by severity level")
+	flags.StringVarP(&opts.Repository, "repository", "", "", "Filter by exact repository name")
+	flags.StringVarP(&opts.ProjectName, "project-name", "", "", "Filter by exact project name")
+	flags.StringVarP(&opts.Package, "package", "", "", "Filter by exact package name")
+	flags.StringVarP(&opts.Tag, "tag", "", "", "Filter by exact artifact tag")
+	flags.StringVarP(&opts.Digest, "digest", "", "", "Filter by exact artifact digest")
+	flags.StringVarP(&opts.Exclude, "exclude", "", "", "Exclude vulnerabilities using a ',' separated query string (e.g., k=v or k=[min~max])")
+	flags.BoolVarP(&opts.Fixable, "fixable", "", false, "Only show fixable vulnerabilities")
+
+	return cmd
+}

--- a/doc/cli-docs/harbor-artifact-delete.md
+++ b/doc/cli-docs/harbor-artifact-delete.md
@@ -22,7 +22,7 @@ harbor artifact delete [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-artifact-label-add.md
+++ b/doc/cli-docs/harbor-artifact-label-add.md
@@ -38,7 +38,7 @@ harbor artifact label add [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-artifact-label-delete.md
+++ b/doc/cli-docs/harbor-artifact-label-delete.md
@@ -40,7 +40,7 @@ harbor artifact label delete [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-artifact-label-list.md
+++ b/doc/cli-docs/harbor-artifact-label-list.md
@@ -46,7 +46,7 @@ harbor artifact label list [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-artifact-label.md
+++ b/doc/cli-docs/harbor-artifact-label.md
@@ -30,7 +30,7 @@ harbor artifact label del <project>/<repository>/<reference> <label name>
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-artifact-list.md
+++ b/doc/cli-docs/harbor-artifact-list.md
@@ -38,7 +38,7 @@ harbor artifact list [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-artifact-scan-start.md
+++ b/doc/cli-docs/harbor-artifact-scan-start.md
@@ -32,7 +32,7 @@ harbor artifact scan start <project>/<repository>/<reference>
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-artifact-scan-stop.md
+++ b/doc/cli-docs/harbor-artifact-scan-stop.md
@@ -32,7 +32,7 @@ harbor artifact scan stop <project>/<repository>/<reference>
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-artifact-scan.md
+++ b/doc/cli-docs/harbor-artifact-scan.md
@@ -28,7 +28,7 @@ harbor artifact scan start <project>/<repository>/<reference>
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-artifact-tags-create.md
+++ b/doc/cli-docs/harbor-artifact-tags-create.md
@@ -28,7 +28,7 @@ harbor artifact tags create <project>/<repository>/<reference> <tag>
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-artifact-tags-delete.md
+++ b/doc/cli-docs/harbor-artifact-tags-delete.md
@@ -28,7 +28,7 @@ harbor artifact tags delete <project>/<repository>/<reference> <tag>
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-artifact-tags-list.md
+++ b/doc/cli-docs/harbor-artifact-tags-list.md
@@ -28,7 +28,7 @@ harbor artifact tags list <project>/<repository>/<reference>
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-artifact-tags.md
+++ b/doc/cli-docs/harbor-artifact-tags.md
@@ -24,7 +24,7 @@ weight: 85
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-artifact-view.md
+++ b/doc/cli-docs/harbor-artifact-view.md
@@ -32,7 +32,7 @@ harbor artifact view <project>/<repository>:<tag> OR harbor artifact view <proje
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-artifact.md
+++ b/doc/cli-docs/harbor-artifact.md
@@ -28,7 +28,7 @@ Manage artifacts in Harbor Repository
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-config-apply.md
+++ b/doc/cli-docs/harbor-config-apply.md
@@ -37,7 +37,7 @@ harbor config apply -f <config_file>
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-config-view.md
+++ b/doc/cli-docs/harbor-config-view.md
@@ -44,7 +44,7 @@ harbor config view [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-config.md
+++ b/doc/cli-docs/harbor-config.md
@@ -55,7 +55,7 @@ Categories available:
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-context-delete.md
+++ b/doc/cli-docs/harbor-context-delete.md
@@ -45,7 +45,7 @@ harbor context delete <item> [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-context-get.md
+++ b/doc/cli-docs/harbor-context-get.md
@@ -40,7 +40,7 @@ harbor context get <item> [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-context-list.md
+++ b/doc/cli-docs/harbor-context-list.md
@@ -28,7 +28,7 @@ harbor context list [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-context-switch.md
+++ b/doc/cli-docs/harbor-context-switch.md
@@ -28,7 +28,7 @@ harbor context switch harbor-cli@https-demo-goharbor-io
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-context-update.md
+++ b/doc/cli-docs/harbor-context-update.md
@@ -41,7 +41,7 @@ harbor context update <item> <value> [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-context.md
+++ b/doc/cli-docs/harbor-context.md
@@ -29,7 +29,7 @@ harbor context list
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-cve-allowlist-add.md
+++ b/doc/cli-docs/harbor-cve-allowlist-add.md
@@ -29,7 +29,7 @@ harbor cve-allowlist add [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-cve-allowlist-list.md
+++ b/doc/cli-docs/harbor-cve-allowlist-list.md
@@ -22,7 +22,7 @@ harbor cve-allowlist list [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-cve-allowlist.md
+++ b/doc/cli-docs/harbor-cve-allowlist.md
@@ -28,7 +28,7 @@ harbor cve-allowlist list
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-health.md
+++ b/doc/cli-docs/harbor-health.md
@@ -28,7 +28,7 @@ harbor health [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-info.md
+++ b/doc/cli-docs/harbor-info.md
@@ -38,7 +38,7 @@ harbor info [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-instance-create.md
+++ b/doc/cli-docs/harbor-instance-create.md
@@ -41,7 +41,7 @@ harbor instance create [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-instance-delete.md
+++ b/doc/cli-docs/harbor-instance-delete.md
@@ -35,7 +35,7 @@ harbor instance delete [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-instance-list.md
+++ b/doc/cli-docs/harbor-instance-list.md
@@ -39,7 +39,7 @@ harbor instance list [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-instance.md
+++ b/doc/cli-docs/harbor-instance.md
@@ -23,7 +23,7 @@ These instances represent external services such as Dragonfly or Kraken that hel
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-label-create.md
+++ b/doc/cli-docs/harbor-label-create.md
@@ -37,7 +37,7 @@ harbor label create
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-label-delete.md
+++ b/doc/cli-docs/harbor-label-delete.md
@@ -31,7 +31,7 @@ harbor label delete [labelname]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-label-list.md
+++ b/doc/cli-docs/harbor-label-list.md
@@ -32,7 +32,7 @@ harbor label list [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-label-update.md
+++ b/doc/cli-docs/harbor-label-update.md
@@ -34,7 +34,7 @@ harbor label update [labelname]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-label.md
+++ b/doc/cli-docs/harbor-label.md
@@ -18,7 +18,7 @@ weight: 65
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-ldap-import.md
+++ b/doc/cli-docs/harbor-ldap-import.md
@@ -23,7 +23,7 @@ harbor ldap import [userID] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-ldap-ping.md
+++ b/doc/cli-docs/harbor-ldap-ping.md
@@ -30,7 +30,7 @@ harbor ldap ping [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-ldap-search.md
+++ b/doc/cli-docs/harbor-ldap-search.md
@@ -22,7 +22,7 @@ harbor ldap search [userID] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-ldap.md
+++ b/doc/cli-docs/harbor-ldap.md
@@ -24,7 +24,7 @@ weight: 20
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-login.md
+++ b/doc/cli-docs/harbor-login.md
@@ -30,7 +30,7 @@ harbor login [server] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-logs.md
+++ b/doc/cli-docs/harbor-logs.md
@@ -39,7 +39,7 @@ harbor logs [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-password.md
+++ b/doc/cli-docs/harbor-password.md
@@ -22,7 +22,7 @@ harbor password [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-project-config-list.md
+++ b/doc/cli-docs/harbor-project-config-list.md
@@ -46,7 +46,7 @@ harbor project config list  [project_name] [flags]
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
       --id                     Use project ID instead of name
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-project-config-update.md
+++ b/doc/cli-docs/harbor-project-config-update.md
@@ -53,7 +53,7 @@ harbor project config update [project_name] [flags]
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
       --id                     Use project ID instead of name
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-project-config.md
+++ b/doc/cli-docs/harbor-project-config.md
@@ -19,7 +19,7 @@ weight: 45
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-project-create.md
+++ b/doc/cli-docs/harbor-project-create.md
@@ -26,7 +26,7 @@ harbor project create [project name] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-project-delete.md
+++ b/doc/cli-docs/harbor-project-delete.md
@@ -34,7 +34,7 @@ harbor project delete [projectname1] [projectname2] or harbor project delete --p
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-project-list.md
+++ b/doc/cli-docs/harbor-project-list.md
@@ -31,7 +31,7 @@ harbor project list [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-project-logs.md
+++ b/doc/cli-docs/harbor-project-logs.md
@@ -26,7 +26,7 @@ harbor project logs [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-project-member-create.md
+++ b/doc/cli-docs/harbor-project-member-create.md
@@ -41,7 +41,7 @@ harbor project member create [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-project-member-delete.md
+++ b/doc/cli-docs/harbor-project-member-delete.md
@@ -35,7 +35,7 @@ harbor project member delete [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-project-member-list.md
+++ b/doc/cli-docs/harbor-project-member-list.md
@@ -37,7 +37,7 @@ harbor project member list [projectName] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-project-member-update.md
+++ b/doc/cli-docs/harbor-project-member-update.md
@@ -35,7 +35,7 @@ harbor project member update [ProjectName] [memberName] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-project-member.md
+++ b/doc/cli-docs/harbor-project-member.md
@@ -28,7 +28,7 @@ Manage members and assign roles to them
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-project-robot-create.md
+++ b/doc/cli-docs/harbor-project-robot-create.md
@@ -82,7 +82,7 @@ harbor project robot create [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-project-robot-delete.md
+++ b/doc/cli-docs/harbor-project-robot-delete.md
@@ -54,7 +54,7 @@ harbor project robot delete [robotName] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-project-robot-list.md
+++ b/doc/cli-docs/harbor-project-robot-list.md
@@ -63,7 +63,7 @@ harbor project robot list [projectName] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-project-robot-refresh.md
+++ b/doc/cli-docs/harbor-project-robot-refresh.md
@@ -63,7 +63,7 @@ harbor project robot refresh [robotID] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-project-robot-update.md
+++ b/doc/cli-docs/harbor-project-robot-update.md
@@ -72,7 +72,7 @@ harbor project robot update [robotID] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-project-robot-view.md
+++ b/doc/cli-docs/harbor-project-robot-view.md
@@ -52,7 +52,7 @@ harbor project robot view [robotID] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-project-robot.md
+++ b/doc/cli-docs/harbor-project-robot.md
@@ -24,7 +24,7 @@ weight: 40
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-project-search.md
+++ b/doc/cli-docs/harbor-project-search.md
@@ -22,7 +22,7 @@ harbor project search [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-project-view.md
+++ b/doc/cli-docs/harbor-project-view.md
@@ -23,7 +23,7 @@ harbor project view [NAME|ID] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-project.md
+++ b/doc/cli-docs/harbor-project.md
@@ -28,7 +28,7 @@ Manage projects in Harbor
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-quota-list.md
+++ b/doc/cli-docs/harbor-quota-list.md
@@ -31,7 +31,7 @@ harbor quota list [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-quota-update.md
+++ b/doc/cli-docs/harbor-quota-update.md
@@ -25,7 +25,7 @@ harbor quota update [QuotaID] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-quota-view.md
+++ b/doc/cli-docs/harbor-quota-view.md
@@ -24,7 +24,7 @@ harbor quota view [quotaID] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-quota.md
+++ b/doc/cli-docs/harbor-quota.md
@@ -28,7 +28,7 @@ Manage quotas of projects
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-registry-create.md
+++ b/doc/cli-docs/harbor-registry-create.md
@@ -36,7 +36,7 @@ harbor registry create
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-registry-delete.md
+++ b/doc/cli-docs/harbor-registry-delete.md
@@ -28,7 +28,7 @@ harbor registry delete [registryname]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-registry-list.md
+++ b/doc/cli-docs/harbor-registry-list.md
@@ -26,7 +26,7 @@ harbor registry list [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-registry-update.md
+++ b/doc/cli-docs/harbor-registry-update.md
@@ -30,7 +30,7 @@ harbor registry update [registry_name] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-registry-view.md
+++ b/doc/cli-docs/harbor-registry-view.md
@@ -28,7 +28,7 @@ harbor registry view [registryName]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-registry.md
+++ b/doc/cli-docs/harbor-registry.md
@@ -28,7 +28,7 @@ Manage registries in Harbor
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-replication-executions-list.md
+++ b/doc/cli-docs/harbor-replication-executions-list.md
@@ -37,7 +37,7 @@ harbor replication executions list [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-replication-executions-view.md
+++ b/doc/cli-docs/harbor-replication-executions-view.md
@@ -34,7 +34,7 @@ harbor replication executions view [ID] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-replication-executions.md
+++ b/doc/cli-docs/harbor-replication-executions.md
@@ -22,7 +22,7 @@ Manage replication executions in Harbor context
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-replication-log.md
+++ b/doc/cli-docs/harbor-replication-log.md
@@ -37,7 +37,7 @@ harbor replication log [EXECUTION_ID] [TASK_ID] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-replication-policies-create.md
+++ b/doc/cli-docs/harbor-replication-policies-create.md
@@ -23,7 +23,7 @@ harbor replication policies create [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-replication-policies-delete.md
+++ b/doc/cli-docs/harbor-replication-policies-delete.md
@@ -22,7 +22,7 @@ harbor replication policies delete [NAME|ID] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-replication-policies-list.md
+++ b/doc/cli-docs/harbor-replication-policies-list.md
@@ -26,7 +26,7 @@ harbor replication policies list [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-replication-policies-update.md
+++ b/doc/cli-docs/harbor-replication-policies-update.md
@@ -22,7 +22,7 @@ harbor replication policies update [policy-id] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-replication-policies-view.md
+++ b/doc/cli-docs/harbor-replication-policies-view.md
@@ -22,7 +22,7 @@ harbor replication policies view [NAME|ID] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-replication-policies.md
+++ b/doc/cli-docs/harbor-replication-policies.md
@@ -22,7 +22,7 @@ Manage replication policies in Harbor context
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-replication-start.md
+++ b/doc/cli-docs/harbor-replication-start.md
@@ -22,7 +22,7 @@ harbor replication start [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-replication-stop.md
+++ b/doc/cli-docs/harbor-replication-stop.md
@@ -22,7 +22,7 @@ harbor replication stop [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-replication.md
+++ b/doc/cli-docs/harbor-replication.md
@@ -22,7 +22,7 @@ Manage replications in Harbor context
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-repo-delete.md
+++ b/doc/cli-docs/harbor-repo-delete.md
@@ -32,7 +32,7 @@ harbor repo delete [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-repo-list.md
+++ b/doc/cli-docs/harbor-repo-list.md
@@ -36,7 +36,7 @@ harbor repo list [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-repo-search.md
+++ b/doc/cli-docs/harbor-repo-search.md
@@ -22,7 +22,7 @@ harbor repo search [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-repo-view.md
+++ b/doc/cli-docs/harbor-repo-view.md
@@ -32,7 +32,7 @@ harbor repo view [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-repo.md
+++ b/doc/cli-docs/harbor-repo.md
@@ -22,7 +22,7 @@ Manage repositories in Harbor context
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-robot-create.md
+++ b/doc/cli-docs/harbor-robot-create.md
@@ -73,7 +73,7 @@ harbor robot create [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-robot-delete.md
+++ b/doc/cli-docs/harbor-robot-delete.md
@@ -47,7 +47,7 @@ harbor robot delete [robotName] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-robot-list.md
+++ b/doc/cli-docs/harbor-robot-list.md
@@ -60,7 +60,7 @@ harbor robot list [projectName] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-robot-refresh.md
+++ b/doc/cli-docs/harbor-robot-refresh.md
@@ -63,7 +63,7 @@ harbor robot refresh [robotID] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-robot-update.md
+++ b/doc/cli-docs/harbor-robot-update.md
@@ -74,7 +74,7 @@ harbor robot update [robotID] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-robot-view.md
+++ b/doc/cli-docs/harbor-robot-view.md
@@ -51,7 +51,7 @@ harbor robot view [robotID] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-robot.md
+++ b/doc/cli-docs/harbor-robot.md
@@ -24,7 +24,7 @@ weight: 75
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-scan-all-metrics.md
+++ b/doc/cli-docs/harbor-scan-all-metrics.md
@@ -50,7 +50,7 @@ harbor scan-all metrics [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-scan-all-run.md
+++ b/doc/cli-docs/harbor-scan-all-run.md
@@ -49,7 +49,7 @@ harbor scan-all run [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-scan-all-stop.md
+++ b/doc/cli-docs/harbor-scan-all-stop.md
@@ -36,7 +36,7 @@ harbor scan-all stop [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-scan-all-update-schedule.md
+++ b/doc/cli-docs/harbor-scan-all-update-schedule.md
@@ -57,7 +57,7 @@ harbor scan-all update-schedule [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-scan-all-view-schedule.md
+++ b/doc/cli-docs/harbor-scan-all-view-schedule.md
@@ -44,7 +44,7 @@ harbor scan-all view-schedule [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-scan-all.md
+++ b/doc/cli-docs/harbor-scan-all.md
@@ -18,7 +18,7 @@ weight: 85
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-scanner-create.md
+++ b/doc/cli-docs/harbor-scanner-create.md
@@ -31,7 +31,7 @@ harbor scanner create [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-scanner-delete.md
+++ b/doc/cli-docs/harbor-scanner-delete.md
@@ -39,7 +39,7 @@ harbor scanner delete [scanner-name] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-scanner-list.md
+++ b/doc/cli-docs/harbor-scanner-list.md
@@ -22,7 +22,7 @@ harbor scanner list [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-scanner-metadata.md
+++ b/doc/cli-docs/harbor-scanner-metadata.md
@@ -42,7 +42,7 @@ harbor scanner metadata [scanner-name] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-scanner-set-default.md
+++ b/doc/cli-docs/harbor-scanner-set-default.md
@@ -34,7 +34,7 @@ harbor scanner set-default [scanner-name]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-scanner-update.md
+++ b/doc/cli-docs/harbor-scanner-update.md
@@ -55,7 +55,7 @@ harbor scanner update [scanner-name] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-scanner-view.md
+++ b/doc/cli-docs/harbor-scanner-view.md
@@ -42,7 +42,7 @@ harbor scanner view [scanner-name] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-scanner.md
+++ b/doc/cli-docs/harbor-scanner.md
@@ -18,7 +18,7 @@ weight: 70
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-schedule-list.md
+++ b/doc/cli-docs/harbor-schedule-list.md
@@ -24,7 +24,7 @@ harbor schedule list [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-schedule.md
+++ b/doc/cli-docs/harbor-schedule.md
@@ -18,7 +18,7 @@ weight: 25
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-tag-immutable-create.md
+++ b/doc/cli-docs/harbor-tag-immutable-create.md
@@ -36,7 +36,7 @@ harbor tag immutable create
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-tag-immutable-delete.md
+++ b/doc/cli-docs/harbor-tag-immutable-delete.md
@@ -22,7 +22,7 @@ harbor tag immutable delete [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-tag-immutable-list.md
+++ b/doc/cli-docs/harbor-tag-immutable-list.md
@@ -40,7 +40,7 @@ harbor tag immutable list [PROJECT_NAME] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-tag-immutable.md
+++ b/doc/cli-docs/harbor-tag-immutable.md
@@ -28,7 +28,7 @@ harbor tag immutable
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-tag.md
+++ b/doc/cli-docs/harbor-tag.md
@@ -22,7 +22,7 @@ Manage tags in the Harbor registry, including creating, listing, and deleting ru
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-user-create.md
+++ b/doc/cli-docs/harbor-user-create.md
@@ -27,7 +27,7 @@ harbor user create [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-user-delete.md
+++ b/doc/cli-docs/harbor-user-delete.md
@@ -22,7 +22,7 @@ harbor user delete [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-user-elevate.md
+++ b/doc/cli-docs/harbor-user-elevate.md
@@ -26,7 +26,7 @@ harbor user elevate [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-user-list.md
+++ b/doc/cli-docs/harbor-user-list.md
@@ -26,7 +26,7 @@ harbor user list [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-user-password.md
+++ b/doc/cli-docs/harbor-user-password.md
@@ -26,7 +26,7 @@ harbor user password [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-user.md
+++ b/doc/cli-docs/harbor-user.md
@@ -28,7 +28,7 @@ Manage users in Harbor
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-version.md
+++ b/doc/cli-docs/harbor-version.md
@@ -32,7 +32,7 @@ harbor version [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-vulnerability-list.md
+++ b/doc/cli-docs/harbor-vulnerability-list.md
@@ -45,7 +45,7 @@ harbor vulnerability list [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-vulnerability-list.md
+++ b/doc/cli-docs/harbor-vulnerability-list.md
@@ -26,7 +26,7 @@ harbor vulnerability list [flags]
 
 ```sh
       --cve-id string         Filter by exact CVE ID
-      --cvss-score string     Filter by CVSS v3 score range (e.g. [7.0~10.0])
+      --cvss-score string     Filter by CVSS v3 score range (e.g. 7.0~10.0) or exact score (e.g. 7.0)
       --digest string         Filter by exact artifact digest
       --exclude string        Exclude vulnerabilities using a ',' separated query string (e.g., k=v or k=[min~max])
       --fixable               Only show fixable vulnerabilities

--- a/doc/cli-docs/harbor-vulnerability-list.md
+++ b/doc/cli-docs/harbor-vulnerability-list.md
@@ -25,6 +25,7 @@ harbor vulnerability list [flags]
 ### Options
 
 ```sh
+      --all                   Show all vulnerabilities (up to 1000)
       --cve-id string         Filter by exact CVE ID
       --cvss-score string     Filter by CVSS v3 score range (e.g. 7.0~10.0) or exact score (e.g. 7.0)
       --digest string         Filter by exact artifact digest

--- a/doc/cli-docs/harbor-vulnerability-list.md
+++ b/doc/cli-docs/harbor-vulnerability-list.md
@@ -36,7 +36,6 @@ harbor vulnerability list [flags]
       --page int              Page number (default 1)
       --page-size int         Size of per page (default 10)
       --project-name string   Filter by exact project name
-  -q, --query string          Filter vulnerabilities with a ',' separated query string like exact k=v and range k=[min~max]
       --repository string     Filter by exact repository name
       --severity string       Filter by severity level
       --tag string            Filter by exact artifact tag

--- a/doc/cli-docs/harbor-vulnerability-list.md
+++ b/doc/cli-docs/harbor-vulnerability-list.md
@@ -1,0 +1,55 @@
+---
+title: harbor vulnerability list
+weight: 90
+---
+## harbor vulnerability list
+
+### Description
+
+##### List vulnerabilities in Security Hub
+
+### Synopsis
+
+List vulnerabilities from Harbor Security Hub
+
+```sh
+harbor vulnerability list [flags]
+```
+
+### Examples
+
+```sh
+  harbor vulnerability list
+```
+
+### Options
+
+```sh
+      --cve-id string         Filter by exact CVE ID
+      --cvss-score string     Filter by CVSS v3 score range (e.g. [7.0~10.0])
+      --digest string         Filter by exact artifact digest
+      --exclude string        Exclude vulnerabilities using a ',' separated query string (e.g., k=v or k=[min~max])
+      --fixable               Only show fixable vulnerabilities
+  -h, --help                  help for list
+      --package string        Filter by exact package name
+      --page int              Page number (default 1)
+      --page-size int         Size of per page (default 10)
+      --project-name string   Filter by exact project name
+  -q, --query string          Filter vulnerabilities with a ',' separated query string like exact k=v and range k=[min~max]
+      --repository string     Filter by exact repository name
+      --severity string       Filter by severity level
+      --tag string            Filter by exact artifact tag
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor vulnerability](harbor-vulnerability.md)	 - Manage vulnerabilities in Security Hub
+

--- a/doc/cli-docs/harbor-vulnerability-summary.md
+++ b/doc/cli-docs/harbor-vulnerability-summary.md
@@ -37,7 +37,7 @@ harbor vulnerability summary [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-vulnerability.md
+++ b/doc/cli-docs/harbor-vulnerability.md
@@ -28,7 +28,7 @@ List vulnerabilities and view vulnerability summary from Harbor Security Hub
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-vulnerability.md
+++ b/doc/cli-docs/harbor-vulnerability.md
@@ -35,5 +35,6 @@ List vulnerabilities and view vulnerability summary from Harbor Security Hub
 ### SEE ALSO
 
 * [harbor](harbor.md)	 - Official Harbor CLI
+* [harbor vulnerability list](harbor-vulnerability-list.md)	 - List vulnerabilities in Security Hub
 * [harbor vulnerability summary](harbor-vulnerability-summary.md)	 - Get Security Hub vulnerability summary
 

--- a/doc/cli-docs/harbor-webhook-create.md
+++ b/doc/cli-docs/harbor-webhook-create.md
@@ -54,7 +54,7 @@ harbor webhook create [name] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-webhook-delete.md
+++ b/doc/cli-docs/harbor-webhook-delete.md
@@ -44,7 +44,7 @@ harbor webhook delete [webhook-name] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-webhook-edit.md
+++ b/doc/cli-docs/harbor-webhook-edit.md
@@ -57,7 +57,7 @@ harbor webhook edit [WEBHOOK_NAME] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-webhook-list.md
+++ b/doc/cli-docs/harbor-webhook-list.md
@@ -42,7 +42,7 @@ harbor webhook list [PROJECT_NAME] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-webhook.md
+++ b/doc/cli-docs/harbor-webhook.md
@@ -41,7 +41,7 @@ This command supports listing, creating, editing, and deleting webhook configura
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor.md
+++ b/doc/cli-docs/harbor.md
@@ -29,7 +29,7 @@ harbor help
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
   -h, --help                   help for harbor
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/man-docs/man1/harbor-artifact-delete.1
+++ b/doc/man-docs/man1/harbor-artifact-delete.1
@@ -24,7 +24,7 @@ delete an artifact
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-artifact-label-add.1
+++ b/doc/man-docs/man1/harbor-artifact-label-add.1
@@ -38,7 +38,7 @@ Examples:
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-artifact-label-delete.1
+++ b/doc/man-docs/man1/harbor-artifact-label-delete.1
@@ -42,7 +42,7 @@ Examples:
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-artifact-label-list.1
+++ b/doc/man-docs/man1/harbor-artifact-label-list.1
@@ -29,7 +29,7 @@ Supports output formatting such as JSON or YAML using the --output (-o) flag.
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-artifact-label.1
+++ b/doc/man-docs/man1/harbor-artifact-label.1
@@ -24,7 +24,7 @@ label command for artifact
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-artifact-list.1
+++ b/doc/man-docs/man1/harbor-artifact-list.1
@@ -50,7 +50,7 @@ Supports pagination, search queries, and sorting using flags.
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-artifact-scan-start.1
+++ b/doc/man-docs/man1/harbor-artifact-scan-start.1
@@ -24,7 +24,7 @@ Start a scan of an artifact in Harbor Repository
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-artifact-scan-stop.1
+++ b/doc/man-docs/man1/harbor-artifact-scan-stop.1
@@ -24,7 +24,7 @@ Stop a scan of an artifact in Harbor Repository
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-artifact-scan.1
+++ b/doc/man-docs/man1/harbor-artifact-scan.1
@@ -24,7 +24,7 @@ Scan an artifact in Harbor Repository
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-artifact-tags-create.1
+++ b/doc/man-docs/man1/harbor-artifact-tags-create.1
@@ -24,7 +24,7 @@ Create a tag of an artifact
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-artifact-tags-delete.1
+++ b/doc/man-docs/man1/harbor-artifact-tags-delete.1
@@ -24,7 +24,7 @@ Delete a tag of an artifact
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-artifact-tags-list.1
+++ b/doc/man-docs/man1/harbor-artifact-tags-list.1
@@ -24,7 +24,7 @@ List tags of an artifact
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-artifact-tags.1
+++ b/doc/man-docs/man1/harbor-artifact-tags.1
@@ -24,7 +24,7 @@ Manage tags of an artifact
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-artifact-view.1
+++ b/doc/man-docs/man1/harbor-artifact-view.1
@@ -24,7 +24,7 @@ Get information of an artifact
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-artifact.1
+++ b/doc/man-docs/man1/harbor-artifact.1
@@ -24,7 +24,7 @@ Manage artifacts in Harbor Repository
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-config-apply.1
+++ b/doc/man-docs/man1/harbor-config-apply.1
@@ -36,7 +36,7 @@ Make sure to run 'harbor config get' first to populate the local config file wit
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-config-view.1
+++ b/doc/man-docs/man1/harbor-config-view.1
@@ -51,7 +51,7 @@ Examples:
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-config.1
+++ b/doc/man-docs/man1/harbor-config.1
@@ -37,7 +37,7 @@ Categories available:
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-context-delete.1
+++ b/doc/man-docs/man1/harbor-context-delete.1
@@ -34,7 +34,7 @@ If you specify --name, that credential (rather than the "current" one) will be u
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-context-get.1
+++ b/doc/man-docs/man1/harbor-context-get.1
@@ -29,7 +29,7 @@ If you specify --name, that credential (rather than the "current" one) will be u
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-context-list.1
+++ b/doc/man-docs/man1/harbor-context-list.1
@@ -24,7 +24,7 @@ List contexts
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-context-switch.1
+++ b/doc/man-docs/man1/harbor-context-switch.1
@@ -24,7 +24,7 @@ Switch to a new context
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-context-update.1
+++ b/doc/man-docs/man1/harbor-context-update.1
@@ -30,7 +30,7 @@ If you specify --name, that credential (rather than the "current" one) will be u
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-context.1
+++ b/doc/man-docs/man1/harbor-context.1
@@ -25,7 +25,7 @@ The context command allows you to manage configuration items of the Harbor CLI.
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-cve-allowlist-add.1
+++ b/doc/man-docs/man1/harbor-cve-allowlist-add.1
@@ -36,7 +36,7 @@ Create allowlist of CVEs to ignore during vulnerability scanning
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-cve-allowlist-list.1
+++ b/doc/man-docs/man1/harbor-cve-allowlist-list.1
@@ -24,7 +24,7 @@ List system level allowlist of cve
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-cve-allowlist.1
+++ b/doc/man-docs/man1/harbor-cve-allowlist.1
@@ -24,7 +24,7 @@ Managing CVE lists that are intentionally excluded from vulnerability scanning
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-health.1
+++ b/doc/man-docs/man1/harbor-health.1
@@ -24,7 +24,7 @@ Get the health status of Harbor components
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-info.1
+++ b/doc/man-docs/man1/harbor-info.1
@@ -29,7 +29,7 @@ The output can be formatted as table (default), JSON, or YAML using the '--outpu
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-instance-create.1
+++ b/doc/man-docs/man1/harbor-instance-create.1
@@ -54,7 +54,7 @@ You will need to provide the instance's name, vendor, endpoint, and optionally o
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-instance-delete.1
+++ b/doc/man-docs/man1/harbor-instance-delete.1
@@ -29,7 +29,7 @@ If no argument is provided, you will be prompted to select an instance from a li
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-instance-list.1
+++ b/doc/man-docs/man1/harbor-instance-list.1
@@ -42,7 +42,7 @@ This command provides an easy way to view all instances along with their details
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-instance.1
+++ b/doc/man-docs/man1/harbor-instance.1
@@ -25,7 +25,7 @@ These instances represent external services such as Dragonfly or Kraken that hel
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-label-create.1
+++ b/doc/man-docs/man1/harbor-label-create.1
@@ -44,7 +44,7 @@ create label in harbor
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-label-delete.1
+++ b/doc/man-docs/man1/harbor-label-delete.1
@@ -36,7 +36,7 @@ delete label
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-label-list.1
+++ b/doc/man-docs/man1/harbor-label-list.1
@@ -64,7 +64,7 @@ list labels
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-label-update.1
+++ b/doc/man-docs/man1/harbor-label-update.1
@@ -48,7 +48,7 @@ update label
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-label.1
+++ b/doc/man-docs/man1/harbor-label.1
@@ -24,7 +24,7 @@ Manage labels in Harbor
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-ldap-import.1
+++ b/doc/man-docs/man1/harbor-ldap-import.1
@@ -28,7 +28,7 @@ import ldap user by registered userid
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-ldap-ping.1
+++ b/doc/man-docs/man1/harbor-ldap-ping.1
@@ -56,7 +56,7 @@ ping ldap server
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-ldap-search.1
+++ b/doc/man-docs/man1/harbor-ldap-search.1
@@ -24,7 +24,7 @@ search ldap user by registered userid
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-ldap.1
+++ b/doc/man-docs/man1/harbor-ldap.1
@@ -24,7 +24,7 @@ Manage ldap users and groups
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-login.1
+++ b/doc/man-docs/man1/harbor-login.1
@@ -40,7 +40,7 @@ Authenticate with Harbor Registry.
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-logs.1
+++ b/doc/man-docs/man1/harbor-logs.1
@@ -58,7 +58,7 @@ harbor-cli logs --output-format json
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-password.1
+++ b/doc/man-docs/man1/harbor-password.1
@@ -24,7 +24,7 @@ Change your password
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-project-config-list.1
+++ b/doc/man-docs/man1/harbor-project-config-list.1
@@ -53,7 +53,7 @@ Examples:
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-project-config-update.1
+++ b/doc/man-docs/man1/harbor-project-config-update.1
@@ -81,7 +81,7 @@ Severity: one of "low", "medium", "high", "critical"
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-project-config.1
+++ b/doc/man-docs/man1/harbor-project-config.1
@@ -28,7 +28,7 @@ Manage project configuration
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-project-create.1
+++ b/doc/man-docs/man1/harbor-project-create.1
@@ -40,7 +40,7 @@ create project
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-project-delete.1
+++ b/doc/man-docs/man1/harbor-project-delete.1
@@ -32,7 +32,7 @@ Delete project by name or ID. Multiple projects can be deleted by providing thei
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-project-list.1
+++ b/doc/man-docs/man1/harbor-project-list.1
@@ -60,7 +60,7 @@ List projects
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-project-logs.1
+++ b/doc/man-docs/man1/harbor-project-logs.1
@@ -40,7 +40,7 @@ get project logs
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-project-member-create.1
+++ b/doc/man-docs/man1/harbor-project-member-create.1
@@ -60,7 +60,7 @@ create project member by Name
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-project-member-delete.1
+++ b/doc/man-docs/man1/harbor-project-member-delete.1
@@ -36,7 +36,7 @@ delete members in a project by username of the member
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-project-member-list.1
+++ b/doc/man-docs/man1/harbor-project-member-list.1
@@ -44,7 +44,7 @@ list members in a project by projectName
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-project-member-update.1
+++ b/doc/man-docs/man1/harbor-project-member-update.1
@@ -36,7 +36,7 @@ update member in a project by MemberName
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-project-member.1
+++ b/doc/man-docs/man1/harbor-project-member.1
@@ -24,7 +24,7 @@ Manage members and assign roles to them
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-project-robot-create.1
+++ b/doc/man-docs/man1/harbor-project-robot-create.1
@@ -111,7 +111,7 @@ Examples:
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-project-robot-delete.1
+++ b/doc/man-docs/man1/harbor-project-robot-delete.1
@@ -62,7 +62,7 @@ Examples:
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-project-robot-list.1
+++ b/doc/man-docs/man1/harbor-project-robot-list.1
@@ -84,7 +84,7 @@ Examples:
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-project-robot-refresh.1
+++ b/doc/man-docs/man1/harbor-project-robot-refresh.1
@@ -76,7 +76,7 @@ Examples:
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-project-robot-update.1
+++ b/doc/man-docs/man1/harbor-project-robot-update.1
@@ -95,7 +95,7 @@ Examples:
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-project-robot-view.1
+++ b/doc/man-docs/man1/harbor-project-robot-view.1
@@ -59,7 +59,7 @@ Examples:
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-project-robot.1
+++ b/doc/man-docs/man1/harbor-project-robot.1
@@ -24,7 +24,7 @@ Manage robot accounts
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-project-search.1
+++ b/doc/man-docs/man1/harbor-project-search.1
@@ -24,7 +24,7 @@ search project based on their names
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-project-view.1
+++ b/doc/man-docs/man1/harbor-project-view.1
@@ -28,7 +28,7 @@ get project by name or id
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-project.1
+++ b/doc/man-docs/man1/harbor-project.1
@@ -24,7 +24,7 @@ Manage projects in Harbor
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-quota-list.1
+++ b/doc/man-docs/man1/harbor-quota-list.1
@@ -44,7 +44,7 @@ list quotas specified for each project
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-quota-update.1
+++ b/doc/man-docs/man1/harbor-quota-update.1
@@ -36,7 +36,7 @@ update quotas for projects
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-quota-view.1
+++ b/doc/man-docs/man1/harbor-quota-view.1
@@ -32,7 +32,7 @@ get quota by quota ID
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-quota.1
+++ b/doc/man-docs/man1/harbor-quota.1
@@ -24,7 +24,7 @@ Manage quotas of projects
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-registry-create.1
+++ b/doc/man-docs/man1/harbor-registry-create.1
@@ -56,7 +56,7 @@ create registry
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-registry-delete.1
+++ b/doc/man-docs/man1/harbor-registry-delete.1
@@ -24,7 +24,7 @@ delete registry by name or id
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-registry-list.1
+++ b/doc/man-docs/man1/harbor-registry-list.1
@@ -40,7 +40,7 @@ list registry
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-registry-update.1
+++ b/doc/man-docs/man1/harbor-registry-update.1
@@ -56,7 +56,7 @@ update registry
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-registry-view.1
+++ b/doc/man-docs/man1/harbor-registry-view.1
@@ -24,7 +24,7 @@ get registry information
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-registry.1
+++ b/doc/man-docs/man1/harbor-registry.1
@@ -24,7 +24,7 @@ Manage registries in Harbor
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-replication-executions-list.1
+++ b/doc/man-docs/man1/harbor-replication-executions-list.1
@@ -40,7 +40,7 @@ List all replication executions for a given replication policy. If no policy ID 
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-replication-executions-view.1
+++ b/doc/man-docs/man1/harbor-replication-executions-view.1
@@ -28,7 +28,7 @@ Get a specific replication execution by its ID. If no ID is provided, it will pr
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-replication-executions.1
+++ b/doc/man-docs/man1/harbor-replication-executions.1
@@ -24,7 +24,7 @@ Manage replication executions in Harbor context
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-replication-log.1
+++ b/doc/man-docs/man1/harbor-replication-log.1
@@ -32,7 +32,7 @@ Get the logs of a specific replication execution and task by their IDs. If no ID
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-replication-policies-create.1
+++ b/doc/man-docs/man1/harbor-replication-policies-create.1
@@ -28,7 +28,7 @@ create replication policies
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-replication-policies-delete.1
+++ b/doc/man-docs/man1/harbor-replication-policies-delete.1
@@ -24,7 +24,7 @@ delete replication policy by name or id
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-replication-policies-list.1
+++ b/doc/man-docs/man1/harbor-replication-policies-list.1
@@ -40,7 +40,7 @@ List replication policies
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-replication-policies-update.1
+++ b/doc/man-docs/man1/harbor-replication-policies-update.1
@@ -24,7 +24,7 @@ Update an existing replication policy
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-replication-policies-view.1
+++ b/doc/man-docs/man1/harbor-replication-policies-view.1
@@ -24,7 +24,7 @@ get replication policy by name or id
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-replication-policies.1
+++ b/doc/man-docs/man1/harbor-replication-policies.1
@@ -24,7 +24,7 @@ Manage replication policies in Harbor context
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-replication-start.1
+++ b/doc/man-docs/man1/harbor-replication-start.1
@@ -24,7 +24,7 @@ start replication
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-replication-stop.1
+++ b/doc/man-docs/man1/harbor-replication-stop.1
@@ -24,7 +24,7 @@ stop replication
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-replication.1
+++ b/doc/man-docs/man1/harbor-replication.1
@@ -24,7 +24,7 @@ Manage replications in Harbor context
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-repo-delete.1
+++ b/doc/man-docs/man1/harbor-repo-delete.1
@@ -24,7 +24,7 @@ Delete a repository within a project in Harbor
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-repo-list.1
+++ b/doc/man-docs/man1/harbor-repo-list.1
@@ -40,7 +40,7 @@ Get information of all repositories in a project
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-repo-search.1
+++ b/doc/man-docs/man1/harbor-repo-search.1
@@ -24,7 +24,7 @@ search repository based on their names
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-repo-view.1
+++ b/doc/man-docs/man1/harbor-repo-view.1
@@ -24,7 +24,7 @@ Get information of a particular repository in a project
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-repo.1
+++ b/doc/man-docs/man1/harbor-repo.1
@@ -24,7 +24,7 @@ Manage repositories in Harbor context
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-robot-create.1
+++ b/doc/man-docs/man1/harbor-robot-create.1
@@ -102,7 +102,7 @@ Examples:
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-robot-delete.1
+++ b/doc/man-docs/man1/harbor-robot-delete.1
@@ -50,7 +50,7 @@ Examples:
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-robot-list.1
+++ b/doc/man-docs/man1/harbor-robot-list.1
@@ -78,7 +78,7 @@ Examples:
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-robot-refresh.1
+++ b/doc/man-docs/man1/harbor-robot-refresh.1
@@ -76,7 +76,7 @@ Examples:
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-robot-update.1
+++ b/doc/man-docs/man1/harbor-robot-update.1
@@ -98,7 +98,7 @@ Examples:
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-robot-view.1
+++ b/doc/man-docs/man1/harbor-robot-view.1
@@ -55,7 +55,7 @@ Examples:
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-robot.1
+++ b/doc/man-docs/man1/harbor-robot.1
@@ -24,7 +24,7 @@ Manage robot accounts
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-scan-all-metrics.1
+++ b/doc/man-docs/man1/harbor-scan-all-metrics.1
@@ -62,7 +62,7 @@ Examples:
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-scan-all-run.1
+++ b/doc/man-docs/man1/harbor-scan-all-run.1
@@ -53,7 +53,7 @@ or through the Harbor web interface.
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-scan-all-stop.1
+++ b/doc/man-docs/man1/harbor-scan-all-stop.1
@@ -37,7 +37,7 @@ Examples:
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-scan-all-update-schedule.1
+++ b/doc/man-docs/man1/harbor-scan-all-update-schedule.1
@@ -67,7 +67,7 @@ Note: For custom schedules, if you provide a 5-field cron expression, the CLI wi
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-scan-all-view-schedule.1
+++ b/doc/man-docs/man1/harbor-scan-all-view-schedule.1
@@ -49,7 +49,7 @@ You can use this command to verify changes after updating the schedule with the 
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-scan-all.1
+++ b/doc/man-docs/man1/harbor-scan-all.1
@@ -24,7 +24,7 @@ Scan all artifacts
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-scanner-create.1
+++ b/doc/man-docs/man1/harbor-scanner-create.1
@@ -60,7 +60,7 @@ Create a scanner
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-scanner-delete.1
+++ b/doc/man-docs/man1/harbor-scanner-delete.1
@@ -41,7 +41,7 @@ Examples:
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-scanner-list.1
+++ b/doc/man-docs/man1/harbor-scanner-list.1
@@ -24,7 +24,7 @@ List scanners
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-scanner-metadata.1
+++ b/doc/man-docs/man1/harbor-scanner-metadata.1
@@ -45,7 +45,7 @@ Flags:
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-scanner-set-default.1
+++ b/doc/man-docs/man1/harbor-scanner-set-default.1
@@ -24,7 +24,7 @@ Set the scanner that will be used as the default in Harbor. This scanner will be
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-scanner-update.1
+++ b/doc/man-docs/man1/harbor-scanner-update.1
@@ -60,7 +60,7 @@ Only the fields passed through flags will be updated; other fields will retain t
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-scanner-view.1
+++ b/doc/man-docs/man1/harbor-scanner-view.1
@@ -45,7 +45,7 @@ Examples:
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-scanner.1
+++ b/doc/man-docs/man1/harbor-scanner.1
@@ -24,7 +24,7 @@ scanner commands
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-schedule-list.1
+++ b/doc/man-docs/man1/harbor-schedule-list.1
@@ -32,7 +32,7 @@ show all schedule jobs in Harbor
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-schedule.1
+++ b/doc/man-docs/man1/harbor-schedule.1
@@ -24,7 +24,7 @@ Schedule jobs in Harbor
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-tag-immutable-create.1
+++ b/doc/man-docs/man1/harbor-tag-immutable-create.1
@@ -40,7 +40,7 @@ create immutable tag rule to the project in harbor
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-tag-immutable-delete.1
+++ b/doc/man-docs/man1/harbor-tag-immutable-delete.1
@@ -24,7 +24,7 @@ delete immutable rule
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-tag-immutable-list.1
+++ b/doc/man-docs/man1/harbor-tag-immutable-list.1
@@ -26,7 +26,7 @@ You can specify the project name as an argument or, if omitted, you will be prom
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-tag-immutable.1
+++ b/doc/man-docs/man1/harbor-tag-immutable.1
@@ -24,7 +24,7 @@ Manage Immutability rules in the project in Harbor
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-tag.1
+++ b/doc/man-docs/man1/harbor-tag.1
@@ -24,7 +24,7 @@ Manage tags in the Harbor registry, including creating, listing, and deleting ru
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-user-create.1
+++ b/doc/man-docs/man1/harbor-user-create.1
@@ -44,7 +44,7 @@ create user
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-user-delete.1
+++ b/doc/man-docs/man1/harbor-user-delete.1
@@ -24,7 +24,7 @@ delete user by name or id
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-user-elevate.1
+++ b/doc/man-docs/man1/harbor-user-elevate.1
@@ -24,7 +24,7 @@ elevate user to admin role
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-user-list.1
+++ b/doc/man-docs/man1/harbor-user-list.1
@@ -40,7 +40,7 @@ List users
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-user-password.1
+++ b/doc/man-docs/man1/harbor-user-password.1
@@ -24,7 +24,7 @@ Allows admin to reset the password for a specified user or select interactively 
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-user.1
+++ b/doc/man-docs/man1/harbor-user.1
@@ -24,7 +24,7 @@ Manage users in Harbor
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-version.1
+++ b/doc/man-docs/man1/harbor-version.1
@@ -24,7 +24,7 @@ Get Harbor CLI version, git commit, go version, build time, release channel, os/
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-vulnerability-list.1
+++ b/doc/man-docs/man1/harbor-vulnerability-list.1
@@ -19,7 +19,7 @@ List vulnerabilities from Harbor Security Hub
 
 .PP
 \fB--cvss-score\fP=""
-	Filter by CVSS v3 score range (e.g. [7.0~10.0])
+	Filter by CVSS v3 score range (e.g. 7.0~10.0) or exact score (e.g. 7.0)
 
 .PP
 \fB--digest\fP=""

--- a/doc/man-docs/man1/harbor-vulnerability-list.1
+++ b/doc/man-docs/man1/harbor-vulnerability-list.1
@@ -76,7 +76,7 @@ List vulnerabilities from Harbor Security Hub
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-vulnerability-list.1
+++ b/doc/man-docs/man1/harbor-vulnerability-list.1
@@ -1,0 +1,93 @@
+.nh
+.TH "HARBOR" "1"  "Harbor Community" "Harbor User Manuals"
+
+.SH NAME
+harbor-vulnerability-list - List vulnerabilities in Security Hub
+
+
+.SH SYNOPSIS
+\fBharbor vulnerability list [flags]\fP
+
+
+.SH DESCRIPTION
+List vulnerabilities from Harbor Security Hub
+
+
+.SH OPTIONS
+\fB--cve-id\fP=""
+	Filter by exact CVE ID
+
+.PP
+\fB--cvss-score\fP=""
+	Filter by CVSS v3 score range (e.g. [7.0~10.0])
+
+.PP
+\fB--digest\fP=""
+	Filter by exact artifact digest
+
+.PP
+\fB--exclude\fP=""
+	Exclude vulnerabilities using a ',' separated query string (e.g., k=v or k=[min~max])
+
+.PP
+\fB--fixable\fP[=false]
+	Only show fixable vulnerabilities
+
+.PP
+\fB-h\fP, \fB--help\fP[=false]
+	help for list
+
+.PP
+\fB--package\fP=""
+	Filter by exact package name
+
+.PP
+\fB--page\fP=1
+	Page number
+
+.PP
+\fB--page-size\fP=10
+	Size of per page
+
+.PP
+\fB--project-name\fP=""
+	Filter by exact project name
+
+.PP
+\fB-q\fP, \fB--query\fP=""
+	Filter vulnerabilities with a ',' separated query string like exact k=v and range k=[min~max]
+
+.PP
+\fB--repository\fP=""
+	Filter by exact repository name
+
+.PP
+\fB--severity\fP=""
+	Filter by severity level
+
+.PP
+\fB--tag\fP=""
+	Filter by exact artifact tag
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+\fB-c\fP, \fB--config\fP=""
+	config file (default is $HOME/.config/harbor-cli/config.yaml)
+
+.PP
+\fB-o\fP, \fB--output-format\fP=""
+	Output format. One of: json|yaml
+
+.PP
+\fB-v\fP, \fB--verbose\fP[=false]
+	verbose output
+
+
+.SH EXAMPLE
+.EX
+  harbor vulnerability list
+.EE
+
+
+.SH SEE ALSO
+\fBharbor-vulnerability(1)\fP

--- a/doc/man-docs/man1/harbor-vulnerability-list.1
+++ b/doc/man-docs/man1/harbor-vulnerability-list.1
@@ -14,6 +14,10 @@ List vulnerabilities from Harbor Security Hub
 
 
 .SH OPTIONS
+\fB--all\fP[=false]
+	Show all vulnerabilities (up to 1000)
+
+.PP
 \fB--cve-id\fP=""
 	Filter by exact CVE ID
 

--- a/doc/man-docs/man1/harbor-vulnerability-list.1
+++ b/doc/man-docs/man1/harbor-vulnerability-list.1
@@ -58,10 +58,6 @@ List vulnerabilities from Harbor Security Hub
 	Filter by exact project name
 
 .PP
-\fB-q\fP, \fB--query\fP=""
-	Filter vulnerabilities with a ',' separated query string like exact k=v and range k=[min~max]
-
-.PP
 \fB--repository\fP=""
 	Filter by exact repository name
 

--- a/doc/man-docs/man1/harbor-vulnerability-summary.1
+++ b/doc/man-docs/man1/harbor-vulnerability-summary.1
@@ -32,7 +32,7 @@ Show vulnerability summary across Harbor artifacts from Security Hub.
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-vulnerability.1
+++ b/doc/man-docs/man1/harbor-vulnerability.1
@@ -38,4 +38,4 @@ List vulnerabilities and view vulnerability summary from Harbor Security Hub
 
 
 .SH SEE ALSO
-\fBharbor(1)\fP, \fBharbor-vulnerability-summary(1)\fP
+\fBharbor(1)\fP, \fBharbor-vulnerability-list(1)\fP, \fBharbor-vulnerability-summary(1)\fP

--- a/doc/man-docs/man1/harbor-vulnerability.1
+++ b/doc/man-docs/man1/harbor-vulnerability.1
@@ -24,7 +24,7 @@ List vulnerabilities and view vulnerability summary from Harbor Security Hub
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-webhook-create.1
+++ b/doc/man-docs/man1/harbor-webhook-create.1
@@ -60,7 +60,7 @@ or leave them out and be guided through an interactive prompt to input each fiel
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-webhook-delete.1
+++ b/doc/man-docs/man1/harbor-webhook-delete.1
@@ -35,7 +35,7 @@ or interactively select a project and webhook if not provided.
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-webhook-edit.1
+++ b/doc/man-docs/man1/harbor-webhook-edit.1
@@ -68,7 +68,7 @@ or leave them out and use the interactive prompt to select and update a webhook.
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-webhook-list.1
+++ b/doc/man-docs/man1/harbor-webhook-list.1
@@ -28,7 +28,7 @@ Use the '--output-format' flag for raw JSON output.
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-webhook.1
+++ b/doc/man-docs/man1/harbor-webhook.1
@@ -28,7 +28,7 @@ This command supports listing, creating, editing, and deleting webhook configura
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor.1
+++ b/doc/man-docs/man1/harbor.1
@@ -23,7 +23,7 @@ Official Harbor CLI
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/huh v0.8.0
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/ansi v0.11.6
+	github.com/gocarina/gocsv v0.0.0-20240520201108-78e41c74b4b1
 	github.com/sahilm/fuzzy v0.1.1
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
@@ -23,7 +25,6 @@ require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/catppuccin/go v0.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
-	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20241222104055-e1130b311607 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,8 @@ github.com/go-openapi/validate v0.24.0 h1:LdfDKwNbpB6Vn40xhTdNZAnfLECL81w+VX3Bum
 github.com/go-openapi/validate v0.24.0/go.mod h1:iyeX1sEufmv3nPbBdX3ieNviWnOZaJ1+zquzJEf2BAQ=
 github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
 github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/gocarina/gocsv v0.0.0-20240520201108-78e41c74b4b1 h1:FWNFq4fM1wPfcK40yHE5UO3RUdSNPaBC+j3PokzA6OQ=
+github.com/gocarina/gocsv v0.0.0-20240520201108-78e41c74b4b1/go.mod h1:5YoVOkjYAQumqlV356Hj3xeYh4BdZuLE0/nRkf2NKkI=
 github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
 github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/goharbor/go-client v0.213.1 h1:bohLwNog8uv8FKhIZ0SHiaDbYr3X/1hovgo5fqZWMdo=

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -94,6 +94,7 @@ type ListVulnerabilityOptions struct {
 	Exclude     string
 	WithTag     bool
 	Fixable     bool
+	All         bool
 	Page        int64
 	PageSize    int64
 	Q           string

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -81,3 +81,20 @@ type GetMemberOptions struct {
 	ID              int64
 	ProjectNameOrID string
 }
+
+type ListVulnerabilityOptions struct {
+	CVEID       string
+	CVSSScore   string
+	Severity    string
+	Repository  string
+	ProjectName string
+	Package     string
+	Tag         string
+	Digest      string
+	Exclude     string
+	WithTag     bool
+	Fixable     bool
+	Page        int64
+	PageSize    int64
+	Q           string
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -97,5 +97,4 @@ type ListVulnerabilityOptions struct {
 	All         bool
 	Page        int64
 	PageSize    int64
-	Q           string
 }

--- a/pkg/api/vulnerability_handler.go
+++ b/pkg/api/vulnerability_handler.go
@@ -14,10 +14,12 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strings"
 
+	v2client "github.com/goharbor/go-client/pkg/sdk/v2.0/client"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/securityhub"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/utils"
@@ -40,7 +42,7 @@ func GetVulnerabilitySummary(withDangerousArtifact, withDangerousCVE bool) (*sec
 	return response, nil
 }
 
-func ListVulnerabilities(opts ...ListVulnerabilityOptions) (*securityhub.ListVulnerabilitiesOK, error) {
+func ListVulnerabilities(opts ...ListVulnerabilityOptions) ([]*models.VulnerabilityItem, error) {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {
 		return nil, err
@@ -55,53 +57,26 @@ func ListVulnerabilities(opts ...ListVulnerabilityOptions) (*securityhub.ListVul
 	if err != nil {
 		return nil, err
 	}
+
 	listFlags.WithTag = true
 
 	if listFlags.Fixable || listFlags.Exclude != "" {
 		excludeMap := parseVulnerabilityExcludeMap(listFlags.Exclude)
-		var res []*models.VulnerabilityItem
-		start := int((listFlags.Page - 1) * listFlags.PageSize)
-		end := int(listFlags.Page * listFlags.PageSize)
-		count := 0
-		for page := int64(1); count < end; page++ {
-			response, err := client.Securityhub.ListVulnerabilities(ctx, &securityhub.ListVulnerabilitiesParams{
-				Page:     &page,
-				PageSize: &listFlags.PageSize,
-				Q:        &q,
-				WithTag:  &listFlags.WithTag,
-			})
-			if err != nil {
-				return nil, err
-			}
-			if len(response.Payload) == 0 {
-				break
-			}
 
-			response.Payload = filterVulnerabilities(
-				response.Payload,
-				listFlags.Fixable,
-				listFlags.Exclude != "",
-				excludeMap,
-			)
-
-			for _, vul := range response.Payload {
-				if count >= start && count < end {
-					res = append(res, vul)
-				}
-				count++
-				if count >= end {
-					break
-				}
-			}
+		res, err := listFilteredVulnerabilities(
+			ctx,
+			client,
+			listFlags.Page,
+			listFlags.PageSize,
+			q,
+			listFlags.WithTag,
+			excludeMap,
+			listFlags.Fixable,
+		)
+		if err != nil {
+			return nil, err
 		}
-		if len(res) == 0 {
-			return &securityhub.ListVulnerabilitiesOK{
-				Payload: nil,
-			}, nil
-		}
-		return &securityhub.ListVulnerabilitiesOK{
-			Payload: res,
-		}, nil
+		return res, nil
 	}
 
 	response, err := client.Securityhub.ListVulnerabilities(ctx, &securityhub.ListVulnerabilitiesParams{
@@ -114,12 +89,69 @@ func ListVulnerabilities(opts ...ListVulnerabilityOptions) (*securityhub.ListVul
 		return nil, err
 	}
 	if len(response.Payload) == 0 {
-		response.Payload = nil
-		response.XTotalCount = 0
-		return response, nil
+		return nil, nil
 	}
 
-	return response, nil
+	return response.Payload, nil
+}
+
+func listFilteredVulnerabilities(
+	ctx context.Context,
+	client *v2client.HarborAPI,
+	page int64,
+	pageSize int64,
+	query string,
+	withTag bool,
+	excludeMap map[string]string,
+	fixable bool,
+) ([]*models.VulnerabilityItem, error) {
+	excludeProvided := len(excludeMap) > 0
+	start := int((page - 1) * pageSize)
+	end := int(page * pageSize)
+
+	filteredCount := 0
+	var filteredVulnerabilities []*models.VulnerabilityItem
+
+	for currentPage := int64(1); filteredCount < end; currentPage++ {
+		response, err := client.Securityhub.ListVulnerabilities(ctx, &securityhub.ListVulnerabilitiesParams{
+			Page:     &currentPage,
+			PageSize: &pageSize,
+			Q:        &query,
+			WithTag:  &withTag,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		payload := response.Payload
+		if len(payload) == 0 {
+			break
+		}
+
+		payload = filterVulnerabilities(
+			payload,
+			fixable,
+			excludeProvided,
+			excludeMap,
+		)
+
+		for _, vul := range payload {
+			if filteredCount >= start && filteredCount < end {
+				filteredVulnerabilities = append(filteredVulnerabilities, vul)
+			}
+
+			filteredCount++
+			if filteredCount >= end {
+				break
+			}
+		}
+	}
+
+	if len(filteredVulnerabilities) == 0 {
+		return nil, nil
+	}
+
+	return filteredVulnerabilities, nil
 }
 
 func buildVulnerabilityQuery(opts ListVulnerabilityOptions) (string, error) {
@@ -142,16 +174,8 @@ func buildVulnerabilityQuery(opts ListVulnerabilityOptions) (string, error) {
 		queries = append(queries, fmt.Sprintf("cvss_score_v3=%s", cvssRange))
 	}
 	if opts.Severity != "" {
-		allowedSeverities := map[string]bool{
-			"Critical": true,
-			"High":     true,
-			"Medium":   true,
-			"Low":      true,
-			"n/a":      true,
-			"None":     true,
-		}
-		if !allowedSeverities[opts.Severity] {
-			return "", fmt.Errorf("invalid severity value: %s. Allowed values are: Low, Medium, High, Critical, n/a, None", opts.Severity)
+		if err := validateVulnerabilitySeverity(opts.Severity); err != nil {
+			return "", err
 		}
 		queries = append(queries, fmt.Sprintf("severity=%s", opts.Severity))
 	}
@@ -178,10 +202,19 @@ func buildVulnerabilityQuery(opts ListVulnerabilityOptions) (string, error) {
 	return strings.Join(queries, ","), nil
 }
 
+func validateVulnerabilitySeverity(severity string) error {
+	switch severity {
+	case "Critical", "High", "Medium", "Low", "n/a", "None":
+		return nil
+	default:
+		return fmt.Errorf("invalid severity value: %s. Allowed values are: Low, Medium, High, Critical, n/a, None", severity)
+	}
+}
+
 func parseVulnerabilityExcludeMap(exclude string) map[string]string {
 	excludeMap := make(map[string]string)
 	for _, query := range strings.Split(exclude, ",") {
-		parts := strings.SplitN(strings.TrimSpace(query), "=", 2)
+		parts := strings.Split(strings.TrimSpace(query), "=")
 		if len(parts) == 2 {
 			excludeMap[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
 		}

--- a/pkg/api/vulnerability_handler.go
+++ b/pkg/api/vulnerability_handler.go
@@ -174,11 +174,6 @@ func buildVulnerabilityQuery(opts ListVulnerabilityOptions) (string, error) {
 	if opts.Digest != "" {
 		queries = append(queries, fmt.Sprintf("digest=%s", opts.Digest))
 	}
-	if opts.Q != "" {
-		// FIXME: Q parameter needs to be converted to standard query format
-		// This will be addressed in draft PR #731
-		queries = append(queries, opts.Q)
-	}
 
 	return strings.Join(queries, ","), nil
 }

--- a/pkg/api/vulnerability_handler.go
+++ b/pkg/api/vulnerability_handler.go
@@ -55,8 +55,55 @@ func ListVulnerabilities(opts ...ListVulnerabilityOptions) (*securityhub.ListVul
 	if err != nil {
 		return nil, err
 	}
-
 	listFlags.WithTag = true
+
+	if listFlags.Fixable || listFlags.Exclude != "" {
+		excludeMap := parseVulnerabilityExcludeMap(listFlags.Exclude)
+		var res []*models.VulnerabilityItem
+		start := int((listFlags.Page - 1) * listFlags.PageSize)
+		end := int(listFlags.Page * listFlags.PageSize)
+		count := 0
+		for page := int64(1); count < end; page++ {
+			response, err := client.Securityhub.ListVulnerabilities(ctx, &securityhub.ListVulnerabilitiesParams{
+				Page:     &page,
+				PageSize: &listFlags.PageSize,
+				Q:        &q,
+				WithTag:  &listFlags.WithTag,
+			})
+			if err != nil {
+				return nil, err
+			}
+			if len(response.Payload) == 0 {
+				break
+			}
+
+			response.Payload = filterVulnerabilities(
+				response.Payload,
+				listFlags.Fixable,
+				listFlags.Exclude != "",
+				excludeMap,
+			)
+
+			for _, vul := range response.Payload {
+				if count >= start && count < end {
+					res = append(res, vul)
+				}
+				count++
+				if count >= end {
+					break
+				}
+			}
+		}
+		if len(res) == 0 {
+			return &securityhub.ListVulnerabilitiesOK{
+				Payload: nil,
+			}, nil
+		}
+		return &securityhub.ListVulnerabilitiesOK{
+			Payload: res,
+		}, nil
+	}
+
 	response, err := client.Securityhub.ListVulnerabilities(ctx, &securityhub.ListVulnerabilitiesParams{
 		Page:     &listFlags.Page,
 		PageSize: &listFlags.PageSize,
@@ -66,40 +113,10 @@ func ListVulnerabilities(opts ...ListVulnerabilityOptions) (*securityhub.ListVul
 	if err != nil {
 		return nil, err
 	}
-
-	if listFlags.Fixable {
-		response.Payload = slices.DeleteFunc(response.Payload, func(vul *models.VulnerabilityItem) bool {
-			return vul.FixedVersion == ""
-		})
-	}
-
-	if listFlags.Exclude != "" {
-		excludeMap := make(map[string]string)
-		for _, query := range strings.Split(listFlags.Exclude, ",") {
-			parts := strings.SplitN(strings.TrimSpace(query), "=", 2)
-			if len(parts) == 2 {
-				excludeMap[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
-			}
-		}
-
-		response.Payload = slices.DeleteFunc(response.Payload, func(vul *models.VulnerabilityItem) bool {
-			if val, ok := excludeMap["cve_id"]; ok && vul.CVEID == val {
-				return true
-			}
-			if val, ok := excludeMap["severity"]; ok && strings.EqualFold(vul.Severity, val) {
-				return true
-			}
-			if val, ok := excludeMap["package"]; ok && vul.Package == val {
-				return true
-			}
-			if val, ok := excludeMap["repository_name"]; ok && vul.RepositoryName == val {
-				return true
-			}
-			if val, ok := excludeMap["digest"]; ok && vul.Digest == val {
-				return true
-			}
-			return false
-		})
+	if len(response.Payload) == 0 {
+		response.Payload = nil
+		response.XTotalCount = 0
+		return response, nil
 	}
 
 	return response, nil
@@ -111,9 +128,31 @@ func buildVulnerabilityQuery(opts ListVulnerabilityOptions) (string, error) {
 		queries = append(queries, fmt.Sprintf("cve_id=%s", opts.CVEID))
 	}
 	if opts.CVSSScore != "" {
-		queries = append(queries, fmt.Sprintf("cvss_score_v3=%s", opts.CVSSScore))
+		cvssRange := opts.CVSSScore
+		if strings.Contains(cvssRange, "~") {
+			parts := strings.Split(cvssRange, "~")
+			if len(parts) == 2 {
+				cvssRange = fmt.Sprintf("[%s~%s]", parts[0], parts[1])
+			} else {
+				return "", fmt.Errorf("invalid cvss score range: %s. Expected format: min~max", cvssRange)
+			}
+		} else {
+			cvssRange = fmt.Sprintf("[%s~%s]", opts.CVSSScore, opts.CVSSScore)
+		}
+		queries = append(queries, fmt.Sprintf("cvss_score_v3=%s", cvssRange))
 	}
 	if opts.Severity != "" {
+		allowedSeverities := map[string]bool{
+			"Critical": true,
+			"High":     true,
+			"Medium":   true,
+			"Low":      true,
+			"n/a":      true,
+			"None":     true,
+		}
+		if !allowedSeverities[opts.Severity] {
+			return "", fmt.Errorf("invalid severity value: %s. Allowed values are: Low, Medium, High, Critical, n/a, None", opts.Severity)
+		}
 		queries = append(queries, fmt.Sprintf("severity=%s", opts.Severity))
 	}
 	if opts.Repository != "" {
@@ -136,8 +175,55 @@ func buildVulnerabilityQuery(opts ListVulnerabilityOptions) (string, error) {
 		queries = append(queries, fmt.Sprintf("digest=%s", opts.Digest))
 	}
 	if opts.Q != "" {
+		// FIXME: Q parameter needs to be converted to standard query format
+		// This will be addressed in draft PR #731
 		queries = append(queries, opts.Q)
 	}
 
 	return strings.Join(queries, ","), nil
+}
+
+func parseVulnerabilityExcludeMap(exclude string) map[string]string {
+	excludeMap := make(map[string]string)
+	for _, query := range strings.Split(exclude, ",") {
+		parts := strings.SplitN(strings.TrimSpace(query), "=", 2)
+		if len(parts) == 2 {
+			excludeMap[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+		}
+	}
+	return excludeMap
+}
+
+func filterVulnerabilities(
+	payload []*models.VulnerabilityItem,
+	fixable bool,
+	excludeProvided bool,
+	excludeMap map[string]string,
+) []*models.VulnerabilityItem {
+	return slices.DeleteFunc(payload, func(vul *models.VulnerabilityItem) bool {
+		if fixable && vul.FixedVersion == "" {
+			return true
+		}
+
+		if !excludeProvided {
+			return false
+		}
+
+		if val, ok := excludeMap["cve_id"]; ok && vul.CVEID == val {
+			return true
+		}
+		if val, ok := excludeMap["severity"]; ok && vul.Severity == val {
+			return true
+		}
+		if val, ok := excludeMap["package"]; ok && vul.Package == val {
+			return true
+		}
+		if val, ok := excludeMap["repository_name"]; ok && vul.RepositoryName == val {
+			return true
+		}
+		if val, ok := excludeMap["digest"]; ok && vul.Digest == val {
+			return true
+		}
+		return false
+	})
 }

--- a/pkg/api/vulnerability_handler.go
+++ b/pkg/api/vulnerability_handler.go
@@ -14,7 +14,12 @@
 package api
 
 import (
+	"fmt"
+	"slices"
+	"strings"
+
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/securityhub"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 )
 
@@ -33,4 +38,105 @@ func GetVulnerabilitySummary(withDangerousArtifact, withDangerousCVE bool) (*sec
 	}
 
 	return response, nil
+}
+
+func ListVulnerabilities(opts ...ListVulnerabilityOptions) (*securityhub.ListVulnerabilitiesOK, error) {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return nil, err
+	}
+
+	var listFlags ListVulnerabilityOptions
+	if len(opts) > 0 {
+		listFlags = opts[0]
+	}
+
+	q, err := buildVulnerabilityQuery(listFlags)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := client.Securityhub.ListVulnerabilities(ctx, &securityhub.ListVulnerabilitiesParams{
+		Page:     &listFlags.Page,
+		PageSize: &listFlags.PageSize,
+		Q:        &q,
+		WithTag:  &listFlags.WithTag,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if listFlags.Fixable {
+		response.Payload = slices.DeleteFunc(response.Payload, func(vul *models.VulnerabilityItem) bool {
+			return vul.FixedVersion == ""
+		})
+	}
+
+	if listFlags.Exclude != "" {
+		excludeMap := make(map[string]string)
+		for _, query := range strings.Split(listFlags.Exclude, ",") {
+			parts := strings.SplitN(strings.TrimSpace(query), "=", 2)
+			if len(parts) == 2 {
+				excludeMap[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+			}
+		}
+
+		response.Payload = slices.DeleteFunc(response.Payload, func(vul *models.VulnerabilityItem) bool {
+			if val, ok := excludeMap["cve_id"]; ok && vul.CVEID == val {
+				return true
+			}
+			if val, ok := excludeMap["severity"]; ok && strings.EqualFold(vul.Severity, val) {
+				return true
+			}
+			if val, ok := excludeMap["package"]; ok && vul.Package == val {
+				return true
+			}
+			if val, ok := excludeMap["repository_name"]; ok && vul.RepositoryName == val {
+				return true
+			}
+			if val, ok := excludeMap["digest"]; ok && vul.Digest == val {
+				return true
+			}
+			return false
+		})
+	}
+
+	return response, nil
+}
+
+func buildVulnerabilityQuery(opts ListVulnerabilityOptions) (string, error) {
+	var queries []string
+	if opts.CVEID != "" {
+		queries = append(queries, fmt.Sprintf("cve_id=%s", opts.CVEID))
+	}
+	if opts.CVSSScore != "" {
+		queries = append(queries, fmt.Sprintf("cvss_score_v3=%s", opts.CVSSScore))
+	}
+	if opts.Severity != "" {
+		queries = append(queries, fmt.Sprintf("severity=%s", opts.Severity))
+	}
+	if opts.Repository != "" {
+		queries = append(queries, fmt.Sprintf("repository_name=%s", opts.Repository))
+	}
+	if opts.ProjectName != "" {
+		projectId, err := GetProjectIDFromName(opts.ProjectName)
+		if err != nil {
+			return "", err
+		}
+		queries = append(queries, fmt.Sprintf("project_id=%d", projectId))
+	}
+	if opts.Package != "" {
+		queries = append(queries, fmt.Sprintf("package=%s", opts.Package))
+	}
+	if opts.Tag != "" {
+		queries = append(queries, fmt.Sprintf("tag=%s", opts.Tag))
+	}
+	if opts.Digest != "" {
+		queries = append(queries, fmt.Sprintf("digest=%s", opts.Digest))
+	}
+	if opts.Q != "" {
+		queries = append(queries, opts.Q)
+	}
+
+	return strings.Join(queries, ","), nil
 }

--- a/pkg/api/vulnerability_handler.go
+++ b/pkg/api/vulnerability_handler.go
@@ -56,6 +56,7 @@ func ListVulnerabilities(opts ...ListVulnerabilityOptions) (*securityhub.ListVul
 		return nil, err
 	}
 
+	listFlags.WithTag = true
 	response, err := client.Securityhub.ListVulnerabilities(ctx, &securityhub.ListVulnerabilitiesParams{
 		Page:     &listFlags.Page,
 		PageSize: &listFlags.PageSize,

--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -216,6 +216,10 @@ func PrintFormat[T any](resp T, format string) error {
 		PrintPayloadInYAMLFormat(resp)
 		return nil
 	}
+	if format == "csv" {
+		PrintPayloadInCSVFormat(resp)
+		return nil
+	}
 	return fmt.Errorf("unable to output in the specified '%s' format", format)
 }
 

--- a/pkg/utils/helper_test.go
+++ b/pkg/utils/helper_test.go
@@ -202,6 +202,20 @@ func TestPrintFormat(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, buf.String(), "foo: bar")
 
+	// CSV
+	buf.Reset()
+	r, w, _ = os.Pipe()
+	os.Stdout = w
+	err = utils.PrintFormat([]payload{obj}, "csv")
+	w.Close()
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("Failed to capture output: %v", err)
+	}
+	os.Stdout = oldOut
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), "Foo")
+	assert.Contains(t, buf.String(), "bar")
+
 	// unsupported
 	err = utils.PrintFormat(obj, "xml")
 	assert.Error(t, err)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -25,6 +25,7 @@ import (
 	"syscall"
 
 	"github.com/charmbracelet/bubbles/table"
+	"github.com/gocarina/gocsv"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/user"
 	uview "github.com/goharbor/harbor-cli/pkg/views/user/select"
 	log "github.com/sirupsen/logrus"
@@ -61,6 +62,17 @@ func PrintPayloadInYAMLFormat(payload any) {
 	}
 
 	fmt.Println(string(yamlStr))
+}
+
+func PrintPayloadInCSVFormat(payload any) {
+	if payload == nil {
+		return
+	}
+
+	err := gocsv.Marshal(payload, os.Stdout)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func ParseProjectRepo(projectRepo string) (project, repo string, err error) {

--- a/pkg/views/vulnerability/list/view.go
+++ b/pkg/views/vulnerability/list/view.go
@@ -1,0 +1,86 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package list
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/table"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/views/base/tablelist"
+)
+
+var columns = []table.Column{
+	{Title: "CVE ID", Width: tablelist.WidthL},
+	{Title: "Description", Width: tablelist.WidthXXL},
+	{Title: "Project", Width: tablelist.WidthM},
+	{Title: "Repository", Width: tablelist.WidthM},
+	{Title: "Digest", Width: tablelist.WidthM},
+	{Title: "Tags", Width: tablelist.WidthS},
+	{Title: "CVSSV3", Width: tablelist.WidthS},
+	{Title: "Severity", Width: tablelist.WidthS},
+	{Title: "Package", Width: tablelist.WidthM},
+	{Title: "Version", Width: tablelist.WidthM},
+	{Title: "Fixed", Width: tablelist.WidthM},
+}
+
+func ViewVulnerabilityList(vulnerabilities []*models.VulnerabilityItem) {
+	if vulnerabilities == nil {
+		fmt.Println("No vulnerabilities found")
+		return
+	}
+
+	var rows []table.Row
+	cveLinks := make(map[string]string)
+	for _, vulnerability := range vulnerabilities {
+		link := ""
+		if len(vulnerability.Links) > 0 {
+			link = vulnerability.Links[0]
+		}
+
+		cveLinks[vulnerability.CVEID] = link
+		projectName := strconv.FormatInt(vulnerability.ProjectID, 10)
+		project, err := api.GetProject(projectName, true)
+		if err == nil && project.Payload != nil {
+			projectName = project.Payload.Name
+		}
+		rows = append(rows, table.Row{
+			vulnerability.CVEID,
+			vulnerability.Desc,
+			projectName,
+			vulnerability.RepositoryName,
+			vulnerability.Digest,
+			strings.Join(vulnerability.Tags, ", "),
+			strconv.FormatFloat(float64(vulnerability.CvssV3Score), 'f', 1, 32),
+			vulnerability.Severity,
+			vulnerability.Package,
+			vulnerability.Version,
+			vulnerability.FixedVersion,
+		})
+	}
+
+	m := tablelist.NewModel(columns, rows, len(rows))
+	tableOutput := m.View()
+
+	for cve, link := range cveLinks {
+		hyperlinkedID := ansi.SetHyperlink(link) + cve + ansi.ResetHyperlink()
+		tableOutput = strings.ReplaceAll(tableOutput, cve, hyperlinkedID)
+	}
+
+	fmt.Println(tableOutput)
+}

--- a/pkg/views/vulnerability/list/view.go
+++ b/pkg/views/vulnerability/list/view.go
@@ -21,17 +21,16 @@ import (
 	"github.com/charmbracelet/bubbles/table"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
-	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/base/tablelist"
 )
 
 var columns = []table.Column{
 	{Title: "CVE ID", Width: tablelist.WidthL},
 	{Title: "Description", Width: tablelist.WidthXXL},
-	{Title: "Project", Width: tablelist.WidthM},
-	{Title: "Repository", Width: tablelist.WidthM},
+	{Title: "Repository", Width: tablelist.WidthL},
 	{Title: "Digest", Width: tablelist.WidthM},
-	{Title: "Tags", Width: tablelist.WidthS},
+	{Title: "Tags", Width: tablelist.WidthM},
 	{Title: "CVSSV3", Width: tablelist.WidthS},
 	{Title: "Severity", Width: tablelist.WidthS},
 	{Title: "Package", Width: tablelist.WidthM},
@@ -39,7 +38,7 @@ var columns = []table.Column{
 	{Title: "Fixed", Width: tablelist.WidthM},
 }
 
-func ViewVulnerabilityList(vulnerabilities []*models.VulnerabilityItem) {
+func ViewVulnerabilityList(vulnerabilities []*models.VulnerabilityItem, hasNext bool) {
 	if vulnerabilities == nil {
 		fmt.Println("No vulnerabilities found")
 		return
@@ -54,15 +53,9 @@ func ViewVulnerabilityList(vulnerabilities []*models.VulnerabilityItem) {
 		}
 
 		cveLinks[vulnerability.CVEID] = link
-		projectName := strconv.FormatInt(vulnerability.ProjectID, 10)
-		project, err := api.GetProject(projectName, true)
-		if err == nil && project.Payload != nil {
-			projectName = project.Payload.Name
-		}
 		rows = append(rows, table.Row{
 			vulnerability.CVEID,
 			vulnerability.Desc,
-			projectName,
 			vulnerability.RepositoryName,
 			vulnerability.Digest,
 			strings.Join(vulnerability.Tags, ", "),
@@ -83,4 +76,21 @@ func ViewVulnerabilityList(vulnerabilities []*models.VulnerabilityItem) {
 	}
 
 	fmt.Println(tableOutput)
+	if hasNext {
+		var hintURL string
+		if cfg, err := utils.GetCurrentHarborConfig(); err == nil {
+			for _, cred := range cfg.Credentials {
+				if cred.Name == cfg.CurrentCredentialName {
+					hintURL = strings.TrimRight(cred.ServerAddress, "/") + "/harbor/interrogation-services/security-hub"
+					break
+				}
+			}
+		}
+
+		if hintURL != "" {
+			fmt.Printf("More results at: %s%s%s\n", ansi.SetHyperlink(hintURL), hintURL, ansi.ResetHyperlink())
+		} else {
+			fmt.Println("More results available in the Harbor web console")
+		}
+	}
 }


### PR DESCRIPTION
> **Note:** This is the second PR for the issue #723 

## Description
The PR adds the new `harbor vuln list` command. A command  that displays the list of vulnerabilities along with filtering from the Security Hub.

<img width="1015" height="499" alt="image" src="https://github.com/user-attachments/assets/ec652f4b-bb22-45ee-ae73-cafc0fb55248" />

## Command usage
-  `harbor vuln list ` (No filters)
![Kooha-2026-03-17-04-14-39](https://github.com/user-attachments/assets/346f5347-c14e-4ae2-9469-0da902939ad8)
The CVE-IDs are hyperlinked  to aquasec website (provided by the api)

-  `harbor vuln list --query "k=v , , , k=[min~max]"` : Using query flag based filtering
![Kooha-2026-03-17-04-22-05](https://github.com/user-attachments/assets/1bf8f499-b8c2-41aa-bd14-85a79e438af6)

-  `harbor vuln list (flags based filtering)` : Using flags for filtering 
![Kooha-2026-03-17-04-27-36](https://github.com/user-attachments/assets/b7524435-1397-4985-8665-4660c17d38c5)

-  `harbor vuln list --fixable`: Show only fixable vulnerabilities (cli side)
![Kooha-2026-03-17-04-29-26](https://github.com/user-attachments/assets/47de0ef6-6ed6-417f-bde4-70826a7c8a58)

-  `harbor vuln list --exclude` : woks oppposite of query flag (cli side)
![Kooha-2026-03-17-04-37-00](https://github.com/user-attachments/assets/556b54f8-7e38-4e1f-95ae-09986a92ca9e)

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance



