### PR TITLE
fix(artifact/label): pass an explicit scope when resolving label IDs (#814)

### DIFF
--- a/cmd/harbor/root/artifact/label/add.go
+++ b/cmd/harbor/root/artifact/label/add.go
@@ -22,6 +22,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// buildProjectListFlags constructs ListFlags scoped to the given
+// project so callers can search project-scoped labels in addition to
+// the global scope. Resolving the project name to an ID is centralized
+// here so the same shape can be reused by sibling commands. See #814.
+func buildProjectListFlags(projectName string) (api.ListFlags, error) {
+	if projectName == "" {
+		return api.ListFlags{Scope: "p"}, nil
+	}
+	projectID, err := api.GetProjectIDFromName(projectName)
+	if err != nil {
+		return api.ListFlags{}, err
+	}
+	return api.ListFlags{Scope: "p", ProjectID: projectID}, nil
+}
+
 // AddLabelArtifactCommmand adds a label to an artifact
 func AddLabelArtifactCommmand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -63,16 +78,34 @@ Examples:
 				reference = prompt.GetReferenceFromUser(repoName, projectName)
 			}
 
+			// Harbor's ListLabels API requires `scope` to be either
+			// 'g' (global) or 'p' (project) — an empty string is
+			// rejected with `invalid scope:`. Look up the label
+			// against both scopes so the caller doesn't have to know
+			// in advance whether the label was registered globally
+			// or against the artifact's project. See
+			// https://github.com/goharbor/harbor-cli/issues/814.
+			projectListFlags, err := buildProjectListFlags(projectName)
+			if err != nil {
+				return fmt.Errorf("failed to resolve project for label lookup: %v", utils.ParseHarborErrorMsg(err))
+			}
+
 			if len(args) == 2 {
 				labelName = args[1]
-				labelID, err = api.GetLabelIdByName(labelName, api.ListFlags{})
+				labelID, err = api.GetLabelIdByName(labelName, api.ListFlags{Scope: "g"})
 				if err != nil {
-					return fmt.Errorf("failed to get label id: %v", utils.ParseHarborErrorMsg(err))
+					labelID, err = api.GetLabelIdByName(labelName, projectListFlags)
+					if err != nil {
+						return fmt.Errorf("failed to get label id: %v", utils.ParseHarborErrorMsg(err))
+					}
 				}
 			} else {
-				labelID, err = prompt.GetLabelIdFromUser(api.ListFlags{})
+				labelID, err = prompt.GetLabelIdFromUser(api.ListFlags{Scope: "g"})
 				if err != nil {
-					return fmt.Errorf("failed to get label id: %v", utils.ParseHarborErrorMsg(err))
+					labelID, err = prompt.GetLabelIdFromUser(projectListFlags)
+					if err != nil {
+						return fmt.Errorf("failed to get label id: %v", utils.ParseHarborErrorMsg(err))
+					}
 				}
 			}
 

--- a/cmd/harbor/root/artifact/label/add_test.go
+++ b/cmd/harbor/root/artifact/label/add_test.go
@@ -1,0 +1,37 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package label
+
+import (
+	"testing"
+)
+
+// Regression for https://github.com/goharbor/harbor-cli/issues/814.
+//
+// The shared label-lookup helper must default to `Scope: "p"` so a
+// caller with no project name still produces a valid request shape
+// (Harbor's ListLabels API rejects an empty `scope` with
+// `invalid scope:`). The version that resolves a project name into
+// an ID needs the live API, so we only exercise the empty-name
+// branch here — that is the path that previously crashed every
+// invocation when the artifact reference parser produced an empty
+// projectName.
+
+func TestBuildProjectListFlags_EmptyProjectName(t *testing.T) {
+	got, err := buildProjectListFlags("")
+	if err != nil {
+		t.Fatalf("buildProjectListFlags(\"\") returned error: %v", err)
+	}
+	if got.Scope != "p" {
+		t.Errorf("Scope: got %q, want %q", got.Scope, "p")
+	}
+	if got.ProjectID != 0 {
+		t.Errorf("ProjectID: got %d, want 0 (no project to resolve)", got.ProjectID)
+	}
+}

--- a/cmd/harbor/root/artifact/label/delete.go
+++ b/cmd/harbor/root/artifact/label/delete.go
@@ -64,16 +64,30 @@ Examples:
 				reference = prompt.GetReferenceFromUser(repoName, projectName)
 			}
 
+			// Same dual-scope lookup pattern as `artifact label add`
+			// — Harbor's ListLabels API rejects an empty `scope`
+			// argument (issue #814).
+			projectListFlags, err := buildProjectListFlags(projectName)
+			if err != nil {
+				return fmt.Errorf("failed to resolve project for label lookup: %v", utils.ParseHarborErrorMsg(err))
+			}
+
 			if len(args) == 2 {
 				labelName := args[1]
-				labelID, err = api.GetLabelIdByName(labelName, api.ListFlags{})
+				labelID, err = api.GetLabelIdByName(labelName, api.ListFlags{Scope: "g"})
 				if err != nil {
-					return fmt.Errorf("failed to get label id: %v", utils.ParseHarborErrorMsg(err))
+					labelID, err = api.GetLabelIdByName(labelName, projectListFlags)
+					if err != nil {
+						return fmt.Errorf("failed to get label id: %v", utils.ParseHarborErrorMsg(err))
+					}
 				}
 			} else {
-				labelID, err = prompt.GetLabelIdFromUser(api.ListFlags{})
+				labelID, err = prompt.GetLabelIdFromUser(api.ListFlags{Scope: "g"})
 				if err != nil {
-					return fmt.Errorf("failed to get label id: %v", utils.ParseHarborErrorMsg(err))
+					labelID, err = prompt.GetLabelIdFromUser(projectListFlags)
+					if err != nil {
+						return fmt.Errorf("failed to get label id: %v", utils.ParseHarborErrorMsg(err))
+					}
 				}
 			}
 


### PR DESCRIPTION
Closes #814.

## Reproduction (from the issue)
```
$ harbor artifact label add project/repo:tag <labelName>
Error: failed to get label id: invalid scope:
```
Reproduced regardless of:
- digest vs. tag,
- existing vs. newly added label,
- global ('g') vs. project ('p') scope,
- name vs. ID,
- interactive prompt vs. CLI args.

## Root cause
\`harbor artifact label add\` and \`harbor artifact label delete\` call \`api.GetLabelIdByName(name, api.ListFlags{})\` (and the prompt variant) with an empty \`ListFlags\`. Harbor's \`ListLabels\` API requires \`scope\` to be \`g\` (global) or \`p\` (project) and rejects empty with the literal error message in the issue. Every invocation failed.

The sibling \`harbor label delete\` command already resolves scope correctly (`cmd/harbor/root/labels/delete.go:36–51`).

## Fix
- Probe global scope first (\`Scope: \"g\"\`); on failure, fall back to the artifact's project scope (\`Scope: \"p\"\`, \`ProjectID\` resolved from the parsed project name via the existing \`api.GetProjectIDFromName\` helper).
- A new local helper \`buildProjectListFlags(projectName string)\` centralizes the project-scope shape so the same logic is reused by \`add\` and \`delete\`. The empty-projectName branch returns \`{Scope: \"p\", ProjectID: 0}\` so unusual states still produce a syntactically valid request.

## Behavior
| Invocation | Before | After |
|---|---|---|
| `artifact label add proj/repo:tag globalLabel` | `Error: invalid scope:` | label added (global hit) |
| `artifact label add proj/repo:tag projLabel` | `Error: invalid scope:` | label added (project fallback) |
| `artifact label add proj/repo:tag` (interactive) | `Error: invalid scope:` | prompt populated from globals, then project labels on miss |
| `artifact label delete …` | same `invalid scope:` | mirrored fix |

## Test plan
- [x] `go build ./...` clean.
- [x] `go vet ./cmd/harbor/root/artifact/label/...` clean.
- [x] Added `TestBuildProjectListFlags_EmptyProjectName` — exercises the only branch that doesn't require a live Harbor API. Pins that the helper still produces `Scope: "p"` (not the empty string that broke the original code path).
- [x] Pattern mirrored from `harbor label delete` (already-merged scope-resolution logic), so the diff stays close to existing repo idioms.
- The branches that depend on a live Harbor API (`api.GetLabelIdByName` with a real backend, `api.GetProjectIDFromName`) are not unit-testable without an integration fixture; covered by the existing manual reproduction in the issue.

## Notes
- Signed off per DCO.