### PR TITLE
chore(lint): enable unused linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,6 +8,7 @@ linters:
     - misspell
     - nilnil
     - staticcheck
+    - unused
     - whitespace
   settings:
     goheader:


### PR DESCRIPTION
## Description
Enables the `unused` linter in golangci-lint configuration to improve detection of unused code.
- Fixes #782 

## Type of Change
Please select the relevant type.

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [x] Chore / maintenance

## Changes
- Enabled the `unused` linter in `.golangci.yaml`
- Kept the change minimal to introduce one linter at a time
- Allow CI to report any existing unused code for follow-up fixes
