### PR TITLE
chore: bump Go version to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/goharbor/harbor-cli
 
-go 1.25.0
+go 1.26.2
 
 require (
 	github.com/atotto/clipboard v0.1.4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/goharbor/harbor-cli
 
-go 1.24.8
+go 1.25.0
 
 require (
 	github.com/atotto/clipboard v0.1.4


### PR DESCRIPTION
## Description
Bumps Go version from 1.24.8 to 1.25.0

- Fixes #805 

## Type of Change
Please select the relevant type.

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [x] Chore / maintenance

## Changes
- Updated Go version in `go.mod` to 1.25.0
- Ran `go mod tidy` to ensure dependency compatibility
 
## Note
While testing locally running `go mod vendor` introduced large changes in the `vendor/` directory which are not required for this PR as discussed in the issue, changes are limited to `go.mod` and `go.sum`.

Build and tests were verified without including vendor updates.
