### PR TITLE
fix(ci): install syft and call binary by absolute path

### DIFF
--- a/.dagger/publishimage.go
+++ b/.dagger/publishimage.go
@@ -299,8 +299,9 @@ func (m *HarborCli) GenerateSBOM(
 		From("anchore/syft:latest").
 		WithSecretVariable("SYFT_REGISTRY_AUTH_PASSWORD", registryPassword).
 		WithEnvVariable("SYFT_REGISTRY_AUTH_USERNAME", registryUsername).
-		// Output SPDX JSON to a known path
-		WithExec([]string{"syft", imageAddr, "-o", "spdx-json=/sbom.spdx.json"})
+		// anchore/syft is FROM scratch with ENTRYPOINT ["/syft"] and no $PATH,
+		// so call the binary by its absolute path.
+		WithExec([]string{"/syft", imageAddr, "-o", "spdx-json=/sbom.spdx.json"})
 
 	return syftCtr.File("/sbom.spdx.json")
 }

--- a/.github/actions/publish-and-sign/action.yaml
+++ b/.github/actions/publish-and-sign/action.yaml
@@ -31,6 +31,11 @@ runs:
     - name: Install Cosign
       uses: sigstore/cosign-installer@v3.7.0
 
+    - name: Install Syft
+      uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 #v0.24.0
+      with:
+        syft-version: v1.32.0
+
     - name: Get Build Artifact
       if: ${{ inputs.BUILD_DIR != '' }}
       uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary
- Add `Install Syft` step to the `publish-and-sign` composite action, pinned to `anchore/sbom-action/download-syft@v0.24.0` with `syft-version: v1.32.0`.
- Fix `GenerateSBOM` in `.dagger/publishimage.go` to call `/syft` by absolute path.

## Why
The latest publish run failed with:
```
exec: "syft": executable file not found in $PATH
HarborCli.publishImageAndSign ERROR
```
`anchore/syft:latest` is built `FROM scratch` with `ENTRYPOINT ["/syft"]` and no shell or `$PATH`. Dagger's `WithExec` does not invoke the entrypoint, so `"syft"` could not be resolved. Using the absolute path `/syft` resolves the binary directly.

The `Install Syft` runner step mirrors the existing `Install Cosign` pattern and pins the action by SHA plus a fixed syft version for reproducibility.

## Test plan
- [ ] Trigger the publish-and-sign workflow on a snapshot tag and confirm `publish-image-and-sign` completes, SBOM is generated, and the in-toto attestation is attached to the published image.