### PR TITLE
fix: reject invalid page values in selected list commands

### DIFF
--- a/cmd/harbor/root/artifact/list.go
+++ b/cmd/harbor/root/artifact/list.go
@@ -43,6 +43,9 @@ Supports pagination, search queries, and sorting using flags.`,
 
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.Page < 1 {
+				return fmt.Errorf("page number must be greater than or equal to 1")
+			}
 			if opts.PageSize < 0 {
 				return fmt.Errorf("page size must be greater than or equal to 0")
 			}

--- a/cmd/harbor/root/artifact/list_test.go
+++ b/cmd/harbor/root/artifact/list_test.go
@@ -1,3 +1,16 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package artifact
 
 import (

--- a/cmd/harbor/root/artifact/list_test.go
+++ b/cmd/harbor/root/artifact/list_test.go
@@ -1,0 +1,21 @@
+package artifact
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListArtifactCommand_InvalidPage(t *testing.T) {
+	cmd := ListArtifactCommand()
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--page", "0"})
+
+	err := cmd.Execute()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "page number must be greater than or equal to 1")
+}

--- a/cmd/harbor/root/instance/list.go
+++ b/cmd/harbor/root/instance/list.go
@@ -35,6 +35,9 @@ This command provides an easy way to view all instances along with their details
 		Example: `  harbor-cli instance list --page 1 --page-size 10
   harbor-cli instance list --query "name=my-instance" --sort "asc"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.Page < 1 {
+				return fmt.Errorf("page number must be greater than or equal to 1")
+			}
 			if opts.PageSize < 0 {
 				return fmt.Errorf("page size must be greater than or equal to 0")
 			}

--- a/cmd/harbor/root/instance/list_test.go
+++ b/cmd/harbor/root/instance/list_test.go
@@ -1,0 +1,34 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package instance
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListInstanceCommand_InvalidPage(t *testing.T) {
+	cmd := ListInstanceCommand()
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--page", "0"})
+
+	err := cmd.Execute()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "page number must be greater than or equal to 1")
+}

--- a/cmd/harbor/root/labels/create_test.go
+++ b/cmd/harbor/root/labels/create_test.go
@@ -248,3 +248,16 @@ func TestCreateLabelCommand_FlagDescriptions(t *testing.T) {
 	descFlag := flags.Lookup("description")
 	assert.Contains(t, descFlag.Usage, "Description of the label")
 }
+
+func TestListLabelCommand_InvalidPage(t *testing.T) {
+	cmd := ListLabelCommand()
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--page", "0"})
+
+	err := cmd.Execute()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "page number must be greater than or equal to 1")
+}

--- a/cmd/harbor/root/labels/list.go
+++ b/cmd/harbor/root/labels/list.go
@@ -39,6 +39,9 @@ func ListLabelCommand() *cobra.Command {
 		Short: "list labels",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.Page < 1 {
+				return fmt.Errorf("page number must be greater than or equal to 1")
+			}
 			if opts.PageSize < 0 {
 				return fmt.Errorf("page size must be greater than or equal to 0")
 			}

--- a/cmd/harbor/root/logs.go
+++ b/cmd/harbor/root/logs.go
@@ -48,6 +48,9 @@ harbor-cli logs --follow --refresh-interval 2s
 
 harbor-cli logs --output-format json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.Page < 1 {
+				return fmt.Errorf("page number must be greater than or equal to 1")
+			}
 			if opts.PageSize < 0 {
 				return fmt.Errorf("page size must be greater than or equal to 0")
 			}

--- a/cmd/harbor/root/project/list.go
+++ b/cmd/harbor/root/project/list.go
@@ -44,6 +44,9 @@ func ListProjectCommand() *cobra.Command {
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Debug("Starting project list command")
+			if opts.Page < 1 {
+				return fmt.Errorf("page number must be greater than or equal to 1")
+			}
 
 			if opts.PageSize < 0 {
 				return fmt.Errorf("page size must be greater than or equal to 0")

--- a/cmd/harbor/root/project/list_test.go
+++ b/cmd/harbor/root/project/list_test.go
@@ -1,3 +1,16 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package project
 
 import (

--- a/cmd/harbor/root/project/list_test.go
+++ b/cmd/harbor/root/project/list_test.go
@@ -1,0 +1,21 @@
+package project
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListProjectCommand_InvalidPage(t *testing.T) {
+	cmd := ListProjectCommand()
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--page", "0"})
+
+	err := cmd.Execute()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "page number must be greater than or equal to 1")
+}

--- a/cmd/harbor/root/project/member/list.go
+++ b/cmd/harbor/root/project/member/list.go
@@ -40,6 +40,9 @@ func ListMemberCommand() *cobra.Command {
 		Example: "  harbor project member list my-project",
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.Page < 1 {
+				return fmt.Errorf("page number must be greater than or equal to 1")
+			}
 			if opts.PageSize < 0 {
 				return fmt.Errorf("page size must be greater than or equal to 0")
 			}

--- a/cmd/harbor/root/project/robot/list.go
+++ b/cmd/harbor/root/project/robot/list.go
@@ -70,6 +70,9 @@ Examples:
   harbor-cli project robot list`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.Page < 1 {
+				return fmt.Errorf("page number must be greater than or equal to 1")
+			}
 			if opts.PageSize < 0 {
 				return fmt.Errorf("page size must be greater than or equal to 0")
 			}

--- a/cmd/harbor/root/quota/list.go
+++ b/cmd/harbor/root/quota/list.go
@@ -32,6 +32,9 @@ func ListQuotaCommand() *cobra.Command {
 		Short: "list quotas",
 		Long:  "list quotas specified for each project",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.Page < 1 {
+				return fmt.Errorf("page number must be greater than or equal to 1")
+			}
 			if opts.PageSize < 0 {
 				return fmt.Errorf("page size must be greater than or equal to 0")
 			}

--- a/cmd/harbor/root/quota/list_test.go
+++ b/cmd/harbor/root/quota/list_test.go
@@ -1,0 +1,34 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package quota
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListQuotaCommand_InvalidPage(t *testing.T) {
+	cmd := ListQuotaCommand()
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--page", "0"})
+
+	err := cmd.Execute()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "page number must be greater than or equal to 1")
+}

--- a/cmd/harbor/root/registry/list.go
+++ b/cmd/harbor/root/registry/list.go
@@ -33,6 +33,9 @@ func ListRegistryCommand() *cobra.Command {
 		Short: "list registry",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.Page < 1 {
+				return fmt.Errorf("page number must be greater than or equal to 1")
+			}
 			if opts.PageSize < 0 {
 				return fmt.Errorf("page size must be greater than or equal to 0")
 			}

--- a/cmd/harbor/root/registry/list_test.go
+++ b/cmd/harbor/root/registry/list_test.go
@@ -1,3 +1,16 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package registry
 
 import (

--- a/cmd/harbor/root/registry/list_test.go
+++ b/cmd/harbor/root/registry/list_test.go
@@ -1,0 +1,21 @@
+package registry
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListRegistryCommand_InvalidPage(t *testing.T) {
+	cmd := ListRegistryCommand()
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--page", "0"})
+
+	err := cmd.Execute()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "page number must be greater than or equal to 1")
+}

--- a/cmd/harbor/root/replication/executions/list.go
+++ b/cmd/harbor/root/replication/executions/list.go
@@ -37,7 +37,17 @@ func ListCommand() *cobra.Command {
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Debug("Starting replication executions list command")
+			if opts.Page < 1 {
+				return fmt.Errorf("page number must be greater than or equal to 1")
+			}
 
+			if opts.PageSize < 0 {
+				return fmt.Errorf("page size must be greater than or equal to 0")
+			}
+
+			if opts.PageSize > 100 {
+				return fmt.Errorf("page size should be less than or equal to 100")
+			}
 			var rpolicyID int64
 			if len(args) > 0 {
 				var err error
@@ -48,14 +58,6 @@ func ListCommand() *cobra.Command {
 				}
 			} else {
 				rpolicyID = prompt.GetReplicationPolicyFromUser()
-			}
-
-			if opts.PageSize < 0 {
-				return fmt.Errorf("page size must be greater than or equal to 0")
-			}
-
-			if opts.PageSize > 100 {
-				return fmt.Errorf("page size should be less than or equal to 100")
 			}
 
 			log.Debug("Fetching executions...")

--- a/cmd/harbor/root/replication/policies/list.go
+++ b/cmd/harbor/root/replication/policies/list.go
@@ -32,6 +32,9 @@ func ListCommand() *cobra.Command {
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Debug("Starting replications list command")
+			if opts.Page < 1 {
+				return fmt.Errorf("page number must be greater than or equal to 1")
+			}
 
 			if opts.PageSize < 0 {
 				return fmt.Errorf("page size must be greater than or equal to 0")

--- a/cmd/harbor/root/repository/list.go
+++ b/cmd/harbor/root/repository/list.go
@@ -36,6 +36,10 @@ func ListRepositoryCommand() *cobra.Command {
 		Long:    `Get information of all repositories in a project`,
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.Page < 1 {
+				return fmt.Errorf("page number must be greater than or equal to 1")
+			}
+
 			if opts.PageSize < 0 {
 				return fmt.Errorf("page size must be greater than or equal to 0")
 			}

--- a/cmd/harbor/root/robot/list.go
+++ b/cmd/harbor/root/robot/list.go
@@ -63,6 +63,10 @@ Examples:
   harbor-cli robot list --output-format json`,
 		Args: cobra.MaximumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.Page < 1 {
+				return fmt.Errorf("page number must be greater than or equal to 1")
+			}
+
 			if opts.PageSize < 0 {
 				return fmt.Errorf("page size must be greater than or equal to 0")
 			}

--- a/cmd/harbor/root/schedule/list.go
+++ b/cmd/harbor/root/schedule/list.go
@@ -30,6 +30,10 @@ func ListScheduleCommand() *cobra.Command {
 		Use:   "list",
 		Short: "show all schedule jobs in Harbor",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.Page < 1 {
+				return fmt.Errorf("page number must be greater than or equal to 1")
+			}
+
 			if opts.PageSize < 0 {
 				return fmt.Errorf("page size must be greater than or equal to 0")
 			}

--- a/cmd/harbor/root/schedule/list_test.go
+++ b/cmd/harbor/root/schedule/list_test.go
@@ -1,0 +1,34 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package schedule
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListScheduleCommand_InvalidPage(t *testing.T) {
+	cmd := ListScheduleCommand()
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--page", "0"})
+
+	err := cmd.Execute()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "page number must be greater than or equal to 1")
+}

--- a/cmd/harbor/root/user/list.go
+++ b/cmd/harbor/root/user/list.go
@@ -35,6 +35,10 @@ func UserListCmd() *cobra.Command {
 		Args:    cobra.ExactArgs(0),
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.Page < 1 {
+				return fmt.Errorf("page number must be greater than or equal to 1")
+			}
+
 			if opts.PageSize < 0 {
 				return fmt.Errorf("page size must be greater than or equal to 0")
 			}


### PR DESCRIPTION
## Description
This pull request adds early validation for invalid `--page` values in selected list commands.

Previously, some commands accepted invalid values such as `--page 0` or negative page numbers and passed them to the API, which could lead to inconsistent behavior.

This change ensures that invalid page values are rejected before making API calls, improving CLI reliability and consistency.

- Fixes #778 

## Type of Change
Please select the relevant type.

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
- Added validation to reject `--page < 1` in:
  - `harbor artifact list`
  - `harbor project list`
  - `harbor registry list`
- Used the same validation message as `harbor project logs` for consistency
- Ensured validation occurs before API calls
