### PR TITLE
feat: allow localhost as a valid host in URL validation

### DIFF
--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -196,6 +196,10 @@ func ValidateURL(rawURL string) error {
 		return nil
 	}
 
+	if host == "localhost" {
+		return nil
+	}
+
 	if !domainNameRegex.MatchString(host) {
 		return fmt.Errorf("invalid host: must be a valid IP address or domain name")
 	}

--- a/pkg/utils/helper_test.go
+++ b/pkg/utils/helper_test.go
@@ -143,6 +143,10 @@ func TestValidateURL(t *testing.T) {
 		{"valid IPv4", "http://192.168.1.1", false},
 		{"valid IPv4 with port", "http://192.168.1.1:8080", false},
 		{"valid IPv6", "http://[::1]", false},
+		{"valid localhost http", "http://localhost", false},
+		{"valid localhost https", "https://localhost", false},
+		{"valid localhost http with port", "http://localhost:8080", false},
+		{"valid localhost https with port", "https://localhost:8443", false},
 
 		// invalid URLs
 		{"empty string", "", true},


### PR DESCRIPTION
## Description
This pull request modifies the `ValidateURL` function to allow `localhost` as a valid host. Previously, local development addresses lacking a top-level domain (like `localhost` or `http://localhost:8080`) failed the domain validation regex, which prevented users from successfully logging into local Harbor instances.

- Fixes #783

## Type of Change
Please select the relevant type.

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
- Added an early return check for `"localhost"` in `pkg/utils/helper.go`'s `ValidateURL` function before the strict domain regex is evaluated.
- Expanded the URL validation test suite in `pkg/utils/helper_test.go` to include coverage for `localhost` addresses using both HTTP and HTTPS schemes, as well as with and without ports.
