### PR TITLE
ci: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/publish-and-sign/action.yaml
+++ b/.github/actions/publish-and-sign/action.yaml
@@ -26,10 +26,10 @@ runs:
   using: "composite"
   steps:
     - name: Dagger Version
-      uses: sagikazarmark/dagger-version-action@v0.0.1
+      uses: sagikazarmark/dagger-version-action@b45495ba1f5621efbbf899a218c8b5eec69901d2 # v0.0.1
 
     - name: Install Cosign
-      uses: sigstore/cosign-installer@v3.7.0
+      uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
 
     - name: Install Syft
       uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 #v0.24.0
@@ -38,7 +38,7 @@ runs:
 
     - name: Get Build Artifact
       if: ${{ inputs.BUILD_DIR != '' }}
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: build-dir
         path: ${{ inputs.BUILD_DIR }}
@@ -50,7 +50,7 @@ runs:
       run: cosign env
  
     - name: Publish and Sign Snapshot Image (Build Dir not present)
-      uses: dagger/dagger-for-github@v7
+      uses: dagger/dagger-for-github@b81317a976cb7f7125469707321849737cd1b3bc # v7
       if: ${{ inputs.BUILD_DIR == '' }}
       env:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
@@ -73,7 +73,7 @@ runs:
           --actions-id-token-request-token=env://ACTIONS_ID_TOKEN_REQUEST_TOKEN \
 
     - name: Publish and Sign Snapshot Image (Build Dir present)
-      uses: dagger/dagger-for-github@v7
+      uses: dagger/dagger-for-github@b81317a976cb7f7125469707321849737cd1b3bc # v7
       if: ${{ inputs.BUILD_DIR != '' }}
       env:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -23,16 +23,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Dagger Version
         id: dagger_version
-        uses: sagikazarmark/dagger-version-action@v0.0.3
+        uses: sagikazarmark/dagger-version-action@71fb35824ad241172a822546694a4fc68631eafd # v0.0.3
 
       - name: Generate Document
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@b81317a976cb7f7125469707321849737cd1b3bc # v7
         with:
           version: ${{ steps.dagger_version.outputs.version }}
           verb: call
@@ -55,7 +55,7 @@ jobs:
         continue-on-error: false
 
       - name: Run Dagger golangci-lint
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@b81317a976cb7f7125469707321849737cd1b3bc # v7
         with:
           version: ${{ steps.dagger_version.outputs.version }}
           verb: call
@@ -76,16 +76,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Dagger Version
         id: dagger_version
-        uses: sagikazarmark/dagger-version-action@v0.0.3
+        uses: sagikazarmark/dagger-version-action@71fb35824ad241172a822546694a4fc68631eafd # v0.0.3
 
       - name: Run Vulnerability Check
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@b81317a976cb7f7125469707321849737cd1b3bc # v7
         with:
           version: ${{ steps.dagger_version.outputs.version }}
           verb: call
@@ -184,29 +184,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Dagger Version
         id: dagger_version
-        uses: sagikazarmark/dagger-version-action@v0.0.3
+        uses: sagikazarmark/dagger-version-action@71fb35824ad241172a822546694a4fc68631eafd # v0.0.3
 
       - name: Run Tests
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@b81317a976cb7f7125469707321849737cd1b3bc # v7
         with:
           version: ${{ steps.dagger_version.outputs.version }}
           verb: call
           args: test-report --source=. export --path=TestReport.json
 
       - name: Summarize Tests
-        uses: robherley/go-test-action@v0.7.1
+        uses: robherley/go-test-action@42a1975c97156330b5126c2f35ef0fb78c4c7154 # v0.7.1
         with:
           fromJSONFile: TestReport.json
 
       - name: Run Test Coverage Report
         if: github.event_name == 'pull_request'
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@b81317a976cb7f7125469707321849737cd1b3bc # v7
         with:
           version: ${{ steps.dagger_version.outputs.version }}
           verb: call
@@ -218,13 +218,13 @@ jobs:
 
       - name: Run Test Coverage
         if: github.event_name == 'pull_request'
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@b81317a976cb7f7125469707321849737cd1b3bc # v7
         with:
           version: ${{ steps.dagger_version.outputs.version }}
           verb: call
           args: test-coverage --source=. export --path=coverage.out
 
-      - uses: codecov/codecov-action@v6
+      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         if: github.event_name == 'pull_request'
         with:
           verbose: true
@@ -232,7 +232,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Build Binary
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@b81317a976cb7f7125469707321849737cd1b3bc # v7
         with:
           version: ${{ steps.dagger_version.outputs.version }}
           verb: call
@@ -254,7 +254,7 @@ jobs:
 
       - name: Checkout repo
         if: github.event_name == 'push' && (github.ref == 'refs/heads/main')
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -285,7 +285,7 @@ jobs:
         if: |
           (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
           (github.event_name == 'workflow_dispatch')
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
@@ -300,7 +300,7 @@ jobs:
         if: |
           (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
           (github.event_name == 'workflow_dispatch')
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@b81317a976cb7f7125469707321849737cd1b3bc # v7
         with:
           version: "latest"
           verb: call
@@ -310,7 +310,7 @@ jobs:
         if: |
           (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
           (github.event_name == 'workflow_dispatch')
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@b81317a976cb7f7125469707321849737cd1b3bc # v7
         with:
           version: "latest"
           verb: call
@@ -320,7 +320,7 @@ jobs:
         if: |
           (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
           (github.event_name == 'workflow_dispatch')
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@b81317a976cb7f7125469707321849737cd1b3bc # v7
         with:
           version: "latest"
           verb: call
@@ -330,7 +330,7 @@ jobs:
         if: |
           (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
           (github.event_name == 'workflow_dispatch')
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@b81317a976cb7f7125469707321849737cd1b3bc # v7
         with:
           version: "latest"
           verb: call
@@ -340,7 +340,7 @@ jobs:
         if: |
           (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
           (github.event_name == 'workflow_dispatch')
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@b81317a976cb7f7125469707321849737cd1b3bc # v7
         with:
           version: "latest"
           verb: call
@@ -350,7 +350,7 @@ jobs:
         if: |
           (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
           (github.event_name == 'workflow_dispatch')
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@b81317a976cb7f7125469707321849737cd1b3bc # v7
         with:
           version: "latest"
           verb: call
@@ -360,7 +360,7 @@ jobs:
         if: |
           (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
           (github.event_name == 'workflow_dispatch')
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@b81317a976cb7f7125469707321849737cd1b3bc # v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -372,7 +372,7 @@ jobs:
         if: |
           (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
           (github.event_name == 'workflow_dispatch')
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@b81317a976cb7f7125469707321849737cd1b3bc # v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -384,7 +384,7 @@ jobs:
         if: |
           (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
           (github.event_name == 'workflow_dispatch')
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: build-dir
           path: ./dist

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -15,7 +15,7 @@ jobs:
         if: |
           (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
           (github.event_name == 'workflow_dispatch')
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
@@ -30,7 +30,7 @@ jobs:
         if: |
           (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
           (github.event_name == 'workflow_dispatch')
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@b81317a976cb7f7125469707321849737cd1b3bc # v7
         with:
           version: "latest"
           verb: call
@@ -40,7 +40,7 @@ jobs:
         if: |
           (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
           (github.event_name == 'workflow_dispatch')
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@b81317a976cb7f7125469707321849737cd1b3bc # v7
         with:
           version: "latest"
           verb: call
@@ -50,7 +50,7 @@ jobs:
         if: |
           (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
           (github.event_name == 'workflow_dispatch')
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@b81317a976cb7f7125469707321849737cd1b3bc # v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Closes #824.

Pin every external \`uses:\` reference in \`.github/workflows\` and \`.github/actions\` to a full-length commit SHA. The existing human-readable tag is preserved as a trailing \`# <tag>\` comment so version intent stays visible and Dependabot's \`package-ecosystem: github-actions\` keeps working.

## Pinned actions

| Action | Was | Now |
|---|---|---|
| \`actions/checkout\` | \`@v6\` | \`@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6\` |
| \`actions/checkout\` (pages) | \`@v4\` | \`@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4\` |
| \`actions/upload-artifact\` | \`@v7\` | \`@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7\` |
| \`actions/download-artifact\` | \`@v4\` | \`@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4\` |
| \`sagikazarmark/dagger-version-action\` | \`@v0.0.3\` | \`@71fb35824ad241172a822546694a4fc68631eafd # v0.0.3\` |
| \`sagikazarmark/dagger-version-action\` (composite) | \`@v0.0.1\` | \`@b45495ba1f5621efbbf899a218c8b5eec69901d2 # v0.0.1\` |
| \`dagger/dagger-for-github\` | \`@v7\` | \`@b81317a976cb7f7125469707321849737cd1b3bc # v7\` |
| \`robherley/go-test-action\` | \`@v0.7.1\` | \`@42a1975c97156330b5126c2f35ef0fb78c4c7154 # v0.7.1\` |
| \`codecov/codecov-action\` | \`@v6\` | \`@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6\` |
| \`sigstore/cosign-installer\` | \`@v3.7.0\` | \`@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0\` |

\`anchore/sbom-action/download-syft\` was already pinned and is untouched. The local \`./.github/actions/publish-and-sign\` reference is also left as-is since it's in-tree.

Each SHA was resolved by hitting \`/repos/<org>/<action>/git/ref/tags/<tag>\` via \`gh api\` and, when the tag was annotated, peeling it to its target commit.

## Rationale

Pinning to SHAs defuses the \"we pushed a compromised v7\" supply-chain class of attacks. This matches the guidance in the GitHub OpenSSF best-practices scorecard and what hardening-focused forks of other harbor repos have already adopted.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>