### PR TITLE
feat(project): add confirmation prompt for deletion

### DIFF
--- a/cmd/harbor/root/artifact/delete.go
+++ b/cmd/harbor/root/artifact/delete.go
@@ -19,11 +19,14 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/goharbor/harbor-cli/pkg/views"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 func DeleteArtifactCommand() *cobra.Command {
+	var yes bool
+
 	cmd := &cobra.Command{
 		Use:   "delete",
 		Short: "delete an artifact",
@@ -44,13 +47,29 @@ func DeleteArtifactCommand() *cobra.Command {
 				repoName = prompt.GetRepoNameFromUser(projectName)
 				reference = prompt.GetReferenceFromUser(repoName, projectName)
 			}
+
+			if !yes {
+				confirm, err := views.ConfirmDeletion(fmt.Sprintf("Are you sure you want to delete artifact '%s/%s@%s'?", projectName, repoName, reference))
+				if err != nil {
+					return err
+				}
+				if !confirm {
+					fmt.Println("Deletion cancelled")
+					return nil
+				}
+			}
+
 			err = api.DeleteArtifact(projectName, repoName, reference)
 			if err != nil {
 				return fmt.Errorf("failed to delete an artifact: %v", utils.ParseHarborErrorMsg(err))
 			}
+			fmt.Printf("Artifact '%s/%s@%s' deleted successfully\n", projectName, repoName, reference)
 			return nil
 		},
 	}
+
+	flags := cmd.Flags()
+	flags.BoolVarP(&yes, "yes", "y", false, "Answer yes to all questions and do not prompt")
 
 	return cmd
 }

--- a/cmd/harbor/root/project/delete.go
+++ b/cmd/harbor/root/project/delete.go
@@ -21,6 +21,7 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/goharbor/harbor-cli/pkg/views"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -29,6 +30,7 @@ import (
 func DeleteProjectCommand() *cobra.Command {
 	var forceDelete bool
 	var projectID string
+	var yes bool
 
 	cmd := &cobra.Command{
 		Use:     "delete",
@@ -53,6 +55,16 @@ func DeleteProjectCommand() *cobra.Command {
 			}
 
 			if projectID != "" {
+				if !yes {
+					confirm, err := views.ConfirmDeletion(fmt.Sprintf("Are you sure you want to delete project with ID %s?", projectID))
+					if err != nil {
+						return err
+					}
+					if !confirm {
+						fmt.Println("Deletion cancelled")
+						return nil
+					}
+				}
 				log.Debugf("Deleting project with ID: %s", projectID)
 				wg.Add(1)
 				go func(id string) {
@@ -68,6 +80,16 @@ func DeleteProjectCommand() *cobra.Command {
 					}
 				}(projectID)
 			} else if len(args) > 0 {
+				if !yes {
+					confirm, err := views.ConfirmDeletion(fmt.Sprintf("Are you sure you want to delete %d project(s)?", len(args)))
+					if err != nil {
+						return err
+					}
+					if !confirm {
+						fmt.Println("Deletion cancelled")
+						return nil
+					}
+				}
 				// Delete by project name from args
 				log.Debugf("Deleting %d projects from args...", len(args))
 				for _, projectName := range args {
@@ -94,6 +116,16 @@ func DeleteProjectCommand() *cobra.Command {
 				projectName, err := prompt.GetProjectNameFromUser()
 				if err != nil {
 					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
+				}
+				if !yes {
+					confirm, err := views.ConfirmDeletion(fmt.Sprintf("Are you sure you want to delete project '%s'?", projectName))
+					if err != nil {
+						return err
+					}
+					if !confirm {
+						fmt.Println("Deletion cancelled")
+						return nil
+					}
 				}
 				log.Debugf("User input project: %s", projectName)
 				log.Debugf("Deleting project '%s' with force=%v", projectName, forceDelete)
@@ -129,6 +161,7 @@ func DeleteProjectCommand() *cobra.Command {
 	flags := cmd.Flags()
 	flags.BoolVar(&forceDelete, "force", false, "Forcefully delete all repositories, artifacts, and policies in the project. Use with extreme caution—this action is irreversible.")
 	flags.StringVar(&projectID, "project-id", "", "Specify project ID instead of project name")
+	flags.BoolVarP(&yes, "yes", "y", false, "Answer yes to all questions and do not prompt")
 
 	return cmd
 }

--- a/cmd/harbor/root/repository/delete.go
+++ b/cmd/harbor/root/repository/delete.go
@@ -19,10 +19,13 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/goharbor/harbor-cli/pkg/views"
 	"github.com/spf13/cobra"
 )
 
 func RepoDeleteCmd() *cobra.Command {
+	var yes bool
+
 	cmd := &cobra.Command{
 		Use:     "delete",
 		Short:   "Delete a repository",
@@ -44,12 +47,29 @@ func RepoDeleteCmd() *cobra.Command {
 				}
 				repoName = prompt.GetRepoNameFromUser(projectName)
 			}
+
+			if !yes {
+				confirm, err := views.ConfirmDeletion(fmt.Sprintf("Are you sure you want to delete repository '%s/%s'?", projectName, repoName))
+				if err != nil {
+					return err
+				}
+				if !confirm {
+					fmt.Println("Deletion cancelled")
+					return nil
+				}
+			}
+
 			err = api.RepoDelete(projectName, repoName, false)
 			if err != nil {
 				return fmt.Errorf("failed to delete repository: %v", err)
 			}
+			fmt.Printf("Repository '%s/%s' deleted successfully\n", projectName, repoName)
 			return nil
 		},
 	}
+
+	flags := cmd.Flags()
+	flags.BoolVarP(&yes, "yes", "y", false, "Answer yes to all questions and do not prompt")
+
 	return cmd
 }

--- a/cmd/harbor/root/robot/delete.go
+++ b/cmd/harbor/root/robot/delete.go
@@ -19,12 +19,15 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/goharbor/harbor-cli/pkg/views"
 
 	"github.com/spf13/cobra"
 )
 
 // to-do improve DeleteRobotCommand and multi select & delete
 func DeleteRobotCommand() *cobra.Command {
+	var yes bool
+
 	cmd := &cobra.Command{
 		Use:   "delete [robotName]",
 		Short: "delete robot by name",
@@ -55,6 +58,7 @@ Examples:
 			var (
 				robotID int64
 				err     error
+				name    string
 			)
 			if len(args) == 1 {
 				robotName := args[0]
@@ -68,12 +72,26 @@ Examples:
 					}
 				}
 				robotID = robot.ID
+				name = robot.Name
 			} else {
 				robotID, err = prompt.GetRobotIDFromUser(-1)
 				if err != nil {
 					return fmt.Errorf("failed to get robot ID from user: %v", utils.ParseHarborErrorMsg(err))
 				}
+				name = fmt.Sprintf("ID %d", robotID)
 			}
+
+			if !yes {
+				confirm, err := views.ConfirmDeletion(fmt.Sprintf("Are you sure you want to delete robot account '%s'?", name))
+				if err != nil {
+					return err
+				}
+				if !confirm {
+					fmt.Println("Deletion cancelled")
+					return nil
+				}
+			}
+
 			err = api.DeleteRobot(robotID)
 			if err != nil {
 				errorCode := utils.ParseHarborErrorCode(err)
@@ -87,6 +105,9 @@ Examples:
 			return nil
 		},
 	}
+
+	flags := cmd.Flags()
+	flags.BoolVarP(&yes, "yes", "y", false, "Answer yes to all questions and do not prompt")
 
 	return cmd
 }

--- a/pkg/views/confirmation.go
+++ b/pkg/views/confirmation.go
@@ -15,7 +15,6 @@ package views
 
 import (
 	"github.com/charmbracelet/huh"
-	log "github.com/sirupsen/logrus"
 )
 
 func ConfirmElevation() (bool, error) {
@@ -26,9 +25,18 @@ func ConfirmElevation() (bool, error) {
 		Affirmative("Yes").
 		Negative("No").
 		Value(&confirm).Run()
-	if err != nil {
-		log.Fatal(err)
-	}
 
-	return confirm, nil
+	return confirm, err
+}
+
+func ConfirmDeletion(message string) (bool, error) {
+	var confirm bool
+
+	err := huh.NewConfirm().
+		Title(message).
+		Affirmative("Yes").
+		Negative("No").
+		Value(&confirm).Run()
+
+	return confirm, err
 }


### PR DESCRIPTION
  Adds a mandatory confirmation prompt before deleting projects to prevent accidental data loss. This addresses the request in #771 and follows maintainer feedback to use the huh library for a consistent terminal UI. It also includes a skip flag for automated scripts.

   - Fixes #771
 
 ##  Type of Change
   - [x] New feature

  ## Changes
   - Created a reusable ConfirmDeletion view in pkg/views/confirmation.go.
   - Updated harbor project delete to require confirmation for ID-based, name-based, and interactive deletions.
   - Added a --yes / -y flag to the project delete command to bypass prompts in non-interactive environments.
   - Ensured context-aware messages (e.g., specific project name or count of projects) are shown in the prompt.