### PR TITLE
fix: adding CNAME

### DIFF
--- a/.dagger/apt.go
+++ b/.dagger/apt.go
@@ -64,6 +64,12 @@ Description: Harbor CLI — a command-line interface for interacting with your H
 EOF`,
 	})
 
+	// CNAME File
+	container = container.WithExec([]string{
+		"bash", "-c",
+		`echo 'harborcli.goharbor.io' > /repo/CNAME`,
+	})
+
 	container = container.
 		WithWorkdir("/repo").
 		WithExec([]string{
@@ -79,7 +85,7 @@ EOF`,
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
 
-        git add dists pool 
+        git add dists pool CNAME 
 
         git commit -m "Update APT repo for %s" || echo "No changes to commit"
         git push origin gh-pages -f


### PR DESCRIPTION
## Description
Adds CNAME to the gh-pages build for `apt`

## Type of Change
Please select the relevant type.

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
- Adds CNAME file w/ `harborcli.goharbor.io` 
