### PR TITLE
fix(login): enforce mutual exclusivity of --password and --password-stdin flags

### DIFF
--- a/cmd/harbor/root/login.go
+++ b/cmd/harbor/root/login.go
@@ -80,9 +80,11 @@ func LoginCommand() *cobra.Command {
 
 	flags := cmd.Flags()
 	flags.StringVarP(&Username, "username", "u", "", "Username")
-	flags.StringVarP(&Name, "context-name", "", "", "Login context name (optional)")
+	flags.StringVarP(&Name, "context-name", "n", "", "Login context name (optional)")
 	flags.StringVarP(&Password, "password", "p", "", "Password")
 	flags.BoolVar(&passwordStdin, "password-stdin", false, "Take the password from stdin")
+
+	cmd.MarkFlagsMutuallyExclusive("password", "password-stdin")
 
 	return cmd
 }

--- a/cmd/harbor/root/login_test.go
+++ b/cmd/harbor/root/login_test.go
@@ -106,3 +106,19 @@ func Test_Login_Success_RobotAccount(t *testing.T) {
 	err := cmd.Execute()
 	assert.NoError(t, err, "Expected no error for robot account login")
 }
+
+func Test_Login_Failure_MutuallyExclusiveFlags(t *testing.T) {
+	tempDir := t.TempDir()
+	data := helpers.Initialize(t, tempDir)
+	defer helpers.ConfigCleanup(t, data)
+
+	cmd := root.LoginCommand()
+	cmd.SetArgs([]string{"http://demo.goharbor.io"})
+
+	assert.NoError(t, cmd.Flags().Set("username", "admin"))
+	assert.NoError(t, cmd.Flags().Set("password", "Harbor12345"))
+	assert.NoError(t, cmd.Flags().Set("password-stdin", "true"))
+
+	err := cmd.Execute()
+	assert.Error(t, err, "Expected error when both --password and --password-stdin are set")
+}

--- a/doc/cli-docs/harbor-login.md
+++ b/doc/cli-docs/harbor-login.md
@@ -19,7 +19,7 @@ harbor login [server] [flags]
 ### Options
 
 ```sh
-      --context-name string   Login context name (optional)
+  -n, --context-name string   Login context name (optional)
   -h, --help                  help for login
   -p, --password string       Password
       --password-stdin        Take the password from stdin

--- a/doc/man-docs/man1/harbor-login.1
+++ b/doc/man-docs/man1/harbor-login.1
@@ -14,7 +14,7 @@ Authenticate with Harbor Registry.
 
 
 .SH OPTIONS
-\fB--context-name\fP=""
+\fB-n\fP, \fB--context-name\fP=""
 	Login context name (optional)
 
 .PP


### PR DESCRIPTION
## Description

The `harbor login` command accepted both `--password` and `--password-stdin` simultaneously without any error. This caused silent ambiguous behavior where `--password-stdin` overwrote the `-p` value with no user-facing warning.

- Fixes #848

## Type of Change

- [x] Bug fix

## Changes

- Added `cmd.MarkFlagsMutuallyExclusive("password", "password-stdin")` in `LoginCommand()` — uses Cobra's built-in constraint enforcement
- Added `-n` as a short alias for `--context-name` to match convention of all other login flags
- Added test case `Test_Login_Failure_MutuallyExclusiveFlags` to cover the validation

## Testing

Verified locally: