### PR TITLE
docs: update contributing; add clear boundaries for issues and prs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,13 +105,28 @@ dagger call run-doc export --path=./doc
 git commit -s -m "feat(project): add delete command for project resources"
 ```
 
-### 7. Push and Open a PR
+### 7. Push to your own fork
 
 ```bash
 git push origin feat/<your-feature-name>
 ```
 
-Then, [Open a Pull Request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on GitHub
+### 8. Create a dedicated issue **first**
+
+Before opening a pull request, please [open a dedicated issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/creating-an-issue) describing the problem you're solving or the feature you're proposing. This gives maintainers a chance to provide early feedback and helps avoid duplicated effort.
+
+**Pull requests without a linked issue will not be reviewed and may be closed.**
+
+### 9. Open a Pull Request
+
+Once your issue has been acknowledged, [open a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) and [link it to your issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue).
+
+A good PR includes:
+- A clear description of **what** changed and **why**
+- Evidence that you tested your changes (screenshots, terminal output, etc.)
+- Well-structured, readable commits
+
+> **A note on AI-generated contributions:** We appreciate the intent, but please don't submit PRs that are purely AI-generated without your own understanding and review. Drive-by PRs — especially bulk or low-effort ones produced by AI tools — add review burden for maintainers and will be closed. If you use AI to assist your work, that's fine — just make sure you understand every line you're submitting and can speak to the changes in review.
 
 ## 🧪 Running Tests
 


### PR DESCRIPTION
Closes #762

## What changed

Rewrote steps 7–9 in CONTRIBUTING.md to clarify the contribution workflow and set expectations around PR quality.

### Before
- Steps 7–9 were a single "Push and Open a PR" step with a link, no guidance on issue-first workflow, PR quality, or AI-generated submissions.

### After
- **Step 7** is now just "push to your fork" kept simple.
- **Step 8** makes explicit that a dedicated issue must be opened **before** a PR, giving maintainers a chance to provide early feedback. Includes a bold closure policy for PRs without linked issues.
- **Step 9** sets concrete PR expectations (what/why, test evidence, readable commits) and adds a note that AI-assisted work is welcome, but purely AI-generated drive-by PRs will be closed.

## Why

- Contributors sometimes open PRs without issues, which makes triage harder.
- Low-effort AI-generated bulk PRs have been adding unnecessary review burden.
- The previous wording didn't set any quality bar or explain the expected workflow clearly enough.

The tone stays welcoming the goal is to encourage thoughtful contributions, not discourage new contributors.