### PR TITLE
fix: improve login error messages 

### DIFF
--- a/.dagger/publishimage.go
+++ b/.dagger/publishimage.go
@@ -43,10 +43,10 @@ func (m *HarborCli) PublishImageAndSign(
 		// Generate SBOM (SPDX JSON) for the published image
 		sbom := m.GenerateSBOM(
 			ctx,
-			addr, 
-			registryUsername, 
+			addr,
+			registryUsername,
 			registryPassword,
-		);
+		)
 
 		// Attest SBOM to the image using Cosign in-toto attestation
 		if _, err := m.AttestSBOM(

--- a/cmd/harbor/root/login.go
+++ b/cmd/harbor/root/login.go
@@ -136,9 +136,17 @@ func RunLogin(opts login.LoginView) error {
 	ctx := context.Background()
 	_, err = client.User.GetCurrentUserInfo(ctx, &user.GetCurrentUserInfoParams{})
 	if err != nil {
-		if !strings.Contains(err.Error(), "status 412") {
-			return fmt.Errorf("%v", utils.ParseHarborErrorMsg(err))
-		}
+    errMsg := err.Error()
+
+    if strings.Contains(errMsg, "502") {
+        return fmt.Errorf("server error (502): Harbor API is unavailable, please try again later")
+    }
+    if strings.Contains(errMsg, "401") || strings.Contains(errMsg, "403") {
+        return fmt.Errorf("authentication failed: invalid username or password")
+    }
+    if !strings.Contains(errMsg, "status 412") {
+        return fmt.Errorf("login failed: %v", utils.ParseHarborErrorMsg(err))
+    }
 	}
 	if err := utils.GenerateEncryptionKey(); err != nil {
 		fmt.Println("Encryption key already exists or could not be created:", err)

--- a/cmd/harbor/root/login.go
+++ b/cmd/harbor/root/login.go
@@ -136,17 +136,17 @@ func RunLogin(opts login.LoginView) error {
 	ctx := context.Background()
 	_, err = client.User.GetCurrentUserInfo(ctx, &user.GetCurrentUserInfoParams{})
 	if err != nil {
-    errMsg := err.Error()
+		errMsg := err.Error()
 
-    if strings.Contains(errMsg, "502") {
-        return fmt.Errorf("server error (502): Harbor API is unavailable, please try again later")
-    }
-    if strings.Contains(errMsg, "401") || strings.Contains(errMsg, "403") {
-        return fmt.Errorf("authentication failed: invalid username or password")
-    }
-    if !strings.Contains(errMsg, "status 412") {
-        return fmt.Errorf("login failed: %v", utils.ParseHarborErrorMsg(err))
-    }
+		if strings.Contains(errMsg, "502") {
+			return fmt.Errorf("server error (502): Harbor API is unavailable, please try again later")
+		}
+		if strings.Contains(errMsg, "401") || strings.Contains(errMsg, "403") {
+			return fmt.Errorf("authentication failed: invalid username or password")
+		}
+		if !strings.Contains(errMsg, "status 412") {
+			return fmt.Errorf("login failed: %v", utils.ParseHarborErrorMsg(err))
+		}
 	}
 	if err := utils.GenerateEncryptionKey(); err != nil {
 		fmt.Println("Encryption key already exists or could not be created:", err)


### PR DESCRIPTION
## Description
This PR improves the error messages returned during `harbor login`.
Currently, login failures return raw go-swagger error messages which are not user friendly.  
This change introduces clearer error messages by detecting common HTTP status codes.

- Fixes a part of #808 
## Type of Change
Please select the relevant 

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
- Detect HTTP status codes from login errors (e.g. 502, 401/403)
- Differentiate between:
  - Server errors (5xx)
  - Authentication errors (401/403)
- Return user friendly messages instead of raw go-swagger errors
