### PR TITLE
fix: Adding the --project flag for setting the scope of the label to artifact

### DIFF
--- a/cmd/harbor/root/artifact/label/add.go
+++ b/cmd/harbor/root/artifact/label/add.go
@@ -24,6 +24,7 @@ import (
 
 // AddLabelArtifactCommmand adds a label to an artifact
 func AddLabelArtifactCommmand() *cobra.Command {
+	var isProject bool
 	cmd := &cobra.Command{
 		Use:   "add",
 		Short: "Attach a label to an artifact in a Harbor project repository",
@@ -47,6 +48,7 @@ Examples:
 				labelName                        string
 				labelID                          int64
 				err                              error
+				opts                             api.ListFlags
 			)
 
 			if len(args) >= 1 {
@@ -62,15 +64,25 @@ Examples:
 				repoName = prompt.GetRepoNameFromUser(projectName)
 				reference = prompt.GetReferenceFromUser(repoName, projectName)
 			}
+			if isProject {
+				id, err := api.GetProjectIDFromName(projectName)
+				if err != nil {
+					return err
+				}
+				opts.Scope = "p"
+				opts.ProjectID = id
+			} else {
+				opts.Scope = "g"
+			}
 
 			if len(args) == 2 {
 				labelName = args[1]
-				labelID, err = api.GetLabelIdByName(labelName, api.ListFlags{})
+				labelID, err = api.GetLabelIdByName(labelName, opts)
 				if err != nil {
 					return fmt.Errorf("failed to get label id: %v", utils.ParseHarborErrorMsg(err))
 				}
 			} else {
-				labelID, err = prompt.GetLabelIdFromUser(api.ListFlags{})
+				labelID, err = prompt.GetLabelIdFromUser(opts)
 				if err != nil {
 					return fmt.Errorf("failed to get label id: %v", utils.ParseHarborErrorMsg(err))
 				}
@@ -86,6 +98,8 @@ Examples:
 			return nil
 		},
 	}
+	flags := cmd.Flags()
+	flags.BoolVarP(&isProject, "project", "p", false, "Add project-scoped labels. eg --project, -p(specific project)")
 
 	return cmd
 }

--- a/cmd/harbor/root/artifact/label/delete.go
+++ b/cmd/harbor/root/artifact/label/delete.go
@@ -24,6 +24,7 @@ import (
 
 // DelLabelArtifactCommmand deletes a label from an artifact
 func DelLabelArtifactCommmand() *cobra.Command {
+	var isProject bool
 	cmd := &cobra.Command{
 		Use:     "delete",
 		Aliases: []string{"del"},
@@ -48,6 +49,7 @@ Examples:
 				projectName, repoName, reference string
 				labelID                          int64
 				err                              error
+				opts                             api.ListFlags
 			)
 
 			if len(args) >= 1 {
@@ -63,15 +65,25 @@ Examples:
 				repoName = prompt.GetRepoNameFromUser(projectName)
 				reference = prompt.GetReferenceFromUser(repoName, projectName)
 			}
+			if isProject {
+				id, err := api.GetProjectIDFromName(projectName)
+				if err != nil {
+					return err
+				}
+				opts.Scope = "p"
+				opts.ProjectID = id
+			} else {
+				opts.Scope = "g"
+			}
 
 			if len(args) == 2 {
 				labelName := args[1]
-				labelID, err = api.GetLabelIdByName(labelName, api.ListFlags{})
+				labelID, err = api.GetLabelIdByName(labelName, opts)
 				if err != nil {
 					return fmt.Errorf("failed to get label id: %v", utils.ParseHarborErrorMsg(err))
 				}
 			} else {
-				labelID, err = prompt.GetLabelIdFromUser(api.ListFlags{})
+				labelID, err = prompt.GetLabelIdFromUser(opts)
 				if err != nil {
 					return fmt.Errorf("failed to get label id: %v", utils.ParseHarborErrorMsg(err))
 				}
@@ -85,6 +97,8 @@ Examples:
 			return nil
 		},
 	}
+	flags := cmd.Flags()
+	flags.BoolVarP(&isProject, "project", "p", false, "Delete project-scoped labels. eg --project, -p(specific project)")
 
 	return cmd
 }

--- a/doc/cli-docs/harbor-artifact-label-add.md
+++ b/doc/cli-docs/harbor-artifact-label-add.md
@@ -31,7 +31,8 @@ harbor artifact label add [flags]
 ### Options
 
 ```sh
-  -h, --help   help for add
+  -h, --help      help for add
+  -p, --project   Add project-scoped labels. eg --project, -p(specific project)
 ```
 
 ### Options inherited from parent commands

--- a/doc/cli-docs/harbor-artifact-label-delete.md
+++ b/doc/cli-docs/harbor-artifact-label-delete.md
@@ -33,7 +33,8 @@ harbor artifact label delete [flags]
 ### Options
 
 ```sh
-  -h, --help   help for delete
+  -h, --help      help for delete
+  -p, --project   Delete project-scoped labels. eg --project, -p(specific project)
 ```
 
 ### Options inherited from parent commands

--- a/doc/man-docs/man1/harbor-artifact-label-add.1
+++ b/doc/man-docs/man1/harbor-artifact-label-add.1
@@ -31,6 +31,10 @@ Examples:
 \fB-h\fP, \fB--help\fP[=false]
 	help for add
 
+.PP
+\fB-p\fP, \fB--project\fP[=false]
+	Add project-scoped labels. eg --project, -p(specific project)
+
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 \fB-c\fP, \fB--config\fP=""

--- a/doc/man-docs/man1/harbor-artifact-label-delete.1
+++ b/doc/man-docs/man1/harbor-artifact-label-delete.1
@@ -35,6 +35,10 @@ Examples:
 \fB-h\fP, \fB--help\fP[=false]
 	help for delete
 
+.PP
+\fB-p\fP, \fB--project\fP[=false]
+	Delete project-scoped labels. eg --project, -p(specific project)
+
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 \fB-c\fP, \fB--config\fP=""


### PR DESCRIPTION
## Description
Adds the --project flag to the `add` and `delete` command of `artifact label` since there was no scope defined in the current implementation and was leading to an error, have set the default scope to be global 


- Fixes #814 

## Type of Change
Please select the relevant type.

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
-After the changes the command is working properly and for reference 

<img width="1093" height="273" alt="image" src="https://github.com/user-attachments/assets/48d39005-bc3d-4c7a-b6ed-ae69b241f650" />
<img width="1476" height="503" alt="image" src="https://github.com/user-attachments/assets/63ee2345-e570-4ade-b10e-364ca8ae7028" />





