### PR TITLE
fix(user): validate email format before API call in create command

### DIFF
--- a/cmd/harbor/root/user/create.go
+++ b/cmd/harbor/root/user/create.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/utils"
 
 	"github.com/goharbor/harbor-cli/pkg/views/user/create"
 	"github.com/spf13/cobra"
@@ -41,6 +42,9 @@ func UserCreateCmd() *cobra.Command {
 			}
 
 			if opts.Email != "" && opts.Realname != "" && opts.Password != "" && opts.Username != "" {
+				if !utils.ValidateEmail(opts.Email) {
+					return fmt.Errorf("invalid email format")
+				}
 				err = api.CreateUser(opts)
 			} else {
 				err = createUserView(createView)


### PR DESCRIPTION
Closes #815

When all flags are provided, `harbor user create` skips the interactive
form and calls the API directly. The interactive form validates email
via `utils.ValidateEmail()`, but the flag path didn't, so invalid
emails were sent to the API and returned confusing server-side errors.

Added the same `ValidateEmail` check to the flag path so the CLI
rejects bad emails early with a clear message.