### PR TITLE
feat(project): add confirmation prompt before deleting projects

### DIFF
--- a/cmd/harbor/root/project/delete.go
+++ b/cmd/harbor/root/project/delete.go
@@ -52,6 +52,23 @@ func DeleteProjectCommand() *cobra.Command {
 				}
 			}
 
+			if !forceDelete {
+				var confirm string
+				if projectID != "" {
+    				fmt.Printf("Are you sure you want to delete project ID: %s ? (y/n): ", projectID)
+				} else if len(args) > 0 {
+					fmt.Printf("Are you sure you want to delete project(s): %v ? (y/n): ", args)
+				} else {
+					fmt.Print("Are you sure you want to delete the selected project? (y/n): ")
+				} 
+				fmt.Scanln(&confirm)
+
+				if confirm != "y" && confirm != "Y" {
+					fmt.Println("Aborted.")
+					return nil
+				}
+			}
+
 			if projectID != "" {
 				log.Debugf("Deleting project with ID: %s", projectID)
 				wg.Add(1)

--- a/cmd/harbor/root/project/delete.go
+++ b/cmd/harbor/root/project/delete.go
@@ -53,17 +53,7 @@ func DeleteProjectCommand() *cobra.Command {
 			}
 
 			if !forceDelete {
-				msg := ""
-
-				if projectID != "" {
-					msg = fmt.Sprintf("Delete project ID: %s?", projectID)
-				} else if len(args) > 0 {
-					msg = fmt.Sprintf("Delete project(s): %v?", args)
-				} else {
-					msg = "Delete selected project?"
-				}
-
-				confirm, err := prompt.ConfirmProjectDeletion(msg)
+				confirm, err := prompt.ConfirmProjectDeletion(projectID, args)
 				if err != nil {
 					return err
 				}

--- a/cmd/harbor/root/project/delete.go
+++ b/cmd/harbor/root/project/delete.go
@@ -53,17 +53,22 @@ func DeleteProjectCommand() *cobra.Command {
 			}
 
 			if !forceDelete {
-				var confirm string
-				if projectID != "" {
-    				fmt.Printf("Are you sure you want to delete project ID: %s ? (y/n): ", projectID)
-				} else if len(args) > 0 {
-					fmt.Printf("Are you sure you want to delete project(s): %v ? (y/n): ", args)
-				} else {
-					fmt.Print("Are you sure you want to delete the selected project? (y/n): ")
-				} 
-				fmt.Scanln(&confirm)
+				msg := ""
 
-				if confirm != "y" && confirm != "Y" {
+				if projectID != "" {
+					msg = fmt.Sprintf("Delete project ID: %s?", projectID)
+				} else if len(args) > 0 {
+					msg = fmt.Sprintf("Delete project(s): %v?", args)
+				} else {
+					msg = "Delete selected project?"
+				}
+
+				confirm, err := prompt.ConfirmProjectDeletion(msg)
+				if err != nil {
+					return err
+				}
+
+				if !confirm {
 					fmt.Println("Aborted.")
 					return nil
 				}

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -24,6 +24,7 @@ import (
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/constants"
+	"github.com/charmbracelet/huh"
 	aview "github.com/goharbor/harbor-cli/pkg/views/artifact/select"
 	tview "github.com/goharbor/harbor-cli/pkg/views/artifact/tags/select"
 	immview "github.com/goharbor/harbor-cli/pkg/views/immutable/select"
@@ -432,4 +433,19 @@ func GetRoleIDFromUser() int64 {
 	}()
 
 	return <-roleID
+}
+
+func ConfirmProjectDeletion(message string) (bool, error) {
+	var confirm bool
+
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title(message).
+				Value(&confirm),
+		),
+	)
+
+	err := form.Run()
+	return confirm, err
 }

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -435,8 +435,18 @@ func GetRoleIDFromUser() int64 {
 	return <-roleID
 }
 
-func ConfirmProjectDeletion(message string) (bool, error) {
+func ConfirmProjectDeletion(projectID string, args []string) (bool, error) {
 	var confirm bool
+
+	message := ""
+
+	if projectID != "" {
+		message = fmt.Sprintf("Delete project ID: %s?", projectID)
+	} else if len(args) > 0 {
+		message = fmt.Sprintf("Delete project(s): %v?", args)
+	} else {
+		message = "Delete selected project?"
+	}
 
 	form := huh.NewForm(
 		huh.NewGroup(


### PR DESCRIPTION
## Description
Adds a confirmation prompt before deleting projects to prevent accidental destructive operations.

Closes #771

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
- Added confirmation prompt before project deletion
- Displays project name(s) or project ID in the confirmation message
- Aborts deletion if user does not confirm
- Skips prompt when `--force` flag is used

## Screenshots
Before (old prompt):

<img width="1283" height="151" alt="image" src="https://github.com/user-attachments/assets/33b13645-5f34-4783-b762-c783591dfd59" />

After (huh UI):

<img width="1097" height="255" alt="image" src="https://github.com/user-attachments/assets/4bb98b3e-7982-4cc5-91c2-b8e16d5fc759" />

