### PR TITLE
chore(login): improve --password flag description with security guidance

### DIFF
--- a/cmd/harbor/root/login.go
+++ b/cmd/harbor/root/login.go
@@ -85,7 +85,7 @@ func LoginCommand() *cobra.Command {
 	flags := cmd.Flags()
 	flags.StringVarP(&Username, "username", "u", "", "Username")
 	flags.StringVarP(&Name, "context-name", "n", "", "Login context name (optional)")
-	flags.StringVarP(&Password, "password", "p", "", "Password")
+	flags.StringVarP(&Password, "password", "p", "", "Password (not recommended, use --password-stdin for better security)")
 	flags.BoolVar(&passwordStdin, "password-stdin", false, "Take the password from stdin")
 	flags.BoolVarP(&skipVerifyClient, "skip-verify-client", "", false, "Skip whether the clients basic auth credentials shall be validated against the Harbor server during login. This is not recommended as it may lead to storing invalid credentials. Use this flag if you want to skip validation of credentials during login, for example, when the Harbor server is not reachable at the moment of login but you still want to store the credentials for later use.")
 

--- a/doc/cli-docs/harbor-login.md
+++ b/doc/cli-docs/harbor-login.md
@@ -21,7 +21,7 @@ harbor login [server] [flags]
 ```sh
   -n, --context-name string   Login context name (optional)
   -h, --help                  help for login
-  -p, --password string       Password
+  -p, --password string       Password (not recommended, use --password-stdin for better security)
       --password-stdin        Take the password from stdin
       --skip-verify-client    Skip whether the clients basic auth credentials shall be validated against the Harbor server during login. This is not recommended as it may lead to storing invalid credentials. Use this flag if you want to skip validation of credentials during login, for example, when the Harbor server is not reachable at the moment of login but you still want to store the credentials for later use.
   -u, --username string       Username

--- a/doc/man-docs/man1/harbor-login.1
+++ b/doc/man-docs/man1/harbor-login.1
@@ -23,7 +23,7 @@ Authenticate with Harbor Registry.
 
 .PP
 \fB-p\fP, \fB--password\fP=""
-	Password
+	Password (not recommended, use --password-stdin for better security)
 
 .PP
 \fB--password-stdin\fP[=false]


### PR DESCRIPTION
## Description

The `--password` / `-p` flag in `harbor login` had a minimal description (`Password`) that gave users no indication of the shell history security risk. Updated the description to guide users toward the safer `--password-stdin` alternative, following the same convention used by `docker login`.

- Fixes #854

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [x] Chore / maintenance

## Changes

- Updated `--password` flag description in `cmd/harbor/root/login.go` to warn about shell history exposure and recommend `--password-stdin`
- Added `-n` short flag for `--context-name` in `harbor login` command
- Updated `doc/cli-docs/harbor-login.md` to reflect the new flag description and the new `-n` short flag
- Updated `doc/man-docs/man1/harbor-login.1` to reflect the new flag description and the new `-n` short flag

## Testing
$ harbor login --help
```
-p, --password string Password (not recommended, use --password-stdin for better security)
```
