### PR TITLE
refactor(views): add loading spinner to tablelist model

### DIFF
--- a/pkg/views/base/tablelist/model.go
+++ b/pkg/views/base/tablelist/model.go
@@ -14,6 +14,7 @@
 package tablelist
 
 import (
+	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -31,7 +32,9 @@ const (
 )
 
 type Model struct {
-	Table table.Model
+	Table     table.Model
+	Spinner   spinner.Model
+	IsLoading bool
 }
 
 func NewModel(columns []table.Column, rows []table.Row, height int) Model {
@@ -55,19 +58,49 @@ func NewModel(columns []table.Column, rows []table.Row, height int) Model {
 		Bold(false)
 	t.SetStyles(s)
 
-	return Model{Table: t}
+	sp := spinner.New()
+	sp.Spinner = spinner.Dot
+	sp.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
+
+	return Model{
+		Table:     t,
+		Spinner:   sp,
+		IsLoading: len(rows) == 0,
+	}
 }
 
 func (m Model) Init() tea.Cmd {
+	if m.IsLoading {
+		return m.Spinner.Tick
+	}
 	return tea.Quit
 }
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
+	switch msg := msg.(type) {
+	case spinner.TickMsg:
+		if m.IsLoading {
+			m.Spinner, cmd = m.Spinner.Update(msg)
+			return m, cmd
+		}
+	case []table.Row:
+		m.Table.SetRows(msg)
+		m.IsLoading = false
+		return m, nil
+	case tea.KeyMsg:
+		if msg.String() == "q" || msg.String() == "ctrl+c" {
+			return m, tea.Quit
+		}
+	}
+
 	m.Table, cmd = m.Table.Update(msg)
 	return m, cmd
 }
 
 func (m Model) View() string {
+	if m.IsLoading {
+		return "\n  " + m.Spinner.View() + " Loading data...\n"
+	}
 	return views.BaseStyle.Render(m.Table.View()) + "\n"
 }


### PR DESCRIPTION
Implements async loading for the tablelist component. This allows the CLI to show a spinner immediately while data fetches in the background, improving UX.

   - Relates to #821

  Type of Change
   - [x] Refactor

  Changes
   - Added spinner.Model and IsLoading state to tablelist.
   - Updated Update() to handle async data and spinner animations.
   - Updated View() to show the spinner during loading.