### PR TITLE
fix(views): enable searching and fix selection flow in TUI lists

### DIFF
--- a/pkg/views/base/selection/model.go
+++ b/pkg/views/base/selection/model.go
@@ -88,8 +88,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				i, ok := m.List.SelectedItem().(Item)
 				if ok {
 					m.Choice = string(i)
+					return m, tea.Quit
 				}
-				return m, tea.Quit
 			}
 		}
 	}


### PR DESCRIPTION
## Description
This PR fixes the interactive selection lists where the search filter was not working and the program would close too early when trying to filter.
![Kooha-2026-03-26-17-08-14](https://github.com/user-attachments/assets/109d18b0-2e1a-42e6-b1e0-76d8edb44e38)

- Fixes #772 

## Type of Change
Please select the relevant type.

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
- Fixed Search: Enabled the search engine to see item names so the / filter can actually find results.
- Fixed Selection Flow: Ensured that pressing Enter applies the filter first and only selects the item on a second press, supporting a natural "filter then select" workflow.

