### PR TITLE
fix(robot): exit cleanly when user presses q in permission grid

### DIFF
--- a/pkg/views/base/tablegrid/model.go
+++ b/pkg/views/base/tablegrid/model.go
@@ -35,7 +35,7 @@ type TableGrid struct {
 	Styles      Styles               // Custom styles
 	Icons       Icons                // Custom icons
 	Footer      string               // Custom footer text
-	Cancelled bool
+	Cancelled   bool
 }
 
 // Styles contains customizable styles for the table grid

--- a/pkg/views/base/tablegrid/model.go
+++ b/pkg/views/base/tablegrid/model.go
@@ -35,6 +35,7 @@ type TableGrid struct {
 	Styles      Styles               // Custom styles
 	Icons       Icons                // Custom icons
 	Footer      string               // Custom footer text
+	Cancelled bool
 }
 
 // Styles contains customizable styles for the table grid
@@ -376,6 +377,7 @@ func (m *TableGrid) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 
 		case "q", "ctrl+c":
+			m.Cancelled = true
 			return m, tea.Quit
 		}
 	}

--- a/pkg/views/robot/select/view.go
+++ b/pkg/views/robot/select/view.go
@@ -132,31 +132,18 @@ func ListPermissions(perms *models.Permissions, kind string, ch chan<- Permissio
 	}
 	_, err = tea.NewProgram(grid, tea.WithAltScreen()).Run()
 	if err != nil {
-    fmt.Println("error creating permissions grid:", err)
-    ch <- PermissionSelectResult{
-        Permissions: nil,
-        Err:         err,
-    }
-    return
-}
-	if grid.Cancelled {
-    ch <- PermissionSelectResult{
-        Permissions: nil,
-        Err:         fmt.Errorf("user exited at permission selection"),
-    }
-    return
+		ch <- PermissionSelectResult{Permissions: nil, Err: err}
+		return
 	}
-	if err != nil {
-		fmt.Println("error creating permissions grid:", err)
+	if grid.Cancelled {
 		ch <- PermissionSelectResult{
 			Permissions: nil,
-			Err:         err,
+			Err:         fmt.Errorf("user exited at permission selection"),
 		}
 		return
 	}
-	data:= grid.GetData()
+	data := grid.GetData()
 	selectedPerms := []models.Permission{}
-
 	for rowIdx, displayName := range grid.RowLabels {
 		kebabResource := utils.ToKebabCase(displayName)
 

--- a/pkg/views/robot/select/view.go
+++ b/pkg/views/robot/select/view.go
@@ -1,4 +1,4 @@
-// Copyright Project Harbor Authors
+﻿// Copyright Project Harbor Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -145,7 +145,8 @@ func ListPermissions(perms *models.Permissions, kind string, ch chan<- Permissio
         Err:         fmt.Errorf("user exited at permission selection"),
     }
     return
-}
+	}
+	data:= grid.GetData()
 	if err != nil {
 		fmt.Println("error creating permissions grid:", err)
 		ch <- PermissionSelectResult{
@@ -154,7 +155,6 @@ func ListPermissions(perms *models.Permissions, kind string, ch chan<- Permissio
 		}
 		return
 	}
-	data := grid.GetData()
 	selectedPerms := []models.Permission{}
 
 	for rowIdx, displayName := range grid.RowLabels {

--- a/pkg/views/robot/select/view.go
+++ b/pkg/views/robot/select/view.go
@@ -1,4 +1,4 @@
-// Copyright Project Harbor Authors
+﻿// Copyright Project Harbor Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -132,12 +132,12 @@ func ListPermissions(perms *models.Permissions, kind string, ch chan<- Permissio
 	}
 	_, err = tea.NewProgram(grid, tea.WithAltScreen()).Run()
 	if grid.Cancelled {
-		ch <- PermissionSelectResult{
-			Permissions: nil,
-			Err:         fmt.Errorf("user exited at permission selection"),
-		}
-		return
-	}
+    ch <- PermissionSelectResult{
+        Permissions: nil,
+        Err:         fmt.Errorf("user exited at permission selection"),
+    }
+    return
+}
 	if err != nil {
 		fmt.Println("error creating permissions grid:", err)
 		ch <- PermissionSelectResult{

--- a/pkg/views/robot/select/view.go
+++ b/pkg/views/robot/select/view.go
@@ -131,6 +131,14 @@ func ListPermissions(perms *models.Permissions, kind string, ch chan<- Permissio
 		return
 	}
 	_, err = tea.NewProgram(grid, tea.WithAltScreen()).Run()
+	if err != nil {
+    fmt.Println("error creating permissions grid:", err)
+    ch <- PermissionSelectResult{
+        Permissions: nil,
+        Err:         err,
+    }
+    return
+}
 	if grid.Cancelled {
     ch <- PermissionSelectResult{
         Permissions: nil,

--- a/pkg/views/robot/select/view.go
+++ b/pkg/views/robot/select/view.go
@@ -1,4 +1,4 @@
-﻿// Copyright Project Harbor Authors
+// Copyright Project Harbor Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/views/robot/select/view.go
+++ b/pkg/views/robot/select/view.go
@@ -146,7 +146,6 @@ func ListPermissions(perms *models.Permissions, kind string, ch chan<- Permissio
     }
     return
 	}
-	data:= grid.GetData()
 	if err != nil {
 		fmt.Println("error creating permissions grid:", err)
 		ch <- PermissionSelectResult{
@@ -155,6 +154,7 @@ func ListPermissions(perms *models.Permissions, kind string, ch chan<- Permissio
 		}
 		return
 	}
+	data:= grid.GetData()
 	selectedPerms := []models.Permission{}
 
 	for rowIdx, displayName := range grid.RowLabels {

--- a/pkg/views/robot/select/view.go
+++ b/pkg/views/robot/select/view.go
@@ -131,6 +131,13 @@ func ListPermissions(perms *models.Permissions, kind string, ch chan<- Permissio
 		return
 	}
 	_, err = tea.NewProgram(grid, tea.WithAltScreen()).Run()
+	if grid.Cancelled {
+		ch <- PermissionSelectResult{
+			Permissions: nil,
+			Err:         fmt.Errorf("user exited at permission selection"),
+		}
+		return
+	}
 	if err != nil {
 		fmt.Println("error creating permissions grid:", err)
 		ch <- PermissionSelectResult{


### PR DESCRIPTION
#Description:
This PR fixes a bug in the interactive permission selection step of harbor robot create and harbor project robot create.
When a user pressed q or Ctrl+C to back out of the permission grid, the TUI would close as expected : but the cancellation was silently swallowed. The calling code in ListPermissions had no way to know the user had opted out, so it would carry on and attempt to create the robot account anyway, sometimes with empty or incomplete permissions. Not great.
The fix is straightforward: a Cancelled field is added to the TableGrid struct, set to true when the user exits early, and checked in ListPermissions before any permission data is processed. If cancelled, an error is sent back up the chain and the command exits cleanly : no robot account created, no silent failures.

Fixes #847

Type of Change
 [x]Bug fix

#Changes:
Added a Cancelled bool field to the TableGrid struct in pkg/views/base/tablegrid/model.go
Set m.Cancelled = true in the Update() method when the user presses q or Ctrl+C, prior to calling tea.Quit
Added a grid.Cancelled check in ListPermissions (pkg/views/robot/select/view.go) : cancellation now sends an error on the result channel, halting robot creation cleanly

#Testing 
Run harbor robot create
Fill in name and duration
When the permission grid appears, press q
Command exits cleanly with: user exited at permission selection
Confirmed no robot account is created on the Harbor server
