### PR TITLE
feat(project): add view command for project member

### DIFF
--- a/cmd/harbor/root/project/member.go
+++ b/cmd/harbor/root/project/member.go
@@ -31,6 +31,7 @@ func Member() *cobra.Command {
 		member.CreateMemberCommand(),
 		member.DeleteMemberCommand(),
 		member.UpdateMemberCommand(),
+		member.ViewMemberCommand(),
 	)
 
 	return cmd

--- a/cmd/harbor/root/project/member/view.go
+++ b/cmd/harbor/root/project/member/view.go
@@ -1,0 +1,88 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package member
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/prompt"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/goharbor/harbor-cli/pkg/views/member/view"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// ViewMemberCommand creates a new `harbor project member view` command
+func ViewMemberCommand() *cobra.Command {
+	var opts api.GetMemberOptions
+	var isID bool
+
+	cmd := &cobra.Command{
+		Use:     "view [projectName] [memberID]",
+		Short:   "get project member by ID or name",
+		Long:    "get member details by MemberID",
+		Example: "  harbor project member view my-project [memberID]\n  harbor project member view my-project 5\n  harbor project member view my-project 5 --wide",
+		Args:    cobra.MaximumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+
+			if len(args) == 1 {
+				opts.ProjectNameOrID = args[0]
+			} else if len(args) == 2 {
+				opts.ProjectNameOrID = args[0]
+				opts.ID, _ = strconv.ParseInt(args[1], 0, 64)
+			}
+
+			if opts.ProjectNameOrID == "" {
+				opts.ProjectNameOrID, err = prompt.GetProjectNameFromUser()
+				if err != nil {
+					return fmt.Errorf("failed to get project name: %v", err)
+				}
+			}
+
+			if opts.ID == 0 {
+				opts.ID = prompt.GetMemberIDFromUser(opts.ProjectNameOrID, "")
+				if opts.ID == 0 {
+					return fmt.Errorf("no members found in project")
+				}
+			}
+
+			opts.XIsResourceName = !isID
+
+			member, err := api.GetMember(opts)
+			if err != nil {
+				return fmt.Errorf("failed to get project member info: %v", err)
+			}
+
+			FormatFlag := viper.GetString("output-format")
+			if FormatFlag != "" {
+				err = utils.PrintFormat(member.Payload, FormatFlag)
+				if err != nil {
+					return err
+				}
+			} else {
+				wideFlag := viper.GetBool("wide")
+				view.ViewMember(member.Payload, wideFlag)
+			}
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.BoolVarP(&isID, "id", "", false, "parses projectName as an ID")
+	return cmd
+}

--- a/doc/cli-docs/harbor-project-member-view.md
+++ b/doc/cli-docs/harbor-project-member-view.md
@@ -13,28 +13,29 @@ weight: 90
 get member details by MemberID
 
 ```sh
-harbor project member view [ProjectName Or ID] [member ID] [flags]
+harbor project member view [projectName] [memberID] [flags]
 ```
 
 ### Examples
 
 ```sh
   harbor project member view my-project [memberID]
+  harbor project member view my-project 5
+  harbor project member view my-project 5 --wide
 ```
 
 ### Options
 
 ```sh
-  -h, --help                 help for view
-      --id int               Member ID
-  -p, --projectname string   Project Name
+  -h, --help   help for view
+      --id     parses projectName as an ID
 ```
 
 ### Options inherited from parent commands
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/cli-docs/harbor-project-member.md
+++ b/doc/cli-docs/harbor-project-member.md
@@ -39,4 +39,5 @@ Manage members and assign roles to them
 * [harbor project member delete](harbor-project-member-delete.md)	 - delete member by username
 * [harbor project member list](harbor-project-member-list.md)	 - list members in a project
 * [harbor project member update](harbor-project-member-update.md)	 - update member by name
+* [harbor project member view](harbor-project-member-view.md)	 - get project member information
 

--- a/doc/man-docs/man1/harbor-project-member-view.1
+++ b/doc/man-docs/man1/harbor-project-member-view.1
@@ -2,15 +2,15 @@
 .TH "HARBOR" "1"  "Harbor Community" "Harbor User Manuals"
 
 .SH NAME
-harbor-project-member-view - get project member by ID or name
+harbor-project-member-view - get project member information
 
 
 .SH SYNOPSIS
-\fBharbor project member view [ProjectName Or ID] [member ID] [flags]\fP
+\fBharbor project member view [projectName] [memberID] [flags]\fP
 
 
 .SH DESCRIPTION
-get member details by MemberID
+get project member information
 
 
 .SH OPTIONS
@@ -18,12 +18,8 @@ get member details by MemberID
 	help for view
 
 .PP
-\fB--id\fP=0
-	Member ID
-
-.PP
-\fB-p\fP, \fB--projectname\fP=""
-	Project Name
+\fB--id\fP[=false]
+	parses projectName as an ID
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
@@ -32,7 +28,7 @@ get member details by MemberID
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]
@@ -41,7 +37,8 @@ get member details by MemberID
 
 .SH EXAMPLE
 .EX
-  harbor project member view my-project [memberID]
+  harbor project member view my-project 5
+  harbor project member view my-project 5 --wide
 .EE
 
 

--- a/doc/man-docs/man1/harbor-project-member.1
+++ b/doc/man-docs/man1/harbor-project-member.1
@@ -38,4 +38,4 @@ Manage members and assign roles to them
 
 
 .SH SEE ALSO
-\fBharbor-project(1)\fP, \fBharbor-project-member-create(1)\fP, \fBharbor-project-member-delete(1)\fP, \fBharbor-project-member-list(1)\fP, \fBharbor-project-member-update(1)\fP
+\fBharbor-project(1)\fP, \fBharbor-project-member-create(1)\fP, \fBharbor-project-member-delete(1)\fP, \fBharbor-project-member-list(1)\fP, \fBharbor-project-member-update(1)\fP, \fBharbor-project-member-view(1)\fP

--- a/pkg/views/webhook/create/view.go
+++ b/pkg/views/webhook/create/view.go
@@ -83,7 +83,12 @@ func WebhookCreateView(createView *CreateView) error {
 				Title("Endpoint URL").
 				Value(&createView.EndpointURL).
 				Validate(func(str string) error {
-					return utils.ValidateURL(str)
+					formattedUrl := utils.FormatUrl(str)
+					if err := utils.ValidateURL(formattedUrl); err != nil {
+						return err
+					}
+					createView.EndpointURL = formattedUrl
+					return nil
 				}),
 			huh.NewInput().
 				Title("Auth Header").

--- a/pkg/views/webhook/edit/view.go
+++ b/pkg/views/webhook/edit/view.go
@@ -109,9 +109,11 @@ func WebhookEditView(editView *EditView) {
 					if strings.TrimSpace(str) == "" {
 						return errors.New("endpoint URL cannot be empty")
 					}
-					if err := utils.ValidateURL(str); err != nil {
+					formattedUrl := utils.FormatUrl(str)
+					if err := utils.ValidateURL(formattedUrl); err != nil {
 						return err
 					}
+					editView.EndpointURL = formattedUrl
 					return nil
 				}),
 


### PR DESCRIPTION
## Description
This pull request adds the `harbor project member view` command to the CLI.

Previously, the `project member` subcommand group was missing a `view` command, making it inconsistent with the rest of the CLI (which follows a standard CRUD+view pattern). Users who wanted to inspect a specific member had to run a `list` command and filter the output manually. 

This PR leverages the already existing backend API handler and TUI view components to provide a dedicated command that supports interactive prompts, `--wide` outputs, and structured JSON/YAML outputs for scripting workflows.

- Fixes #838 

## Type of Change
Please select the relevant type.

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [X] Documentation update
- [ ] Chore / maintenance

## Changes
- Created `cmd/harbor/root/project/member/view.go` to implement `ViewMemberCommand()`.
- Wired the new command into the `project member` subcommand group in `cmd/harbor/root/project/member.go`.
- Regenerated CLI markdown documentation to include the new command's usage and help output.
