### PR TITLE
feat: immutable tags update subcommand

### DIFF
--- a/cmd/harbor/root/tag/immutable/cmd.go
+++ b/cmd/harbor/root/tag/immutable/cmd.go
@@ -28,6 +28,7 @@ func Immutable() *cobra.Command {
 		CreateImmutableCommand(),
 		ListImmutableCommand(),
 		DeleteImmutableCommand(),
+		UpdateImmutableCommand(),
 	)
 
 	return cmd

--- a/cmd/harbor/root/tag/immutable/update.go
+++ b/cmd/harbor/root/tag/immutable/update.go
@@ -1,0 +1,169 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package immutable
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/prompt"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/goharbor/harbor-cli/pkg/views/immutable/create"
+	"github.com/spf13/cobra"
+)
+
+func UpdateImmutableCommand() *cobra.Command {
+	var opts create.CreateView
+	var immutableID int64
+
+	cmd := &cobra.Command{
+		Use:   "update [PROJECT_NAME]",
+		Short: "update immutable tag rule",
+		Long:  "update immutable tag rule for a project in harbor",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+			var projectName string
+
+			if len(args) > 0 {
+				projectName = args[0]
+			} else {
+				projectName, err = prompt.GetProjectNameFromUser()
+				if err != nil {
+					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
+				}
+			}
+
+			if immutableID == 0 {
+				immutableID = prompt.GetImmutableTagRule(projectName)
+			}
+
+			existingRule, err := getImmutableRuleByID(projectName, immutableID)
+			if err != nil {
+				return fmt.Errorf("failed to load existing immutable tag rule: %v", err)
+			}
+
+			updateView := buildUpdateViewFromRule(existingRule)
+			applyFlagOverrides(updateView, opts)
+
+			if !hasAnyUpdateFlag(opts) {
+				create.CreateImmutableView(updateView)
+			}
+
+			applyViewToRule(existingRule, updateView)
+
+			if existingRule.ID == 0 {
+				existingRule.ID = immutableID
+			}
+
+			err = api.UpdateImmutable(existingRule, projectName, immutableID)
+			if err != nil {
+				return fmt.Errorf("failed to update immutable tag rule: %v", err)
+			}
+
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.Int64VarP(&immutableID, "immutable-id", "", 0, "immutable rule ID to update")
+	flags.StringVarP(&opts.ScopeSelectors.Decoration, "repo-decoration", "", "", "repository which either apply or exclude from the rule")
+	flags.StringVarP(&opts.ScopeSelectors.Pattern, "repo-list", "", "", "list of repository to which to either apply or exclude from the rule")
+	flags.StringVarP(&opts.TagSelectors.Decoration, "tag-decoration", "", "", "tags which either apply or exclude from the rule")
+	flags.StringVarP(&opts.TagSelectors.Pattern, "tag-list", "", "", "list of tags to which to either apply or exclude from the rule")
+
+	return cmd
+}
+
+func getImmutableRuleByID(projectName string, immutableID int64) (*models.ImmutableRule, error) {
+	resp, err := api.ListImmutable(projectName)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, rule := range resp.Payload {
+		if rule != nil && rule.ID == immutableID {
+			return rule, nil
+		}
+	}
+
+	return nil, errors.New("immutable rule not found")
+}
+
+func buildUpdateViewFromRule(rule *models.ImmutableRule) *create.CreateView {
+	view := &create.CreateView{}
+	if rule == nil {
+		return view
+	}
+
+	if len(rule.TagSelectors) > 0 && rule.TagSelectors[0] != nil {
+		view.TagSelectors.Decoration = rule.TagSelectors[0].Decoration
+		view.TagSelectors.Pattern = rule.TagSelectors[0].Pattern
+	}
+
+	if repoScopes, ok := rule.ScopeSelectors["repository"]; ok && len(repoScopes) > 0 {
+		view.ScopeSelectors.Decoration = repoScopes[0].Decoration
+		view.ScopeSelectors.Pattern = repoScopes[0].Pattern
+	}
+
+	return view
+}
+
+func applyFlagOverrides(target *create.CreateView, opts create.CreateView) {
+	if target == nil {
+		return
+	}
+
+	if opts.ScopeSelectors.Decoration != "" {
+		target.ScopeSelectors.Decoration = opts.ScopeSelectors.Decoration
+	}
+	if opts.ScopeSelectors.Pattern != "" {
+		target.ScopeSelectors.Pattern = opts.ScopeSelectors.Pattern
+	}
+	if opts.TagSelectors.Decoration != "" {
+		target.TagSelectors.Decoration = opts.TagSelectors.Decoration
+	}
+	if opts.TagSelectors.Pattern != "" {
+		target.TagSelectors.Pattern = opts.TagSelectors.Pattern
+	}
+}
+
+func applyViewToRule(rule *models.ImmutableRule, view *create.CreateView) {
+	if rule == nil || view == nil {
+		return
+	}
+
+	rule.TagSelectors = []*models.ImmutableSelector{{
+		Decoration: view.TagSelectors.Decoration,
+		Pattern:    view.TagSelectors.Pattern,
+	}}
+
+	rule.ScopeSelectors = map[string][]models.ImmutableSelector{
+		"repository": {
+			{
+				Decoration: view.ScopeSelectors.Decoration,
+				Pattern:    view.ScopeSelectors.Pattern,
+			},
+		},
+	}
+}
+
+func hasAnyUpdateFlag(opts create.CreateView) bool {
+	return opts.ScopeSelectors.Decoration != "" ||
+		opts.ScopeSelectors.Pattern != "" ||
+		opts.TagSelectors.Decoration != "" ||
+		opts.TagSelectors.Pattern != ""
+}

--- a/cmd/harbor/root/tag/immutable/update.go
+++ b/cmd/harbor/root/tag/immutable/update.go
@@ -27,7 +27,7 @@ import (
 
 func UpdateImmutableCommand() *cobra.Command {
 	var opts create.CreateView
-	var immutableID int64
+	var tagName string
 
 	cmd := &cobra.Command{
 		Use:   "update [PROJECT_NAME]",
@@ -47,11 +47,7 @@ func UpdateImmutableCommand() *cobra.Command {
 				}
 			}
 
-			if immutableID == 0 {
-				immutableID = prompt.GetImmutableTagRule(projectName)
-			}
-
-			existingRule, err := getImmutableRuleByID(projectName, immutableID)
+			existingRule, err := getImmutableRuleForUpdate(projectName, tagName)
 			if err != nil {
 				return fmt.Errorf("failed to load existing immutable tag rule: %v", err)
 			}
@@ -66,10 +62,10 @@ func UpdateImmutableCommand() *cobra.Command {
 			applyViewToRule(existingRule, updateView)
 
 			if existingRule.ID == 0 {
-				existingRule.ID = immutableID
+				return errors.New("immutable rule ID is missing")
 			}
 
-			err = api.UpdateImmutable(existingRule, projectName, immutableID)
+			err = api.UpdateImmutable(existingRule, projectName, existingRule.ID)
 			if err != nil {
 				return fmt.Errorf("failed to update immutable tag rule: %v", err)
 			}
@@ -79,13 +75,22 @@ func UpdateImmutableCommand() *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.Int64VarP(&immutableID, "immutable-id", "", 0, "immutable rule ID to update")
+	flags.StringVarP(&tagName, "tag_name", "", "", "tag pattern of the immutable rule to update")
 	flags.StringVarP(&opts.ScopeSelectors.Decoration, "repo-decoration", "", "", "repository which either apply or exclude from the rule")
 	flags.StringVarP(&opts.ScopeSelectors.Pattern, "repo-list", "", "", "list of repository to which to either apply or exclude from the rule")
 	flags.StringVarP(&opts.TagSelectors.Decoration, "tag-decoration", "", "", "tags which either apply or exclude from the rule")
 	flags.StringVarP(&opts.TagSelectors.Pattern, "tag-list", "", "", "list of tags to which to either apply or exclude from the rule")
 
 	return cmd
+}
+
+func getImmutableRuleForUpdate(projectName, tagName string) (*models.ImmutableRule, error) {
+	if tagName == "" {
+		immutableID := prompt.GetImmutableTagRule(projectName)
+		return getImmutableRuleByID(projectName, immutableID)
+	}
+
+	return getImmutableRuleByTagName(projectName, tagName)
 }
 
 func getImmutableRuleByID(projectName string, immutableID int64) (*models.ImmutableRule, error) {
@@ -101,6 +106,27 @@ func getImmutableRuleByID(projectName string, immutableID int64) (*models.Immuta
 	}
 
 	return nil, errors.New("immutable rule not found")
+}
+
+func getImmutableRuleByTagName(projectName, tagName string) (*models.ImmutableRule, error) {
+	resp, err := api.ListImmutable(projectName)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, rule := range resp.Payload {
+		if rule == nil {
+			continue
+		}
+
+		for _, tagSelector := range rule.TagSelectors {
+			if tagSelector != nil && tagSelector.Pattern == tagName {
+				return rule, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("immutable rule with tag pattern %q not found", tagName)
 }
 
 func buildUpdateViewFromRule(rule *models.ImmutableRule) *create.CreateView {

--- a/doc/cli-docs/harbor-tag-immutable-update.md
+++ b/doc/cli-docs/harbor-tag-immutable-update.md
@@ -31,7 +31,7 @@ harbor tag immutable update [PROJECT_NAME] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-tag-immutable-update.md
+++ b/doc/cli-docs/harbor-tag-immutable-update.md
@@ -1,0 +1,41 @@
+---
+title: harbor tag immutable update
+weight: 50
+---
+## harbor tag immutable update
+
+### Description
+
+##### update immutable tag rule
+
+### Synopsis
+
+update immutable tag rule for a project in harbor
+
+```sh
+harbor tag immutable update [PROJECT_NAME] [flags]
+```
+
+### Options
+
+```sh
+  -h, --help                     help for update
+      --immutable-id int         immutable rule ID to update
+      --repo-decoration string   repository which either apply or exclude from the rule
+      --repo-list string         list of repository to which to either apply or exclude from the rule
+      --tag-decoration string    tags which either apply or exclude from the rule
+      --tag-list string          list of tags to which to either apply or exclude from the rule
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor tag immutable](harbor-tag-immutable.md)	 - Manage Immutability rules in the project
+

--- a/doc/cli-docs/harbor-tag-immutable-update.md
+++ b/doc/cli-docs/harbor-tag-immutable-update.md
@@ -20,11 +20,11 @@ harbor tag immutable update [PROJECT_NAME] [flags]
 
 ```sh
   -h, --help                     help for update
-      --immutable-id int         immutable rule ID to update
       --repo-decoration string   repository which either apply or exclude from the rule
       --repo-list string         list of repository to which to either apply or exclude from the rule
       --tag-decoration string    tags which either apply or exclude from the rule
       --tag-list string          list of tags to which to either apply or exclude from the rule
+      --tag_name string          tag pattern of the immutable rule to update
 ```
 
 ### Options inherited from parent commands

--- a/doc/cli-docs/harbor-tag-immutable.md
+++ b/doc/cli-docs/harbor-tag-immutable.md
@@ -38,4 +38,5 @@ harbor tag immutable
 * [harbor tag immutable create](harbor-tag-immutable-create.md)	 - create immutable tag rule
 * [harbor tag immutable delete](harbor-tag-immutable-delete.md)	 - delete immutable rule
 * [harbor tag immutable list](harbor-tag-immutable-list.md)	 - Display all immutable tag rules for a project
+* [harbor tag immutable update](harbor-tag-immutable-update.md)	 - update immutable tag rule
 

--- a/doc/man-docs/man1/harbor-tag-immutable-update.1
+++ b/doc/man-docs/man1/harbor-tag-immutable-update.1
@@ -44,7 +44,7 @@ update immutable tag rule for a project in harbor
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-tag-immutable-update.1
+++ b/doc/man-docs/man1/harbor-tag-immutable-update.1
@@ -1,0 +1,55 @@
+.nh
+.TH "HARBOR" "1"  "Harbor Community" "Harbor User Manuals"
+
+.SH NAME
+harbor-tag-immutable-update - update immutable tag rule
+
+
+.SH SYNOPSIS
+\fBharbor tag immutable update [PROJECT_NAME] [flags]\fP
+
+
+.SH DESCRIPTION
+update immutable tag rule for a project in harbor
+
+
+.SH OPTIONS
+\fB-h\fP, \fB--help\fP[=false]
+	help for update
+
+.PP
+\fB--immutable-id\fP=0
+	immutable rule ID to update
+
+.PP
+\fB--repo-decoration\fP=""
+	repository which either apply or exclude from the rule
+
+.PP
+\fB--repo-list\fP=""
+	list of repository to which to either apply or exclude from the rule
+
+.PP
+\fB--tag-decoration\fP=""
+	tags which either apply or exclude from the rule
+
+.PP
+\fB--tag-list\fP=""
+	list of tags to which to either apply or exclude from the rule
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+\fB-c\fP, \fB--config\fP=""
+	config file (default is $HOME/.config/harbor-cli/config.yaml)
+
+.PP
+\fB-o\fP, \fB--output-format\fP=""
+	Output format. One of: json|yaml
+
+.PP
+\fB-v\fP, \fB--verbose\fP[=false]
+	verbose output
+
+
+.SH SEE ALSO
+\fBharbor-tag-immutable(1)\fP

--- a/doc/man-docs/man1/harbor-tag-immutable-update.1
+++ b/doc/man-docs/man1/harbor-tag-immutable-update.1
@@ -18,10 +18,6 @@ update immutable tag rule for a project in harbor
 	help for update
 
 .PP
-\fB--immutable-id\fP=0
-	immutable rule ID to update
-
-.PP
 \fB--repo-decoration\fP=""
 	repository which either apply or exclude from the rule
 
@@ -36,6 +32,10 @@ update immutable tag rule for a project in harbor
 .PP
 \fB--tag-list\fP=""
 	list of tags to which to either apply or exclude from the rule
+
+.PP
+\fB--tag_name\fP=""
+	tag pattern of the immutable rule to update
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS

--- a/doc/man-docs/man1/harbor-tag-immutable.1
+++ b/doc/man-docs/man1/harbor-tag-immutable.1
@@ -38,4 +38,4 @@ harbor tag immutable
 
 
 .SH SEE ALSO
-\fBharbor-tag(1)\fP, \fBharbor-tag-immutable-create(1)\fP, \fBharbor-tag-immutable-delete(1)\fP, \fBharbor-tag-immutable-list(1)\fP
+\fBharbor-tag(1)\fP, \fBharbor-tag-immutable-create(1)\fP, \fBharbor-tag-immutable-delete(1)\fP, \fBharbor-tag-immutable-list(1)\fP, \fBharbor-tag-immutable-update(1)\fP

--- a/pkg/api/immutable_handler.go
+++ b/pkg/api/immutable_handler.go
@@ -28,6 +28,7 @@ func CreateImmutable(opts create.CreateView, projectName string) error {
 	if err != nil {
 		return err
 	}
+	xIsResourceName := false
 	tagSelector := &models.ImmutableSelector{
 		Decoration: opts.TagSelectors.Decoration,
 		Pattern:    opts.TagSelectors.Pattern,
@@ -42,7 +43,7 @@ func CreateImmutable(opts create.CreateView, projectName string) error {
 		},
 	}
 
-	_, err = client.Immutable.CreateImmuRule(ctx, &immutable.CreateImmuRuleParams{ProjectNameOrID: projectName, ImmutableRule: &models.ImmutableRule{TagSelectors: []*models.ImmutableSelector{tagSelector}, ScopeSelectors: scopeSelector}})
+	_, err = client.Immutable.CreateImmuRule(ctx, &immutable.CreateImmuRuleParams{ProjectNameOrID: projectName, XIsResourceName: &xIsResourceName, ImmutableRule: &models.ImmutableRule{TagSelectors: []*models.ImmutableSelector{tagSelector}, ScopeSelectors: scopeSelector}})
 
 	if err != nil {
 		return err
@@ -57,7 +58,8 @@ func ListImmutable(projectName string) (immutable.ListImmuRulesOK, error) {
 	if err != nil {
 		return immutable.ListImmuRulesOK{}, err
 	}
-	response, err := client.Immutable.ListImmuRules(ctx, &immutable.ListImmuRulesParams{ProjectNameOrID: projectName})
+	xIsResourceName := false
+	response, err := client.Immutable.ListImmuRules(ctx, &immutable.ListImmuRulesParams{ProjectNameOrID: projectName, XIsResourceName: &xIsResourceName})
 	if err != nil {
 		return immutable.ListImmuRulesOK{}, err
 	}
@@ -70,7 +72,8 @@ func DeleteImmutable(projectName string, ImmutableID int64) error {
 	if err != nil {
 		return err
 	}
-	_, err = client.Immutable.DeleteImmuRule(ctx, &immutable.DeleteImmuRuleParams{ProjectNameOrID: projectName, ImmutableRuleID: ImmutableID})
+	xIsResourceName := false
+	_, err = client.Immutable.DeleteImmuRule(ctx, &immutable.DeleteImmuRuleParams{ProjectNameOrID: projectName, XIsResourceName: &xIsResourceName, ImmutableRuleID: ImmutableID})
 	if err != nil {
 		return err
 	}
@@ -85,12 +88,14 @@ func UpdateImmutable(rule *models.ImmutableRule, projectName string, immutableID
 	if err != nil {
 		return err
 	}
+	xIsResourceName := false
 	if rule == nil {
 		return errors.New("immutable rule payload cannot be nil")
 	}
 
 	_, err = client.Immutable.UpdateImmuRule(ctx, &immutable.UpdateImmuRuleParams{
 		ProjectNameOrID: projectName,
+		XIsResourceName: &xIsResourceName,
 		ImmutableRuleID: immutableID,
 		ImmutableRule:   rule,
 	})

--- a/pkg/api/immutable_handler.go
+++ b/pkg/api/immutable_handler.go
@@ -14,6 +14,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/immutable"
@@ -76,5 +77,27 @@ func DeleteImmutable(projectName string, ImmutableID int64) error {
 
 	fmt.Println("Immutable rule deleted successfully")
 
+	return nil
+}
+
+func UpdateImmutable(rule *models.ImmutableRule, projectName string, immutableID int64) error {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return err
+	}
+	if rule == nil {
+		return errors.New("immutable rule payload cannot be nil")
+	}
+
+	_, err = client.Immutable.UpdateImmuRule(ctx, &immutable.UpdateImmuRuleParams{
+		ProjectNameOrID: projectName,
+		ImmutableRuleID: immutableID,
+		ImmutableRule:   rule,
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Immutable rule updated successfully")
 	return nil
 }


### PR DESCRIPTION
## Description
Briefly describe what this pull request does and why the change is needed.
The Harbor CLI currently lacks support for updating existing immutable rules via CLI. 
`harbor tag immutable update [PROJECT_NAME]` command with interactive-first behavior if project name not mentioned.

- Fixes #798 

## Type of Change
Please select the relevant type.

```bash
harbor tag immutable update [PROJECT_NAME]
  --rule-id <id>           # Rule ID to update (optional; interactive if omitted)
  --tag-pattern <pattern>  # New tag matching pattern (optional; interactive if omitted)
  --scope <scope>          # Scope (include/exclude) (optional; interactive if omitted)
  --file <path>            # Load rule update config from JSON file (optional)
```

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
- cmd/harbor/root/tag/immutable/cmd.go
- cmd/harbor/root/tag/immutable/update.go
- pkg/api/immutable_handler.go
