### PR TITLE
fix(registry): return error on failed name lookup and handle it in delete

### DIFF
--- a/cmd/harbor/root/registry/delete.go
+++ b/cmd/harbor/root/registry/delete.go
@@ -15,6 +15,7 @@ package registry
 
 import (
 	"fmt"
+	"strconv"
 	"sync"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
@@ -33,7 +34,17 @@ func DeleteRegistryCommand() *cobra.Command {
 			errChan := make(chan error, len(args))
 			if len(args) > 0 {
 				for _, arg := range args {
-					registryID, _ := api.GetRegistryIdByName(arg)
+					var registryID int64
+					if id, err := strconv.ParseInt(arg, 10, 64); err == nil {
+						registryID = id
+					} else {
+						id, err := api.GetRegistryIdByName(arg)
+						if err != nil {
+							errChan <- fmt.Errorf("failed to resolve registry '%s': %v", arg, err)
+							continue
+						}
+						registryID = id
+					}
 					wg.Add(1)
 					go func(registryID int64) {
 						defer wg.Done()

--- a/pkg/api/registry_handler.go
+++ b/pkg/api/registry_handler.go
@@ -175,7 +175,7 @@ func GetRegistryProviders() ([]string, error) {
 }
 
 func GetRegistryIdByName(registryName string) (int64, error) {
-	var opts ListFlags
+	opts := ListFlags{Name: registryName}
 
 	r, err := ListRegistries(opts)
 	if err != nil {
@@ -188,5 +188,5 @@ func GetRegistryIdByName(registryName string) (int64, error) {
 		}
 	}
 
-	return 0, err
+	return 0, fmt.Errorf("registry '%s' not found", registryName)
 }


### PR DESCRIPTION
Closes #840

Two bugs in `GetRegistryIdByName`:

1. Returns `(0, nil)` when the registry name isn't found, so callers
   can't distinguish "not found" from success. Fixed to return
   `fmt.Errorf("registry '<name>' not found")`.

2. Calls `ListRegistries` with empty opts, so the lookup only checks
   the default page. Now passes the name filter so the API handles
   filtering server-side.

Also fixed `registry delete` to:
- Actually check the error from `GetRegistryIdByName` instead of
  discarding it with `_`
- Try `strconv.ParseInt` first so numeric IDs work as arguments too

Same pattern as the user lookup fix in #820.