### PR TITLE
feat : instance remaining subcommands

### DIFF
--- a/cmd/harbor/root/instance/cmd.go
+++ b/cmd/harbor/root/instance/cmd.go
@@ -26,6 +26,7 @@ These instances represent external services such as Dragonfly or Kraken that hel
 		CreateInstanceCommand(),
 		DeleteInstanceCommand(),
 		ListInstanceCommand(),
+		PingInstanceCommand(),
 		UpdateInstanceCommand(),
 		ViewInstanceCommand(),
 	)

--- a/cmd/harbor/root/instance/cmd.go
+++ b/cmd/harbor/root/instance/cmd.go
@@ -26,6 +26,7 @@ These instances represent external services such as Dragonfly or Kraken that hel
 		CreateInstanceCommand(),
 		DeleteInstanceCommand(),
 		ListInstanceCommand(),
+		ViewInstanceCommand(),
 	)
 	return cmd
 }

--- a/cmd/harbor/root/instance/cmd.go
+++ b/cmd/harbor/root/instance/cmd.go
@@ -26,6 +26,7 @@ These instances represent external services such as Dragonfly or Kraken that hel
 		CreateInstanceCommand(),
 		DeleteInstanceCommand(),
 		ListInstanceCommand(),
+		UpdateInstanceCommand(),
 		ViewInstanceCommand(),
 	)
 	return cmd

--- a/cmd/harbor/root/instance/create.go
+++ b/cmd/harbor/root/instance/create.go
@@ -24,6 +24,7 @@ import (
 
 func CreateInstanceCommand() *cobra.Command {
 	var opts create.CreateView
+	var authUsername, authPassword, authToken string
 
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -35,16 +36,7 @@ You will need to provide the instance's name, vendor, endpoint, and optionally o
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
-			createView := &create.CreateView{
-				Name:        opts.Name,
-				Vendor:      opts.Vendor,
-				Description: opts.Description,
-				Endpoint:    opts.Endpoint,
-				Insecure:    opts.Insecure,
-				Enabled:     opts.Enabled,
-				AuthMode:    opts.AuthMode,
-				AuthInfo:    opts.AuthInfo,
-			}
+			var instanceName string
 
 			if opts.Name != "" && opts.Vendor != "" && opts.Endpoint != "" {
 				formattedEndpoint := utils.FormatUrl(opts.Endpoint)
@@ -52,26 +44,65 @@ You will need to provide the instance's name, vendor, endpoint, and optionally o
 					return err
 				}
 				opts.Endpoint = formattedEndpoint
+
+				switch opts.AuthMode {
+				case "BASIC":
+					if authUsername == "" || authPassword == "" {
+						return fmt.Errorf("username and password are required when authmode is BASIC. Use --auth-username and --auth-password flags")
+					}
+					opts.AuthInfo = map[string]string{
+						"username": authUsername,
+						"password": authPassword,
+					}
+				case "OAUTH":
+					if authToken == "" {
+						return fmt.Errorf("token is required when authmode is OAUTH. Use --auth-token flag")
+					}
+					opts.AuthInfo = map[string]string{
+						"token": authToken,
+					}
+				case "NONE":
+					// Auth credentials are ignored when authmode is NONE
+				default:
+					return fmt.Errorf("invalid authmode '%s'. Valid options: NONE, BASIC, OAUTH", opts.AuthMode)
+				}
+
 				err = api.CreateInstance(opts)
+				instanceName = opts.Name
 			} else {
+				createView := &create.CreateView{
+					Name:        opts.Name,
+					Vendor:      opts.Vendor,
+					Description: opts.Description,
+					Endpoint:    opts.Endpoint,
+					Insecure:    opts.Insecure,
+					Enabled:     opts.Enabled,
+					AuthMode:    opts.AuthMode,
+				}
 				err = createInstanceView(createView)
+				instanceName = createView.Name
 			}
 
 			if err != nil {
-				return fmt.Errorf("failed to create instance: %v", err)
+				return fmt.Errorf("failed to create instance: %v", utils.ParseHarborErrorMsg(err))
 			}
+
+			fmt.Printf("Instance '%s' created successfully\n", instanceName)
 			return nil
 		},
 	}
 
 	flags := cmd.Flags()
 	flags.StringVarP(&opts.Name, "name", "n", "", "Name of the instance")
-	flags.StringVarP(&opts.Vendor, "provider", "p", "", "Provider for the instance")
-	flags.StringVarP(&opts.Endpoint, "url", "u", "", "URL for the instance")
-	flags.StringVarP(&opts.Description, "description", "", "", "Description of the instance")
-	flags.BoolVarP(&opts.Insecure, "insecure", "i", true, "Whether or not the certificate will be verified when Harbor tries to access the server")
-	flags.BoolVarP(&opts.Enabled, "enable", "", true, "Whether it is enabled or not")
-	flags.StringVarP(&opts.AuthMode, "authmode", "a", "NONE", "Choosing different types of authentication method")
+	flags.StringVarP(&opts.Vendor, "provider", "p", "", "Provider for the instance (e.g. dragonfly, kraken)")
+	flags.StringVarP(&opts.Endpoint, "url", "u", "", "Endpoint URL for the instance")
+	flags.StringVarP(&opts.Description, "description", "d", "", "Description of the instance")
+	flags.BoolVarP(&opts.Insecure, "insecure", "", false, "Whether or not the certificate will be verified when Harbor tries to access the server")
+	flags.BoolVarP(&opts.Enabled, "enable", "", true, "Whether the instance is enabled or not")
+	flags.StringVarP(&opts.AuthMode, "authmode", "a", "NONE", "Authentication mode (NONE, BASIC, OAUTH)")
+	flags.StringVar(&authUsername, "auth-username", "", "Username for BASIC authentication")
+	flags.StringVar(&authPassword, "auth-password", "", "Password for BASIC authentication")
+	flags.StringVar(&authToken, "auth-token", "", "Token for OAUTH authentication")
 
 	return cmd
 }
@@ -81,6 +112,8 @@ func createInstanceView(createView *create.CreateView) error {
 		createView = &create.CreateView{}
 	}
 
-	create.CreateInstanceView(createView)
+	if err := create.CreateInstanceView(createView); err != nil {
+		return err
+	}
 	return api.CreateInstance(*createView)
 }

--- a/cmd/harbor/root/instance/create.go
+++ b/cmd/harbor/root/instance/create.go
@@ -15,6 +15,7 @@ package instance
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
@@ -32,7 +33,7 @@ func CreateInstanceCommand() *cobra.Command {
 		Long: `Create a new preheat provider instance within Harbor for distributing container images.
 The instance can be an external service such as Dragonfly, Kraken, or any custom provider.
 You will need to provide the instance's name, vendor, endpoint, and optionally other details such as authentication and security options.`,
-		Example: `  harbor-cli instance create --name my-instance --provider Dragonfly --url http://dragonfly.local --description "My preheat provider instance" --enable=true`,
+		Example: `  harbor-cli instance create --name my-instance --provider dragonfly --url http://dragonfly.local --description "My preheat provider instance" --enable=true`,
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
@@ -44,6 +45,8 @@ You will need to provide the instance's name, vendor, endpoint, and optionally o
 					return err
 				}
 				opts.Endpoint = formattedEndpoint
+
+				opts.AuthMode = strings.ToUpper(strings.TrimSpace(opts.AuthMode))
 
 				switch opts.AuthMode {
 				case "BASIC":
@@ -97,7 +100,7 @@ You will need to provide the instance's name, vendor, endpoint, and optionally o
 	flags.StringVarP(&opts.Vendor, "provider", "p", "", "Provider for the instance (e.g. dragonfly, kraken)")
 	flags.StringVarP(&opts.Endpoint, "url", "u", "", "Endpoint URL for the instance")
 	flags.StringVarP(&opts.Description, "description", "d", "", "Description of the instance")
-	flags.BoolVarP(&opts.Insecure, "insecure", "", false, "Whether or not the certificate will be verified when Harbor tries to access the server")
+	flags.BoolVarP(&opts.Insecure, "insecure", "i", false, "Whether or not the certificate will be verified when Harbor tries to access the server")
 	flags.BoolVarP(&opts.Enabled, "enable", "", true, "Whether the instance is enabled or not")
 	flags.StringVarP(&opts.AuthMode, "authmode", "a", "NONE", "Authentication mode (NONE, BASIC, OAUTH)")
 	flags.StringVar(&authUsername, "auth-username", "", "Username for BASIC authentication")

--- a/cmd/harbor/root/instance/delete.go
+++ b/cmd/harbor/root/instance/delete.go
@@ -43,7 +43,10 @@ If no argument is provided, you will be prompted to select an instance from a li
 			} else if len(args) > 0 {
 				instanceName = args[0]
 			} else {
-				instanceName = prompt.GetInstanceFromUser()
+				instanceName, err = prompt.GetInstanceNameFromUser()
+				if err != nil {
+					return fmt.Errorf("%v", err)
+				}
 			}
 			err = api.DeleteInstance(instanceName)
 			if err != nil {

--- a/cmd/harbor/root/instance/list.go
+++ b/cmd/harbor/root/instance/list.go
@@ -45,7 +45,7 @@ This command provides an easy way to view all instances along with their details
 				return fmt.Errorf("page size should be less than or equal to 100")
 			}
 
-			instance, err := api.ListInstance(opts)
+			instance, err := api.ListAllInstance(opts)
 
 			if err != nil {
 				return fmt.Errorf("failed to get instance list: %v", err)

--- a/cmd/harbor/root/instance/ping.go
+++ b/cmd/harbor/root/instance/ping.go
@@ -30,7 +30,12 @@ func PingInstanceCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "ping [NAME|ID]",
 		Short: "Ping preheat provider instance by name or id",
-		Args:  cobra.MaximumNArgs(1),
+		Long: `Ping a preheat provider instance to test its connectivity in Harbor. You can specify the instance
+by name or ID directly as an argument. If no argument is provided, you will be prompted to select
+an instance from a list of available instances.`,
+		Example: `  harbor-cli instance ping my-instance
+  harbor-cli instance ping 1 --id`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			var instanceName string

--- a/cmd/harbor/root/instance/ping.go
+++ b/cmd/harbor/root/instance/ping.go
@@ -1,0 +1,78 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package instance
+
+import (
+	"fmt"
+
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/prompt"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func PingInstanceCommand() *cobra.Command {
+	var useInstanceID bool
+
+	cmd := &cobra.Command{
+		Use:   "ping [NAME|ID]",
+		Short: "Ping preheat provider instance by name or id",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+			var instanceName string
+
+			if useInstanceID && len(args) == 0 {
+				return fmt.Errorf("instance ID must be provided when using --id")
+			}
+
+			if len(args) > 0 {
+				log.Debugf("Instance name provided: %s", args[0])
+				instanceName = args[0]
+			} else {
+				log.Debug("No instance name provided, prompting user")
+				instanceName, err = prompt.GetInstanceNameFromUser()
+				if err != nil {
+					return fmt.Errorf("failed to get instance name: %v", utils.ParseHarborErrorMsg(err))
+				}
+			}
+
+			log.Debugf("Pinging instance: %s", instanceName)
+			response, err := api.PingInstance(instanceName, useInstanceID)
+			if err != nil {
+				if utils.ParseHarborErrorCode(err) == "404" {
+					return fmt.Errorf("instance %s does not exist", instanceName)
+				}
+				return fmt.Errorf("failed to ping instance: %v", utils.ParseHarborErrorMsg(err))
+			}
+
+			outputFormat := viper.GetString("output-format")
+			if outputFormat != "" {
+				if err := utils.PrintFormat(response, outputFormat); err != nil {
+					return err
+				}
+			} else {
+				fmt.Printf("Instance '%s' pinged successfully\n", instanceName)
+			}
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.BoolVar(&useInstanceID, "id", false, "Get instance by id")
+
+	return cmd
+}

--- a/cmd/harbor/root/instance/update.go
+++ b/cmd/harbor/root/instance/update.go
@@ -67,10 +67,18 @@ flags are provided, the command opens an interactive update form.`,
 				}
 			}
 
-			instance, err := getInstanceForUpdate(instanceName, isID)
+			resp, err := api.GetInstance(instanceName, isID)
 			if err != nil {
-				return err
+				if utils.ParseHarborErrorCode(err) == "404" {
+					return fmt.Errorf("instance %s does not exist", instanceName)
+				}
+				return fmt.Errorf("failed to get instance: %v", utils.ParseHarborErrorMsg(err))
 			}
+			if resp == nil || resp.Payload == nil {
+				return fmt.Errorf("failed to get instance: empty response")
+			}
+
+			instance := resp.Payload
 			originalName := instance.Name
 
 			if hasUpdateFlagChanges(cmd) {
@@ -97,7 +105,7 @@ flags are provided, the command opens an interactive update form.`,
 	flags.StringVarP(&opts.Name, "name", "n", "", "New name for the instance")
 	flags.StringVarP(&opts.Endpoint, "url", "u", "", "Endpoint URL for the instance")
 	flags.StringVarP(&opts.Description, "description", "d", "", "Description of the instance")
-	flags.BoolVarP(&opts.Insecure, "insecure", "", false, "Whether or not the certificate will be verified when Harbor tries to access the server")
+	flags.BoolVarP(&opts.Insecure, "insecure", "i", false, "Whether or not the certificate will be verified when Harbor tries to access the server")
 	flags.BoolVarP(&opts.Enabled, "enable", "", false, "Whether the instance is enabled or not")
 	flags.StringVarP(&opts.AuthMode, "authmode", "a", "", "Authentication mode (NONE, BASIC, OAUTH)")
 	flags.StringVar(&opts.AuthUsername, "auth-username", "", "Username for BASIC authentication")
@@ -105,22 +113,6 @@ flags are provided, the command opens an interactive update form.`,
 	flags.StringVar(&opts.AuthToken, "auth-token", "", "Token for OAUTH authentication")
 
 	return cmd
-}
-
-func getInstanceForUpdate(instanceName string, isID bool) (*models.Instance, error) {
-	instance, err := api.GetInstance(instanceName, isID)
-	if err != nil {
-		if utils.ParseHarborErrorCode(err) == "404" {
-			return nil, fmt.Errorf("instance %s does not exist", instanceName)
-		}
-		return nil, fmt.Errorf("failed to get instance: %v", utils.ParseHarborErrorMsg(err))
-	}
-
-	if instance == nil || instance.Payload == nil {
-		return nil, fmt.Errorf("failed to get instance: empty response")
-	}
-
-	return instance.Payload, nil
 }
 
 func hasUpdateFlagChanges(cmd *cobra.Command) bool {

--- a/cmd/harbor/root/instance/update.go
+++ b/cmd/harbor/root/instance/update.go
@@ -1,0 +1,199 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package instance
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/prompt"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	viewupdate "github.com/goharbor/harbor-cli/pkg/views/instance/update"
+	"github.com/spf13/cobra"
+)
+
+type updateOptions struct {
+	Name         string
+	Description  string
+	Endpoint     string
+	AuthMode     string
+	Enabled      bool
+	Insecure     bool
+	AuthUsername string
+	AuthPassword string
+	AuthToken    string
+}
+
+func UpdateInstanceCommand() *cobra.Command {
+	var opts updateOptions
+	var isID bool
+
+	cmd := &cobra.Command{
+		Use:   "update [NAME|ID]",
+		Short: "Update a preheat provider instance in Harbor",
+		Long: `Update a preheat provider instance in Harbor by name or ID. If no update
+flags are provided, the command opens an interactive update form.`,
+		Example: `  harbor-cli instance update my-instance --description "Updated preheat instance"
+  harbor-cli instance update 1 --id --enable=false
+  harbor-cli instance update my-instance --authmode BASIC --auth-username admin --auth-password Harbor12345`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+			var instanceName string
+
+			if isID && len(args) == 0 {
+				return fmt.Errorf("instance ID must be provided when using --id")
+			}
+
+			if len(args) > 0 {
+				instanceName = args[0]
+			} else {
+				instanceName, err = prompt.GetInstanceNameFromUser()
+				if err != nil {
+					return fmt.Errorf("failed to get instance name: %v", utils.ParseHarborErrorMsg(err))
+				}
+			}
+
+			instance, err := getInstanceForUpdate(instanceName, isID)
+			if err != nil {
+				return err
+			}
+			originalName := instance.Name
+
+			if hasUpdateFlagChanges(cmd) {
+				err = applyUpdateFlags(cmd, instance, opts)
+			} else {
+				err = viewupdate.UpdateInstanceView(instance)
+			}
+			if err != nil {
+				return err
+			}
+
+			err = api.UpdateInstance(originalName, *instance)
+			if err != nil {
+				return fmt.Errorf("failed to update instance: %v", utils.ParseHarborErrorMsg(err))
+			}
+
+			fmt.Printf("Instance '%s' updated successfully\n", instance.Name)
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.BoolVar(&isID, "id", false, "Get instance by id")
+	flags.StringVarP(&opts.Name, "name", "n", "", "New name for the instance")
+	flags.StringVarP(&opts.Endpoint, "url", "u", "", "Endpoint URL for the instance")
+	flags.StringVarP(&opts.Description, "description", "d", "", "Description of the instance")
+	flags.BoolVarP(&opts.Insecure, "insecure", "", false, "Whether or not the certificate will be verified when Harbor tries to access the server")
+	flags.BoolVarP(&opts.Enabled, "enable", "", false, "Whether the instance is enabled or not")
+	flags.StringVarP(&opts.AuthMode, "authmode", "a", "", "Authentication mode (NONE, BASIC, OAUTH)")
+	flags.StringVar(&opts.AuthUsername, "auth-username", "", "Username for BASIC authentication")
+	flags.StringVar(&opts.AuthPassword, "auth-password", "", "Password for BASIC authentication")
+	flags.StringVar(&opts.AuthToken, "auth-token", "", "Token for OAUTH authentication")
+
+	return cmd
+}
+
+func getInstanceForUpdate(instanceName string, isID bool) (*models.Instance, error) {
+	instance, err := api.GetInstance(instanceName, isID)
+	if err != nil {
+		if utils.ParseHarborErrorCode(err) == "404" {
+			return nil, fmt.Errorf("instance %s does not exist", instanceName)
+		}
+		return nil, fmt.Errorf("failed to get instance: %v", utils.ParseHarborErrorMsg(err))
+	}
+
+	if instance == nil || instance.Payload == nil {
+		return nil, fmt.Errorf("failed to get instance: empty response")
+	}
+
+	return instance.Payload, nil
+}
+
+func hasUpdateFlagChanges(cmd *cobra.Command) bool {
+	flags := cmd.Flags()
+	return flags.Changed("name") ||
+		flags.Changed("url") ||
+		flags.Changed("description") ||
+		flags.Changed("insecure") ||
+		flags.Changed("enable") ||
+		flags.Changed("authmode") ||
+		flags.Changed("auth-username") ||
+		flags.Changed("auth-password") ||
+		flags.Changed("auth-token")
+}
+
+func applyUpdateFlags(cmd *cobra.Command, instance *models.Instance, opts updateOptions) error {
+	flags := cmd.Flags()
+
+	if flags.Changed("name") {
+		if strings.TrimSpace(opts.Name) == "" {
+			return fmt.Errorf("name cannot be empty or only spaces")
+		}
+		instance.Name = strings.TrimSpace(opts.Name)
+	}
+	if flags.Changed("url") {
+		formattedURL := utils.FormatUrl(opts.Endpoint)
+		if err := utils.ValidateURL(formattedURL); err != nil {
+			return err
+		}
+		instance.Endpoint = formattedURL
+	}
+	if flags.Changed("description") {
+		instance.Description = opts.Description
+	}
+	if flags.Changed("insecure") {
+		instance.Insecure = opts.Insecure
+	}
+	if flags.Changed("enable") {
+		instance.Enabled = opts.Enabled
+	}
+
+	if flags.Changed("auth-username") || flags.Changed("auth-password") || flags.Changed("auth-token") {
+		if !flags.Changed("authmode") {
+			return fmt.Errorf("authmode is required when updating auth credentials")
+		}
+	}
+
+	if !flags.Changed("authmode") {
+		return nil
+	}
+
+	instance.AuthMode = strings.ToUpper(strings.TrimSpace(opts.AuthMode))
+
+	switch instance.AuthMode {
+	case "BASIC":
+		if strings.TrimSpace(opts.AuthUsername) == "" || strings.TrimSpace(opts.AuthPassword) == "" {
+			return fmt.Errorf("username and password are required when authmode is BASIC. Use --auth-username and --auth-password flags")
+		}
+		instance.AuthInfo = map[string]string{
+			"username": strings.TrimSpace(opts.AuthUsername),
+			"password": opts.AuthPassword,
+		}
+	case "OAUTH":
+		if strings.TrimSpace(opts.AuthToken) == "" {
+			return fmt.Errorf("token is required when authmode is OAUTH. Use --auth-token flag")
+		}
+		instance.AuthInfo = map[string]string{
+			"token": strings.TrimSpace(opts.AuthToken),
+		}
+	case "NONE":
+		instance.AuthInfo = nil
+	default:
+		return fmt.Errorf("invalid authmode '%s'. Valid options: NONE, BASIC, OAUTH", instance.AuthMode)
+	}
+
+	return nil
+}

--- a/cmd/harbor/root/instance/update.go
+++ b/cmd/harbor/root/instance/update.go
@@ -1,6 +1,7 @@
 // Copyright Project Harbor Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
 // http://www.apache.org/licenses/LICENSE-2.0

--- a/cmd/harbor/root/instance/view.go
+++ b/cmd/harbor/root/instance/view.go
@@ -31,11 +31,20 @@ func ViewInstanceCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "view [NAME|ID]",
 		Short: "get preheat provider instance by name or id",
-		Args:  cobra.MaximumNArgs(1),
+		Long: `Get detailed information about a preheat provider instance in Harbor. You can specify the instance
+by name or ID directly as an argument. If no argument is provided, you will be prompted to select
+an instance from a list of available instances.`,
+		Example: `  harbor-cli instance view my-instance
+  harbor-cli instance view 1 --id`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			var instanceName string
 			var instance *preheat.GetInstanceOK
+
+			if isID && len(args) == 0 {
+				return fmt.Errorf("instance ID must be provided when using --id")
+			}
 
 			if len(args) > 0 {
 				log.Debugf("Instance name provided: %s", args[0])

--- a/cmd/harbor/root/instance/view.go
+++ b/cmd/harbor/root/instance/view.go
@@ -1,0 +1,77 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package instance
+
+import (
+	"fmt"
+
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/preheat"
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/prompt"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/goharbor/harbor-cli/pkg/views/instance/view"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func ViewInstanceCommand() *cobra.Command {
+	var isID bool
+	cmd := &cobra.Command{
+		Use:   "view [NAME|ID]",
+		Short: "get preheat provider instance by name or id",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+			var instanceName string
+			var instance *preheat.GetInstanceOK
+
+			if len(args) > 0 {
+				log.Debugf("Instance name provided: %s", args[0])
+				instanceName = args[0]
+			} else {
+				log.Debug("No instance name provided, prompting user")
+				instanceName, err = prompt.GetInstanceNameFromUser()
+				if err != nil {
+					return fmt.Errorf("failed to get instance name: %v", utils.ParseHarborErrorMsg(err))
+				}
+			}
+
+			log.Debugf("Fetching instance: %s", instanceName)
+			instance, err = api.GetInstance(instanceName, isID)
+			if err != nil {
+				if utils.ParseHarborErrorCode(err) == "404" {
+					return fmt.Errorf("instance %s does not exist", instanceName)
+				}
+				return fmt.Errorf("failed to get instance: %v", utils.ParseHarborErrorMsg(err))
+			}
+
+			FormatFlag := viper.GetString("output-format")
+			if FormatFlag != "" {
+				err = utils.PrintFormat(instance, FormatFlag)
+				if err != nil {
+					return err
+				}
+			} else {
+				view.ViewInstance(instance.Payload)
+			}
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.BoolVar(&isID, "id", false, "Get instance by id")
+
+	return cmd
+}

--- a/doc/cli-docs/harbor-instance-create.md
+++ b/doc/cli-docs/harbor-instance-create.md
@@ -27,14 +27,17 @@ harbor instance create [flags]
 ### Options
 
 ```sh
-  -a, --authmode string      Choosing different types of authentication method (default "NONE")
-      --description string   Description of the instance
-      --enable               Whether it is enabled or not (default true)
-  -h, --help                 help for create
-  -i, --insecure             Whether or not the certificate will be verified when Harbor tries to access the server (default true)
-  -n, --name string          Name of the instance
-  -p, --provider string      Provider for the instance
-  -u, --url string           URL for the instance
+      --auth-password string   Password for BASIC authentication
+      --auth-token string      Token for OAUTH authentication
+      --auth-username string   Username for BASIC authentication
+  -a, --authmode string        Authentication mode (NONE, BASIC, OAUTH) (default "NONE")
+  -d, --description string     Description of the instance
+      --enable                 Whether the instance is enabled or not (default true)
+  -h, --help                   help for create
+      --insecure               Whether or not the certificate will be verified when Harbor tries to access the server
+  -n, --name string            Name of the instance
+  -p, --provider string        Provider for the instance (e.g. dragonfly, kraken)
+  -u, --url string             Endpoint URL for the instance
 ```
 
 ### Options inherited from parent commands

--- a/doc/cli-docs/harbor-instance-create.md
+++ b/doc/cli-docs/harbor-instance-create.md
@@ -21,7 +21,7 @@ harbor instance create [flags]
 ### Examples
 
 ```sh
-  harbor-cli instance create --name my-instance --provider Dragonfly --url http://dragonfly.local --description "My preheat provider instance" --enable=true
+  harbor-cli instance create --name my-instance --provider dragonfly --url http://dragonfly.local --description "My preheat provider instance" --enable=true
 ```
 
 ### Options
@@ -34,7 +34,7 @@ harbor instance create [flags]
   -d, --description string     Description of the instance
       --enable                 Whether the instance is enabled or not (default true)
   -h, --help                   help for create
-      --insecure               Whether or not the certificate will be verified when Harbor tries to access the server
+  -i, --insecure               Whether or not the certificate will be verified when Harbor tries to access the server
   -n, --name string            Name of the instance
   -p, --provider string        Provider for the instance (e.g. dragonfly, kraken)
   -u, --url string             Endpoint URL for the instance

--- a/doc/cli-docs/harbor-instance-ping.md
+++ b/doc/cli-docs/harbor-instance-ping.md
@@ -1,0 +1,33 @@
+---
+title: harbor instance ping
+weight: 25
+---
+## harbor instance ping
+
+### Description
+
+##### Ping preheat provider instance by name or id
+
+```sh
+harbor instance ping [NAME|ID] [flags]
+```
+
+### Options
+
+```sh
+  -h, --help   help for ping
+      --id     Get instance by id
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor instance](harbor-instance.md)	 - Manage preheat provider instances in Harbor
+

--- a/doc/cli-docs/harbor-instance-ping.md
+++ b/doc/cli-docs/harbor-instance-ping.md
@@ -8,8 +8,21 @@ weight: 25
 
 ##### Ping preheat provider instance by name or id
 
+### Synopsis
+
+Ping a preheat provider instance to test its connectivity in Harbor. You can specify the instance
+by name or ID directly as an argument. If no argument is provided, you will be prompted to select
+an instance from a list of available instances.
+
 ```sh
 harbor instance ping [NAME|ID] [flags]
+```
+
+### Examples
+
+```sh
+  harbor-cli instance ping my-instance
+  harbor-cli instance ping 1 --id
 ```
 
 ### Options

--- a/doc/cli-docs/harbor-instance-ping.md
+++ b/doc/cli-docs/harbor-instance-ping.md
@@ -23,7 +23,7 @@ harbor instance ping [NAME|ID] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-instance-update.md
+++ b/doc/cli-docs/harbor-instance-update.md
@@ -1,0 +1,55 @@
+---
+title: harbor instance update
+weight: 20
+---
+## harbor instance update
+
+### Description
+
+##### Update a preheat provider instance in Harbor
+
+### Synopsis
+
+Update a preheat provider instance in Harbor by name or ID. If no update
+flags are provided, the command opens an interactive update form.
+
+```sh
+harbor instance update [NAME|ID] [flags]
+```
+
+### Examples
+
+```sh
+  harbor-cli instance update my-instance --description "Updated preheat instance"
+  harbor-cli instance update 1 --id --enable=false
+  harbor-cli instance update my-instance --authmode BASIC --auth-username admin --auth-password Harbor12345
+```
+
+### Options
+
+```sh
+      --auth-password string   Password for BASIC authentication
+      --auth-token string      Token for OAUTH authentication
+      --auth-username string   Username for BASIC authentication
+  -a, --authmode string        Authentication mode (NONE, BASIC, OAUTH)
+  -d, --description string     Description of the instance
+      --enable                 Whether the instance is enabled or not
+  -h, --help                   help for update
+      --id                     Get instance by id
+      --insecure               Whether or not the certificate will be verified when Harbor tries to access the server
+  -n, --name string            New name for the instance
+  -u, --url string             Endpoint URL for the instance
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor instance](harbor-instance.md)	 - Manage preheat provider instances in Harbor
+

--- a/doc/cli-docs/harbor-instance-update.md
+++ b/doc/cli-docs/harbor-instance-update.md
@@ -45,7 +45,7 @@ harbor instance update [NAME|ID] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-instance-update.md
+++ b/doc/cli-docs/harbor-instance-update.md
@@ -36,7 +36,7 @@ harbor instance update [NAME|ID] [flags]
       --enable                 Whether the instance is enabled or not
   -h, --help                   help for update
       --id                     Get instance by id
-      --insecure               Whether or not the certificate will be verified when Harbor tries to access the server
+  -i, --insecure               Whether or not the certificate will be verified when Harbor tries to access the server
   -n, --name string            New name for the instance
   -u, --url string             Endpoint URL for the instance
 ```

--- a/doc/cli-docs/harbor-instance-view.md
+++ b/doc/cli-docs/harbor-instance-view.md
@@ -23,7 +23,7 @@ harbor instance view [NAME|ID] [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-instance-view.md
+++ b/doc/cli-docs/harbor-instance-view.md
@@ -1,0 +1,33 @@
+---
+title: harbor instance view
+weight: 40
+---
+## harbor instance view
+
+### Description
+
+##### get preheat provider instance by name or id
+
+```sh
+harbor instance view [NAME|ID] [flags]
+```
+
+### Options
+
+```sh
+  -h, --help   help for view
+      --id     Get instance by id
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor instance](harbor-instance.md)	 - Manage preheat provider instances in Harbor
+

--- a/doc/cli-docs/harbor-instance-view.md
+++ b/doc/cli-docs/harbor-instance-view.md
@@ -8,8 +8,21 @@ weight: 40
 
 ##### get preheat provider instance by name or id
 
+### Synopsis
+
+Get detailed information about a preheat provider instance in Harbor. You can specify the instance
+by name or ID directly as an argument. If no argument is provided, you will be prompted to select
+an instance from a list of available instances.
+
 ```sh
 harbor instance view [NAME|ID] [flags]
+```
+
+### Examples
+
+```sh
+  harbor-cli instance view my-instance
+  harbor-cli instance view 1 --id
 ```
 
 ### Options

--- a/doc/cli-docs/harbor-instance.md
+++ b/doc/cli-docs/harbor-instance.md
@@ -33,6 +33,7 @@ These instances represent external services such as Dragonfly or Kraken that hel
 * [harbor instance create](harbor-instance-create.md)	 - Create a new preheat provider instance in Harbor
 * [harbor instance delete](harbor-instance-delete.md)	 - Delete a preheat provider instance by its name or ID
 * [harbor instance list](harbor-instance-list.md)	 - List all preheat provider instances in Harbor
+* [harbor instance ping](harbor-instance-ping.md)	 - Ping preheat provider instance by name or id
 * [harbor instance update](harbor-instance-update.md)	 - Update a preheat provider instance in Harbor
 * [harbor instance view](harbor-instance-view.md)	 - get preheat provider instance by name or id
 

--- a/doc/cli-docs/harbor-instance.md
+++ b/doc/cli-docs/harbor-instance.md
@@ -33,5 +33,6 @@ These instances represent external services such as Dragonfly or Kraken that hel
 * [harbor instance create](harbor-instance-create.md)	 - Create a new preheat provider instance in Harbor
 * [harbor instance delete](harbor-instance-delete.md)	 - Delete a preheat provider instance by its name or ID
 * [harbor instance list](harbor-instance-list.md)	 - List all preheat provider instances in Harbor
+* [harbor instance update](harbor-instance-update.md)	 - Update a preheat provider instance in Harbor
 * [harbor instance view](harbor-instance-view.md)	 - get preheat provider instance by name or id
 

--- a/doc/cli-docs/harbor-instance.md
+++ b/doc/cli-docs/harbor-instance.md
@@ -33,4 +33,5 @@ These instances represent external services such as Dragonfly or Kraken that hel
 * [harbor instance create](harbor-instance-create.md)	 - Create a new preheat provider instance in Harbor
 * [harbor instance delete](harbor-instance-delete.md)	 - Delete a preheat provider instance by its name or ID
 * [harbor instance list](harbor-instance-list.md)	 - List all preheat provider instances in Harbor
+* [harbor instance view](harbor-instance-view.md)	 - get preheat provider instance by name or id
 

--- a/doc/man-docs/man1/harbor-instance-create.1
+++ b/doc/man-docs/man1/harbor-instance-create.1
@@ -16,23 +16,35 @@ You will need to provide the instance's name, vendor, endpoint, and optionally o
 
 
 .SH OPTIONS
-\fB-a\fP, \fB--authmode\fP="NONE"
-	Choosing different types of authentication method
+\fB--auth-password\fP=""
+	Password for BASIC authentication
 
 .PP
-\fB--description\fP=""
+\fB--auth-token\fP=""
+	Token for OAUTH authentication
+
+.PP
+\fB--auth-username\fP=""
+	Username for BASIC authentication
+
+.PP
+\fB-a\fP, \fB--authmode\fP="NONE"
+	Authentication mode (NONE, BASIC, OAUTH)
+
+.PP
+\fB-d\fP, \fB--description\fP=""
 	Description of the instance
 
 .PP
 \fB--enable\fP[=true]
-	Whether it is enabled or not
+	Whether the instance is enabled or not
 
 .PP
 \fB-h\fP, \fB--help\fP[=false]
 	help for create
 
 .PP
-\fB-i\fP, \fB--insecure\fP[=true]
+\fB--insecure\fP[=false]
 	Whether or not the certificate will be verified when Harbor tries to access the server
 
 .PP
@@ -41,11 +53,11 @@ You will need to provide the instance's name, vendor, endpoint, and optionally o
 
 .PP
 \fB-p\fP, \fB--provider\fP=""
-	Provider for the instance
+	Provider for the instance (e.g. dragonfly, kraken)
 
 .PP
 \fB-u\fP, \fB--url\fP=""
-	URL for the instance
+	Endpoint URL for the instance
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS

--- a/doc/man-docs/man1/harbor-instance-create.1
+++ b/doc/man-docs/man1/harbor-instance-create.1
@@ -44,7 +44,7 @@ You will need to provide the instance's name, vendor, endpoint, and optionally o
 	help for create
 
 .PP
-\fB--insecure\fP[=false]
+\fB-i\fP, \fB--insecure\fP[=false]
 	Whether or not the certificate will be verified when Harbor tries to access the server
 
 .PP
@@ -75,7 +75,7 @@ You will need to provide the instance's name, vendor, endpoint, and optionally o
 
 .SH EXAMPLE
 .EX
-  harbor-cli instance create --name my-instance --provider Dragonfly --url http://dragonfly.local --description "My preheat provider instance" --enable=true
+  harbor-cli instance create --name my-instance --provider dragonfly --url http://dragonfly.local --description "My preheat provider instance" --enable=true
 .EE
 
 

--- a/doc/man-docs/man1/harbor-instance-ping.1
+++ b/doc/man-docs/man1/harbor-instance-ping.1
@@ -1,0 +1,39 @@
+.nh
+.TH "HARBOR" "1"  "Harbor Community" "Harbor User Manuals"
+
+.SH NAME
+harbor-instance-ping - Ping preheat provider instance by name or id
+
+
+.SH SYNOPSIS
+\fBharbor instance ping [NAME|ID] [flags]\fP
+
+
+.SH DESCRIPTION
+Ping preheat provider instance by name or id
+
+
+.SH OPTIONS
+\fB-h\fP, \fB--help\fP[=false]
+	help for ping
+
+.PP
+\fB--id\fP[=false]
+	Get instance by id
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+\fB-c\fP, \fB--config\fP=""
+	config file (default is $HOME/.config/harbor-cli/config.yaml)
+
+.PP
+\fB-o\fP, \fB--output-format\fP=""
+	Output format. One of: json|yaml
+
+.PP
+\fB-v\fP, \fB--verbose\fP[=false]
+	verbose output
+
+
+.SH SEE ALSO
+\fBharbor-instance(1)\fP

--- a/doc/man-docs/man1/harbor-instance-ping.1
+++ b/doc/man-docs/man1/harbor-instance-ping.1
@@ -10,7 +10,9 @@ harbor-instance-ping - Ping preheat provider instance by name or id
 
 
 .SH DESCRIPTION
-Ping preheat provider instance by name or id
+Ping a preheat provider instance to test its connectivity in Harbor. You can specify the instance
+by name or ID directly as an argument. If no argument is provided, you will be prompted to select
+an instance from a list of available instances.
 
 
 .SH OPTIONS
@@ -33,6 +35,13 @@ Ping preheat provider instance by name or id
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]
 	verbose output
+
+
+.SH EXAMPLE
+.EX
+  harbor-cli instance ping my-instance
+  harbor-cli instance ping 1 --id
+.EE
 
 
 .SH SEE ALSO

--- a/doc/man-docs/man1/harbor-instance-ping.1
+++ b/doc/man-docs/man1/harbor-instance-ping.1
@@ -28,7 +28,7 @@ Ping preheat provider instance by name or id
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-instance-update.1
+++ b/doc/man-docs/man1/harbor-instance-update.1
@@ -1,0 +1,84 @@
+.nh
+.TH "HARBOR" "1"  "Harbor Community" "Harbor User Manuals"
+
+.SH NAME
+harbor-instance-update - Update a preheat provider instance in Harbor
+
+
+.SH SYNOPSIS
+\fBharbor instance update [NAME|ID] [flags]\fP
+
+
+.SH DESCRIPTION
+Update a preheat provider instance in Harbor by name or ID. If no update
+flags are provided, the command opens an interactive update form.
+
+
+.SH OPTIONS
+\fB--auth-password\fP=""
+	Password for BASIC authentication
+
+.PP
+\fB--auth-token\fP=""
+	Token for OAUTH authentication
+
+.PP
+\fB--auth-username\fP=""
+	Username for BASIC authentication
+
+.PP
+\fB-a\fP, \fB--authmode\fP=""
+	Authentication mode (NONE, BASIC, OAUTH)
+
+.PP
+\fB-d\fP, \fB--description\fP=""
+	Description of the instance
+
+.PP
+\fB--enable\fP[=false]
+	Whether the instance is enabled or not
+
+.PP
+\fB-h\fP, \fB--help\fP[=false]
+	help for update
+
+.PP
+\fB--id\fP[=false]
+	Get instance by id
+
+.PP
+\fB--insecure\fP[=false]
+	Whether or not the certificate will be verified when Harbor tries to access the server
+
+.PP
+\fB-n\fP, \fB--name\fP=""
+	New name for the instance
+
+.PP
+\fB-u\fP, \fB--url\fP=""
+	Endpoint URL for the instance
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+\fB-c\fP, \fB--config\fP=""
+	config file (default is $HOME/.config/harbor-cli/config.yaml)
+
+.PP
+\fB-o\fP, \fB--output-format\fP=""
+	Output format. One of: json|yaml
+
+.PP
+\fB-v\fP, \fB--verbose\fP[=false]
+	verbose output
+
+
+.SH EXAMPLE
+.EX
+  harbor-cli instance update my-instance --description "Updated preheat instance"
+  harbor-cli instance update 1 --id --enable=false
+  harbor-cli instance update my-instance --authmode BASIC --auth-username admin --auth-password Harbor12345
+.EE
+
+
+.SH SEE ALSO
+\fBharbor-instance(1)\fP

--- a/doc/man-docs/man1/harbor-instance-update.1
+++ b/doc/man-docs/man1/harbor-instance-update.1
@@ -65,7 +65,7 @@ flags are provided, the command opens an interactive update form.
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-instance-update.1
+++ b/doc/man-docs/man1/harbor-instance-update.1
@@ -47,7 +47,7 @@ flags are provided, the command opens an interactive update form.
 	Get instance by id
 
 .PP
-\fB--insecure\fP[=false]
+\fB-i\fP, \fB--insecure\fP[=false]
 	Whether or not the certificate will be verified when Harbor tries to access the server
 
 .PP

--- a/doc/man-docs/man1/harbor-instance-view.1
+++ b/doc/man-docs/man1/harbor-instance-view.1
@@ -28,7 +28,7 @@ get preheat provider instance by name or id
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]

--- a/doc/man-docs/man1/harbor-instance-view.1
+++ b/doc/man-docs/man1/harbor-instance-view.1
@@ -1,0 +1,39 @@
+.nh
+.TH "HARBOR" "1"  "Harbor Community" "Harbor User Manuals"
+
+.SH NAME
+harbor-instance-view - get preheat provider instance by name or id
+
+
+.SH SYNOPSIS
+\fBharbor instance view [NAME|ID] [flags]\fP
+
+
+.SH DESCRIPTION
+get preheat provider instance by name or id
+
+
+.SH OPTIONS
+\fB-h\fP, \fB--help\fP[=false]
+	help for view
+
+.PP
+\fB--id\fP[=false]
+	Get instance by id
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+\fB-c\fP, \fB--config\fP=""
+	config file (default is $HOME/.config/harbor-cli/config.yaml)
+
+.PP
+\fB-o\fP, \fB--output-format\fP=""
+	Output format. One of: json|yaml
+
+.PP
+\fB-v\fP, \fB--verbose\fP[=false]
+	verbose output
+
+
+.SH SEE ALSO
+\fBharbor-instance(1)\fP

--- a/doc/man-docs/man1/harbor-instance-view.1
+++ b/doc/man-docs/man1/harbor-instance-view.1
@@ -10,7 +10,9 @@ harbor-instance-view - get preheat provider instance by name or id
 
 
 .SH DESCRIPTION
-get preheat provider instance by name or id
+Get detailed information about a preheat provider instance in Harbor. You can specify the instance
+by name or ID directly as an argument. If no argument is provided, you will be prompted to select
+an instance from a list of available instances.
 
 
 .SH OPTIONS
@@ -33,6 +35,13 @@ get preheat provider instance by name or id
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]
 	verbose output
+
+
+.SH EXAMPLE
+.EX
+  harbor-cli instance view my-instance
+  harbor-cli instance view 1 --id
+.EE
 
 
 .SH SEE ALSO

--- a/doc/man-docs/man1/harbor-instance.1
+++ b/doc/man-docs/man1/harbor-instance.1
@@ -33,4 +33,4 @@ These instances represent external services such as Dragonfly or Kraken that hel
 
 
 .SH SEE ALSO
-\fBharbor(1)\fP, \fBharbor-instance-create(1)\fP, \fBharbor-instance-delete(1)\fP, \fBharbor-instance-list(1)\fP
+\fBharbor(1)\fP, \fBharbor-instance-create(1)\fP, \fBharbor-instance-delete(1)\fP, \fBharbor-instance-list(1)\fP, \fBharbor-instance-view(1)\fP

--- a/doc/man-docs/man1/harbor-instance.1
+++ b/doc/man-docs/man1/harbor-instance.1
@@ -33,4 +33,4 @@ These instances represent external services such as Dragonfly or Kraken that hel
 
 
 .SH SEE ALSO
-\fBharbor(1)\fP, \fBharbor-instance-create(1)\fP, \fBharbor-instance-delete(1)\fP, \fBharbor-instance-list(1)\fP, \fBharbor-instance-update(1)\fP, \fBharbor-instance-view(1)\fP
+\fBharbor(1)\fP, \fBharbor-instance-create(1)\fP, \fBharbor-instance-delete(1)\fP, \fBharbor-instance-list(1)\fP, \fBharbor-instance-ping(1)\fP, \fBharbor-instance-update(1)\fP, \fBharbor-instance-view(1)\fP

--- a/doc/man-docs/man1/harbor-instance.1
+++ b/doc/man-docs/man1/harbor-instance.1
@@ -33,4 +33,4 @@ These instances represent external services such as Dragonfly or Kraken that hel
 
 
 .SH SEE ALSO
-\fBharbor(1)\fP, \fBharbor-instance-create(1)\fP, \fBharbor-instance-delete(1)\fP, \fBharbor-instance-list(1)\fP, \fBharbor-instance-view(1)\fP
+\fBharbor(1)\fP, \fBharbor-instance-create(1)\fP, \fBharbor-instance-delete(1)\fP, \fBharbor-instance-list(1)\fP, \fBharbor-instance-update(1)\fP, \fBharbor-instance-view(1)\fP

--- a/pkg/api/instance_handler.go
+++ b/pkg/api/instance_handler.go
@@ -56,6 +56,26 @@ func DeleteInstance(instanceName string) error {
 	return nil
 }
 
+func UpdateInstance(instanceName string, instance models.Instance) error {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return err
+	}
+
+	instance.Endpoint = strings.TrimSpace(instance.Endpoint)
+
+	_, err = client.Preheat.UpdateInstance(ctx, &preheat.UpdateInstanceParams{
+		PreheatInstanceName: instanceName,
+		Instance:            &instance,
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Instance %s updated", instance.Name)
+	return nil
+}
+
 func ListAllInstance(opts ...ListFlags) (*preheat.ListInstancesOK, error) {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {

--- a/pkg/api/instance_handler.go
+++ b/pkg/api/instance_handler.go
@@ -76,6 +76,30 @@ func UpdateInstance(instanceName string, instance models.Instance) error {
 	return nil
 }
 
+func PingInstance(instanceNameOrID string, useInstanceID bool) (*preheat.PingInstancesOK, error) {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return nil, err
+	}
+
+	instance, err := GetInstance(instanceNameOrID, useInstanceID)
+	if err != nil {
+		return nil, err
+	}
+	if instance == nil || instance.Payload == nil {
+		return nil, fmt.Errorf("failed to ping instance: empty response")
+	}
+
+	response, err := client.Preheat.PingInstances(ctx, &preheat.PingInstancesParams{
+		Instance: instance.Payload,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
 func ListAllInstance(opts ...ListFlags) (*preheat.ListInstancesOK, error) {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {

--- a/pkg/api/instance_handler.go
+++ b/pkg/api/instance_handler.go
@@ -15,6 +15,7 @@ package api
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/preheat"
@@ -55,7 +56,7 @@ func DeleteInstance(instanceName string) error {
 	return nil
 }
 
-func ListInstance(opts ...ListFlags) (*preheat.ListInstancesOK, error) {
+func ListAllInstance(opts ...ListFlags) (*preheat.ListInstancesOK, error) {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {
 		return nil, err
@@ -82,7 +83,7 @@ func ListInstance(opts ...ListFlags) (*preheat.ListInstancesOK, error) {
 }
 
 func GetInstanceNameByID(id int64) (string, error) {
-	instances, err := ListInstance()
+	instances, err := ListAllInstance()
 	if err != nil {
 		return "", err
 	}
@@ -94,4 +95,30 @@ func GetInstanceNameByID(id int64) (string, error) {
 	}
 
 	return "", fmt.Errorf("no instance found with ID: %v", id)
+}
+
+func GetInstance(instanceNameOrID string, useInstanceID bool) (*preheat.GetInstanceOK, error) {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return nil, err
+	}
+	if useInstanceID {
+		instanceID, err := strconv.ParseInt(instanceNameOrID, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		instanceNameOrID, err = GetInstanceNameByID(instanceID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	response, err := client.Preheat.GetInstance(ctx, &preheat.GetInstanceParams{
+		PreheatInstanceName: instanceNameOrID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
 }

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -266,15 +266,39 @@ func GetLabelIdFromUser(opts api.ListFlags) (int64, error) {
 	return res.id, res.err
 }
 
-func GetInstanceFromUser() string {
-	instanceName := make(chan string)
+func GetInstanceNameFromUser() (string, error) {
+	type result struct {
+		name string
+		err  error
+	}
+	resultChan := make(chan result)
 
 	go func() {
-		response, _ := api.ListInstance()
-		instview.InstanceList(response.Payload, instanceName)
+		response, err := api.ListAllInstance()
+		if err != nil {
+			resultChan <- result{"", err}
+			return
+		}
+
+		if len(response.Payload) == 0 {
+			resultChan <- result{"", errors.New("no instances found")}
+			return
+		}
+
+		name, err := instview.InstanceList(response.Payload)
+		if err != nil {
+			if err == instview.ErrUserAborted {
+				resultChan <- result{"", errors.New("user aborted instance selection")}
+			} else {
+				resultChan <- result{"", fmt.Errorf("error during instance selection: %w", err)}
+			}
+			return
+		}
+		resultChan <- result{name, nil}
 	}()
 
-	return <-instanceName
+	res := <-resultChan
+	return res.name, res.err
 }
 
 func GetQuotaIDFromUser() int64 {

--- a/pkg/views/instance/create/view.go
+++ b/pkg/views/instance/create/view.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/charmbracelet/huh"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 )
 
 type CreateView struct {
@@ -33,17 +32,8 @@ type CreateView struct {
 	Insecure    bool
 }
 
-func CreateInstanceView(createView *CreateView) {
-	cv := CreateView{
-		AuthInfo: map[string]string{
-			"username": "",
-			"password": "",
-			"token":    "",
-		},
-	}
-	username := cv.AuthInfo["username"]
-	password := cv.AuthInfo["password"]
-	token := cv.AuthInfo["token"]
+func CreateInstanceView(createView *CreateView) error {
+	var username, password, token string
 	theme := huh.ThemeCharm()
 
 	err := huh.NewForm(
@@ -90,7 +80,7 @@ func CreateInstanceView(createView *CreateView) {
 				Affirmative("yes").
 				Negative("no"),
 			huh.NewConfirm().
-				Title("Verify Cert").
+				Title("Skip Certificate Verification").
 				Value(&createView.Insecure).
 				Affirmative("yes").
 				Negative("no"),
@@ -151,6 +141,21 @@ func CreateInstanceView(createView *CreateView) {
 	).WithTheme(theme).Run()
 
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
+
+	switch createView.AuthMode {
+	case "BASIC":
+		createView.AuthInfo = map[string]string{
+			"username": username,
+			"password": password,
+		}
+	case "OAUTH":
+		createView.AuthInfo = map[string]string{
+			"token": token,
+		}
+	}
+
+	return nil
 }
+

--- a/pkg/views/instance/select/view.go
+++ b/pkg/views/instance/select/view.go
@@ -14,6 +14,7 @@
 package instance
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -23,26 +24,31 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/views/base/selection"
 )
 
-func InstanceList(instance []*models.Instance, choice chan<- string) {
-	itemsList := make([]list.Item, len(instance))
+var ErrUserAborted = errors.New("user aborted selection")
 
-	items := map[string]string{}
-
-	for i, r := range instance {
-		items[r.Name] = r.Name
-		itemsList[i] = selection.Item(r.Name)
+func InstanceList(instances []*models.Instance) (string, error) {
+	items := make([]list.Item, len(instances))
+	for i, instance := range instances {
+		items[i] = selection.Item(instance.Name)
 	}
 
-	m := selection.NewModel(itemsList, "Instance")
+	m := selection.NewModel(items, "Instance")
 
-	p, err := tea.NewProgram(m, tea.WithAltScreen()).Run()
-
+	p, err := tea.NewProgram(m).Run()
 	if err != nil {
 		fmt.Println("Error running program:", err)
 		os.Exit(1)
 	}
 
-	if p, ok := p.(selection.Model); ok {
-		choice <- items[p.Choice]
+	if model, ok := p.(selection.Model); ok {
+		if model.Aborted {
+			return "", ErrUserAborted
+		}
+		if model.Choice == "" {
+			return "", errors.New("no instance selected")
+		}
+		return model.Choice, nil
 	}
+
+	return "", errors.New("unexpected program result")
 }

--- a/pkg/views/instance/update/view.go
+++ b/pkg/views/instance/update/view.go
@@ -11,43 +11,43 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package create
+package update
 
 import (
 	"errors"
 	"strings"
 
 	"github.com/charmbracelet/huh"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 )
 
-type CreateView struct {
-	Vendor      string
-	Name        string
-	Description string
-	Endpoint    string
-	AuthMode    string
-	AuthInfo    map[string]string
-	Enabled     bool
-	Insecure    bool
-}
-
-func CreateInstanceView(createView *CreateView) error {
-	var username, password, token string
+func UpdateInstanceView(instance *models.Instance) error {
 	theme := huh.ThemeCharm()
+
+	authUsername := ""
+	authPassword := ""
+	authToken := ""
+
+	if instance.AuthInfo != nil {
+		switch strings.ToUpper(instance.AuthMode) {
+		case "BASIC":
+			authUsername = instance.AuthInfo["username"]
+			authPassword = instance.AuthInfo["password"]
+		case "OAUTH":
+			authToken = instance.AuthInfo["token"]
+		}
+	}
 
 	err := huh.NewForm(
 		huh.NewGroup(
-			huh.NewSelect[string]().
-				Title("Provider").
-				Options(
-					huh.NewOption("Dragonfly", "dragonfly"),
-					huh.NewOption("Kraken", "kraken"),
-				).
-				Value(&createView.Vendor),
+			huh.NewNote().
+				Title("Provider (cannot be changed)").
+				Description(instance.Vendor),
 			huh.NewInput().
 				Title("Name").
-				Value(&createView.Name).
+				Value(&instance.Name).
 				Validate(func(str string) error {
 					if strings.TrimSpace(str) == "" {
 						return errors.New("name cannot be empty or only spaces")
@@ -56,13 +56,12 @@ func CreateInstanceView(createView *CreateView) error {
 				}),
 			huh.NewInput().
 				Title("Description").
-				Value(&createView.Description),
+				Value(&instance.Description),
 		),
-
 		huh.NewGroup(
 			huh.NewInput().
 				Title("Endpoint").
-				Value(&createView.Endpoint).
+				Value(&instance.Endpoint).
 				Validate(func(str string) error {
 					if strings.TrimSpace(str) == "" {
 						return errors.New("endpoint cannot be empty or only spaces")
@@ -71,21 +70,22 @@ func CreateInstanceView(createView *CreateView) error {
 					if err := utils.ValidateURL(formattedURL); err != nil {
 						return err
 					}
-					createView.Endpoint = formattedURL
+					instance.Endpoint = formattedURL
 					return nil
 				}),
 			huh.NewConfirm().
 				Title("Enable").
-				Value(&createView.Enabled).
+				Value(&instance.Enabled).
 				Affirmative("yes").
-				Negative("no"),
+				Negative("no").
+				WithButtonAlignment(lipgloss.Left),
 			huh.NewConfirm().
 				Title("Skip Certificate Verification").
-				Value(&createView.Insecure).
+				Value(&instance.Insecure).
 				Affirmative("yes").
-				Negative("no"),
+				Negative("no").
+				WithButtonAlignment(lipgloss.Left),
 		),
-
 		huh.NewGroup(
 			huh.NewSelect[string]().
 				Title("Auth Mode").
@@ -94,65 +94,71 @@ func CreateInstanceView(createView *CreateView) error {
 					huh.NewOption("Basic", "BASIC"),
 					huh.NewOption("OAuth", "OAUTH"),
 				).
-				Value(&createView.AuthMode),
+				Value(&instance.AuthMode),
 		),
 		huh.NewGroup(
 			huh.NewInput().
 				Title("Username").
-				Value(&username).
+				Value(&authUsername).
 				Validate(func(str string) error {
+					if instance.AuthMode != "BASIC" {
+						return nil
+					}
 					if strings.TrimSpace(str) == "" {
 						return errors.New("username cannot be empty or only spaces")
-					}
-					if isValid := utils.ValidateUserName(str); !isValid {
-						return errors.New("please enter correct username format")
 					}
 					return nil
 				}),
 			huh.NewInput().
 				Title("Password").
 				EchoMode(huh.EchoModePassword).
-				Value(&password).
+				Value(&authPassword).
 				Validate(func(str string) error {
+					if instance.AuthMode != "BASIC" {
+						return nil
+					}
 					if strings.TrimSpace(str) == "" {
 						return errors.New("password cannot be empty or only spaces")
-					}
-					if err := utils.ValidatePassword(str); err != nil {
-						return err
 					}
 					return nil
 				}),
 		).WithHideFunc(func() bool {
-			return createView.AuthMode == "NONE" || createView.AuthMode == "OAUTH"
+			return instance.AuthMode == "NONE" || instance.AuthMode == "OAUTH"
 		}),
 		huh.NewGroup(
 			huh.NewInput().
 				Title("Token").
-				Value(&token).
+				Value(&authToken).
 				Validate(func(str string) error {
+					if instance.AuthMode != "OAUTH" {
+						return nil
+					}
 					if strings.TrimSpace(str) == "" {
 						return errors.New("token cannot be empty or only spaces")
 					}
 					return nil
 				}),
 		).WithHideFunc(func() bool {
-			return createView.AuthMode == "NONE" || createView.AuthMode == "BASIC"
+			return instance.AuthMode == "NONE" || instance.AuthMode == "BASIC"
 		}),
 	).WithTheme(theme).Run()
-
 	if err != nil {
 		return err
 	}
 
-	switch createView.AuthMode {
+	instance.AuthMode = strings.ToUpper(strings.TrimSpace(instance.AuthMode))
+
+	switch instance.AuthMode {
+	case "NONE":
+		instance.AuthInfo = nil
 	case "BASIC":
-		createView.AuthInfo = map[string]string{
-			"username": username,
-			"password": password,
+		instance.AuthInfo = map[string]string{
+			"username": strings.TrimSpace(authUsername),
+			"password": authPassword,
 		}
 	case "OAUTH":
-		createView.AuthInfo = map[string]string{
-			"token": token,
+		instance.AuthInfo = map[string]string{
+			"token": strings.TrimSpace(authToken),
 		}
 	}
 

--- a/pkg/views/instance/update/view.go
+++ b/pkg/views/instance/update/view.go
@@ -128,6 +128,7 @@ func UpdateInstanceView(instance *models.Instance) error {
 		huh.NewGroup(
 			huh.NewInput().
 				Title("Token").
+				EchoMode(huh.EchoModePassword).
 				Value(&authToken).
 				Validate(func(str string) error {
 					if instance.AuthMode != "OAUTH" {

--- a/pkg/views/instance/view/view.go
+++ b/pkg/views/instance/view/view.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package list
+package view
 
 import (
 	"fmt"
@@ -38,23 +38,21 @@ var columns = []table.Column{
 	{Title: "Setup Timestamp", Width: tablelist.WidthXL},
 }
 
-func ListInstance(instance []*models.Instance) {
+func ViewInstance(instance *models.Instance) {
 	var rows []table.Row
-	for _, regis := range instance {
-		rows = append(rows, table.Row{
-			fmt.Sprintf("%d", regis.ID),
-			regis.Name,
-			regis.Vendor,
-			regis.Endpoint,
-			regis.Status,
-			regis.AuthMode,
-			regis.Description,
-			fmt.Sprintf("%t", regis.Default),
-			fmt.Sprintf("%t", regis.Insecure),
-			fmt.Sprintf("%t", regis.Enabled),
-			time.Unix(regis.SetupTimestamp, 0).Format("2006-01-02 15:04:05"), // updated
-		})
-	}
+	rows = append(rows, table.Row{
+		fmt.Sprintf("%d", instance.ID),
+		instance.Name,
+		instance.Vendor,
+		instance.Endpoint,
+		instance.Status,
+		instance.AuthMode,
+		instance.Description,
+		fmt.Sprintf("%t", instance.Default),
+		fmt.Sprintf("%t", instance.Insecure),
+		fmt.Sprintf("%t", instance.Enabled),
+		time.Unix(instance.SetupTimestamp, 0).Format("2006-01-02 15:04:05"),
+	})
 
 	m := tablelist.NewModel(columns, rows, len(rows))
 


### PR DESCRIPTION
## Description
Adds missing `instance` command support for preheat provider workflows.

- Fixes #811

## Commands

- `instance view` : command to view details of a preheat instance.  
<img width="1494" height="372" alt="Kooha-2026-04-16-03-32-29" src="https://github.com/user-attachments/assets/385ffa04-5099-4400-a6b3-3ec1b486e33b" />

- `instance update` : command to update a preheat instance (flags + interactive form).  
<img width="1418" height="404" alt="Kooha-2026-04-16-03-34-25" src="https://github.com/user-attachments/assets/398b4da6-77d7-4c51-b258-fddff5f7d7b1" />

- `instance ping` : command to ping health of a preheat instance.  
<img width="934" height="310" alt="Kooha-2026-04-16-03-36-54" src="https://github.com/user-attachments/assets/f0ec5d13-0ae6-4765-84f5-f1055262f286" />


## Type of Change
Please select the relevant type.

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
- Added `instance view` command to show details of a single instance.
- Added `instance update` command to edit existing instance configuration.
- Added `instance ping` command to check instance connectivity/health.
- Improved auth handling in `instance create` (auth mode + credentials flow).