### PR TITLE
feat: Implement Lefthook for automated pre-commit checks and DCO sign…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ go.work
 dist/
 /dagger.gen.go
 /internal/*
+
+# Lefthook state (local only)
+.lefthook/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,48 @@ dagger call build-dev --platform darwin/arm64 export --path=./harbor-cli
 ./harbor-dev --help
 ```
 
+## Local Development Hooks (Lefthook)
+
+This project uses [Lefthook](https://github.com/evilmartians/lefthook) to enforce code quality checks automatically on every commit — similar to Husky in JavaScript projects.
+
+### Install Lefthook
+
+```bash
+# macOS
+brew install lefthook
+
+# Linux / other (via Go)
+go install github.com/evilmartians/lefthook@latest
+
+# Or download a binary: https://github.com/evilmartians/lefthook/releases
+```
+
+### Activate the hooks (one-time, after cloning)
+
+```bash
+lefthook install
+```
+
+This registers the Git hooks defined in [`lefthook.yml`](./lefthook.yml). From that point on, every `git commit` will automatically run:
+
+| Hook | What it checks |
+|------|---------------|
+| `gofmt` | All `.go` files are `gofmt`-formatted |
+| `golangci-lint` | Linting via the project's `.golangci.yaml` config |
+| `go build ./...` | Project compiles without errors |
+| `go test ./...` | Full test suite passes |
+| DCO sign-off | Commit message contains a `Signed-off-by:` line (requires `git commit -s`) |
+
+### Skipping hooks (use sparingly)
+
+If you need to bypass the hooks for a work-in-progress commit:
+
+```bash
+git commit --no-verify -m "wip: ..."
+```
+
+> ⚠️ All of the above checks also run in CI. Skipping locally does not bypass CI.
+
 ## Project Structure
 
 ```

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,57 @@
+# Lefthook — Git hooks manager for harbor-cli
+# Install: https://github.com/evilmartians/lefthook#installation
+# Activate: lefthook install
+
+pre-commit:
+  parallel: false
+  commands:
+    # 1. Format check — ensure code is properly formatted
+    gofmt:
+      glob: "**/*.go"
+      run: |
+        unformatted=$(gofmt -l .)
+        if [ -n "$unformatted" ]; then
+          echo "❌ The following files are not gofmt-formatted:"
+          echo "$unformatted"
+          echo ""
+          echo "Run: gofmt -s -w ."
+          exit 1
+        fi
+        echo "✅ gofmt: all files are properly formatted"
+
+    # 2. Lint — run golangci-lint with the project's existing config
+    golangci-lint:
+      glob: "**/*.go"
+      run: golangci-lint run ./...
+      fail_text: "❌ golangci-lint found issues. Fix them before committing."
+
+    # 3. Build — ensure the project compiles cleanly
+    build:
+      run: go build ./...
+      fail_text: "❌ Build failed. Fix compilation errors before committing."
+
+    # 4. Test — run the full test suite
+    test:
+      run: go test ./...
+      fail_text: "❌ Tests failed. Fix failing tests before committing."
+
+commit-msg:
+  commands:
+    # Enforce DCO (Developer Certificate of Origin) sign-off
+    # Contributors must use: git commit -s -m "..."
+    dco-check:
+      run: |
+        commit_msg_file="{1}"
+        if ! grep -qE "^Signed-off-by: .+ <.+@.+>$" "$commit_msg_file"; then
+          echo ""
+          echo "❌ DCO sign-off missing!"
+          echo ""
+          echo "All commits must include a Signed-off-by line, e.g.:"
+          echo "   Signed-off-by: Your Name <your@email.com>"
+          echo ""
+          echo "Fix: use 'git commit -s' to automatically add the sign-off,"
+          echo "     or amend with: git commit --amend -s"
+          echo ""
+          exit 1
+        fi
+        echo "✅ DCO sign-off found"


### PR DESCRIPTION
## Description
This PR introduces **Lefthook**, a fast and native Go Git hooks manager, to enforce strict pre-commit and commit-msg quality checks locally before code is even pushed to CI.

By running `gofmt`, `golangci-lint`, tests, builds, and a DCO sign-off check directly on the developer's machine, this setup catches trivial errors early, speeds up the feedback loop, and prevents broken or incorrectly formatted code from failing in GitHub Actions.

- Closes #765

## Type of Change
Please select the relevant type.

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation update
- [ ] Chore / maintenance

## Changes
- Added [lefthook.yml](cci:7://file:///your-path/harbor-cli/harbor-cli/lefthook.yml:0:0-0:0) configuring `pre-commit` hooks for `gofmt`, `golangci-lint`, `go build`, and `go test` on staged files.
- Added a `commit-msg` hook to enforce the DCO (`Signed-off-by`) standard on all commits.
- Updated [CONTRIBUTING.md](cci:7://file:///your-path/contributions/harbor-cli/harbor-cli/CONTRIBUTING.md:0:0-0:0) with instructions for contributors on how to install and activate Lefthook locally.
- Ignored the local `.lefthook/` state directory in `.gitignore`.