### PR TITLE
fix(ldap): add url and scope validation to ldap ping command

### DIFF
--- a/cmd/harbor/root/ldap/ping.go
+++ b/cmd/harbor/root/ldap/ping.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -29,6 +30,18 @@ func LdapPingCmd() *cobra.Command {
 		Short: "ping ldap server",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.LdapURL != "" {
+				formattedURL := utils.FormatUrl(opts.LdapURL)
+				err := utils.ValidateURL(formattedURL)
+				if err != nil {
+					return err
+				}
+				opts.LdapURL = formattedURL
+			}
+
+			if opts.LdapScope < 0 || opts.LdapScope > 2 {
+				return fmt.Errorf("ldap-scope must be 0, 1, or 2")
+			}
 			response, err := api.LdapPingServer(opts)
 			if err != nil {
 				return err


### PR DESCRIPTION
## Description
Adds input validation for the `harbor ldap ping` command to prevent invalid inputs from being sent to the API.

- Normalizes and validates `--ldap-url` using `utils.FormatUrl()` and `utils.ValidateURL()`
- Restricts `--ldap-scope` to valid values: `0` (base), `1` (one level), `2` (subtree)

This ensures early CLI validation and clearer error messages instead of delayed API failures.

- Fixes #803 

## Type of Change
Please select the relevant type.

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
- Added URL normalization and validation for `--ldap-url`
- Added bounds checking for `--ldap-scope` (0–2 only)
- Improved error handling with early validation before API call
<img width="1327" height="204" alt="image" src="https://github.com/user-attachments/assets/73ec58ca-533e-4476-ab03-ddd03b006405" />

