### PR TITLE
fix(webhook): normalize endpoint URL before validation

### DIFF
--- a/cmd/harbor/root/webhook/create.go
+++ b/cmd/harbor/root/webhook/create.go
@@ -69,10 +69,12 @@ or leave them out and be guided through an interactive prompt to input each fiel
 				opts.NotifyType != "" &&
 				len(opts.EventType) != 0 &&
 				opts.EndpointURL != "" {
-				err = utils.ValidateURL(opts.EndpointURL)
+				formattedURL := utils.FormatUrl(opts.EndpointURL)
+				err = utils.ValidateURL(formattedURL)
 				if err != nil {
 					return err
 				}
+				opts.EndpointURL = formattedURL
 				err = api.CreateWebhook(&opts)
 			} else {
 				err = createWebhookView(createView)

--- a/cmd/harbor/root/webhook/create.go
+++ b/cmd/harbor/root/webhook/create.go
@@ -23,6 +23,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var createWebhook = api.CreateWebhook
+
 func CreateWebhookCmd() *cobra.Command {
 	var opts create.CreateView
 
@@ -75,7 +77,7 @@ or leave them out and be guided through an interactive prompt to input each fiel
 					return err
 				}
 				opts.EndpointURL = formattedURL
-				err = api.CreateWebhook(&opts)
+				err = createWebhook(&opts)
 			} else {
 				err = createWebhookView(createView)
 			}
@@ -112,5 +114,5 @@ func createWebhookView(view *create.CreateView) error {
 	if err != nil {
 		return err
 	}
-	return api.CreateWebhook(view)
+	return createWebhook(view)
 }

--- a/cmd/harbor/root/webhook/edit.go
+++ b/cmd/harbor/root/webhook/edit.go
@@ -85,10 +85,13 @@ or leave them out and use the interactive prompt to select and update a webhook.
 				opts.NotifyType != "" &&
 				len(opts.EventType) != 0 &&
 				opts.EndpointURL != "" {
-				if err := utils.ValidateURL(opts.EndpointURL); err != nil {
+				formattedURL := utils.FormatUrl(opts.EndpointURL)
+				if err := utils.ValidateURL(formattedURL); err != nil {
 					return err
 				}
+				opts.EndpointURL = formattedURL
 				err = api.UpdateWebhook(&opts)
+
 			} else {
 				err = editWebhookView(editView)
 			}

--- a/cmd/harbor/root/webhook/edit.go
+++ b/cmd/harbor/root/webhook/edit.go
@@ -24,6 +24,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var updateWebhook = api.UpdateWebhook
+
 func EditWebhookCmd() *cobra.Command {
 	var opts edit.EditView
 	cmd := &cobra.Command{
@@ -90,7 +92,7 @@ or leave them out and use the interactive prompt to select and update a webhook.
 					return err
 				}
 				opts.EndpointURL = formattedURL
-				err = api.UpdateWebhook(&opts)
+				err = updateWebhook(&opts)
 			} else {
 				err = editWebhookView(editView)
 			}
@@ -149,5 +151,5 @@ func editWebhookView(view *edit.EditView) error {
 		view.NotifyType = selectedWebhook.Targets[0].Type
 	}
 	edit.WebhookEditView(view)
-	return api.UpdateWebhook(view)
+	return updateWebhook(view)
 }

--- a/cmd/harbor/root/webhook/edit.go
+++ b/cmd/harbor/root/webhook/edit.go
@@ -91,7 +91,6 @@ or leave them out and use the interactive prompt to select and update a webhook.
 				}
 				opts.EndpointURL = formattedURL
 				err = api.UpdateWebhook(&opts)
-
 			} else {
 				err = editWebhookView(editView)
 			}

--- a/cmd/harbor/root/webhook/webhook_test.go
+++ b/cmd/harbor/root/webhook/webhook_test.go
@@ -1,3 +1,16 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package webhook
 
 import (

--- a/cmd/harbor/root/webhook/webhook_test.go
+++ b/cmd/harbor/root/webhook/webhook_test.go
@@ -1,0 +1,50 @@
+package webhook
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateWebhookCmd_NormalizesEndpointURLBeforeValidation(t *testing.T) {
+	cmd := CreateWebhookCmd()
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{
+		"my-webhook",
+		"--project", "my-project",
+		"--notify-type", "http",
+		"--event-type", "PUSH_ARTIFACT",
+		"--endpoint-url", "example.com/webhook",
+	})
+
+	err := cmd.Execute()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create webhook")
+	assert.NotContains(t, err.Error(), "invalid URL format")
+	assert.NotContains(t, err.Error(), "invalid host")
+}
+
+func TestEditWebhookCmd_NormalizesEndpointURLBeforeValidation(t *testing.T) {
+	cmd := EditWebhookCmd()
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{
+		"--project", "my-project",
+		"--webhook-id", "1",
+		"--notify-type", "http",
+		"--event-type", "PUSH_ARTIFACT",
+		"--endpoint-url", "example.com/webhook",
+	})
+
+	err := cmd.Execute()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to edit webhook")
+	assert.NotContains(t, err.Error(), "invalid URL format")
+	assert.NotContains(t, err.Error(), "invalid host")
+}

--- a/cmd/harbor/root/webhook/webhook_test.go
+++ b/cmd/harbor/root/webhook/webhook_test.go
@@ -61,3 +61,22 @@ func TestEditWebhookCmd_NormalizesEndpointURLBeforeValidation(t *testing.T) {
 	assert.NotContains(t, err.Error(), "invalid URL format")
 	assert.NotContains(t, err.Error(), "invalid host")
 }
+
+func TestEditWebhookCmd_InvalidEndpointURLReturnsValidationError(t *testing.T) {
+	cmd := EditWebhookCmd()
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{
+		"--project", "my-project",
+		"--webhook-id", "1",
+		"--notify-type", "http",
+		"--event-type", "PUSH_ARTIFACT",
+		"--endpoint-url", "http://",
+	})
+
+	err := cmd.Execute()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "URL must contain a valid host")
+}

--- a/cmd/harbor/root/webhook/webhook_test.go
+++ b/cmd/harbor/root/webhook/webhook_test.go
@@ -17,10 +17,23 @@ import (
 	"bytes"
 	"testing"
 
+	webhookcreate "github.com/goharbor/harbor-cli/pkg/views/webhook/create"
+	webhookedit "github.com/goharbor/harbor-cli/pkg/views/webhook/edit"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestCreateWebhookCmd_NormalizesEndpointURLBeforeValidation(t *testing.T) {
+func TestCreateWebhookCmd_AcceptsAndNormalizesEndpointURL(t *testing.T) {
+	originalCreateWebhook := createWebhook
+	t.Cleanup(func() {
+		createWebhook = originalCreateWebhook
+	})
+
+	createWebhook = func(opts *webhookcreate.CreateView) error {
+		assert.Equal(t, "https://example.com/webhook", opts.EndpointURL)
+		return nil
+	}
+
 	cmd := CreateWebhookCmd()
 
 	var buf bytes.Buffer
@@ -35,13 +48,20 @@ func TestCreateWebhookCmd_NormalizesEndpointURLBeforeValidation(t *testing.T) {
 	})
 
 	err := cmd.Execute()
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to create webhook")
-	assert.NotContains(t, err.Error(), "invalid URL format")
-	assert.NotContains(t, err.Error(), "invalid host")
+	require.NoError(t, err)
 }
 
-func TestEditWebhookCmd_NormalizesEndpointURLBeforeValidation(t *testing.T) {
+func TestEditWebhookCmd_AcceptsAndNormalizesEndpointURL(t *testing.T) {
+	originalUpdateWebhook := updateWebhook
+	t.Cleanup(func() {
+		updateWebhook = originalUpdateWebhook
+	})
+
+	updateWebhook = func(opts *webhookedit.EditView) error {
+		assert.Equal(t, "https://example.com/webhook", opts.EndpointURL)
+		return nil
+	}
+
 	cmd := EditWebhookCmd()
 
 	var buf bytes.Buffer
@@ -56,10 +76,7 @@ func TestEditWebhookCmd_NormalizesEndpointURLBeforeValidation(t *testing.T) {
 	})
 
 	err := cmd.Execute()
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to edit webhook")
-	assert.NotContains(t, err.Error(), "invalid URL format")
-	assert.NotContains(t, err.Error(), "invalid host")
+	require.NoError(t, err)
 }
 
 func TestEditWebhookCmd_InvalidEndpointURLReturnsValidationError(t *testing.T) {


### PR DESCRIPTION
## Description
Normalize webhook `--endpoint-url` values before validating them in the non-interactive create and edit commands.
Other Harbor CLI commands normalize user-provided URLs using `FormatUrl(...)` before validation. Previously, webhook create/edit commands validated raw input directly, which could reject valid inputs like `example.com/webhook` that should be normalized to `https://example.com/webhook`.

- Fixes #799 

## Type of Change


- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
- Normalize `--endpoint-url` using `FormatUrl(...)` before validation in `webhook create`
- Normalize `--endpoint-url` using `FormatUrl(...)` before validation in `webhook edit`
- Ensure consistent behavior with other Harbor CLI commands
