### PR TITLE
Refactor cron validation

### DIFF
--- a/.dagger/publishimage.go
+++ b/.dagger/publishimage.go
@@ -43,10 +43,10 @@ func (m *HarborCli) PublishImageAndSign(
 		// Generate SBOM (SPDX JSON) for the published image
 		sbom := m.GenerateSBOM(
 			ctx,
-			addr,
-			registryUsername,
+			addr, 
+			registryUsername, 
 			registryPassword,
-		)
+		);
 
 		// Attest SBOM to the image using Cosign in-toto attestation
 		if _, err := m.AttestSBOM(

--- a/.dagger/publishimage.go
+++ b/.dagger/publishimage.go
@@ -43,10 +43,10 @@ func (m *HarborCli) PublishImageAndSign(
 		// Generate SBOM (SPDX JSON) for the published image
 		sbom := m.GenerateSBOM(
 			ctx,
-			addr, 
-			registryUsername, 
+			addr,
+			registryUsername,
 			registryPassword,
-		);
+		)
 
 		// Attest SBOM to the image using Cosign in-toto attestation
 		if _, err := m.AttestSBOM(

--- a/cmd/harbor/root/scan_all/update_schedule.go
+++ b/cmd/harbor/root/scan_all/update_schedule.go
@@ -168,4 +168,3 @@ func updateCustomSchedule(cron string) error {
 	fmt.Printf("Successfully set scan all schedule with custom cron expression\n")
 	return nil
 }
-

--- a/cmd/harbor/root/scan_all/update_schedule.go
+++ b/cmd/harbor/root/scan_all/update_schedule.go
@@ -14,7 +14,6 @@
 package scan_all
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -144,7 +143,7 @@ func updateCustomSchedule(cron string) error {
 		update.UpdateSchedule(&cron)
 	}
 
-	if err := validateCron(cron); err != nil {
+	if err := utils.ValidateCronExpression(cron); err != nil {
 		return err
 	}
 
@@ -161,7 +160,7 @@ func updateCustomSchedule(cron string) error {
 	if err != nil {
 		errMsg := utils.ParseHarborErrorMsg(err)
 		if strings.Contains(errMsg, "400") {
-			return fmt.Errorf("invalid cron expression: Harbor rejected the schedule. Use the standard 5-field format (minute hour day month weekday)")
+			return fmt.Errorf("invalid cron expression: Harbor rejected the schedule. Use the standard 6-field format (seconds minute hour day month weekday)")
 		}
 		return fmt.Errorf("failed to update scan schedule: %v", errMsg)
 	}
@@ -170,20 +169,3 @@ func updateCustomSchedule(cron string) error {
 	return nil
 }
 
-func validateCron(cron string) error {
-	if cron == "" {
-		return errors.New("cron expression cannot be empty")
-	}
-	fields := strings.Fields(cron)
-	if len(fields) < 6 {
-		if len(fields) == 5 {
-			logrus.Debugf("Converting 5-field cron to 6-field by adding '0' for seconds")
-			return fmt.Errorf("harbor requires 6-field cron format (including seconds). Try: '0 %s'", cron)
-		}
-		return fmt.Errorf("harbor requires 6-field cron format (seconds minute hour day month weekday)")
-	}
-	if len(fields) > 6 {
-		return fmt.Errorf("too many fields in cron expression, expected 6 but got %d", len(fields))
-	}
-	return nil
-}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -253,8 +253,6 @@ func RemoveColumns(columns []table.Column, colsToRemove []string) []table.Column
 }
 
 // ValidateCronExpression ensures the provided cron string matches Harbor's 6-field requirements.
-var cronRegex = regexp.MustCompile(`^(\*|[0-9]|[1-5][0-9]|\*/([1-9]|[1-5][0-9])) (\*|[0-9]|[1-5][0-9]|\*/([1-9]|[1-5][0-9])) (\*|[0-9]|1[0-9]|2[0-3]|\*/([1-9]|1[0-9]|2[0-3])) (\*|[1-9]|[12][0-9]|3[01]|\*/([1-9]|[12][0-9]|3[01])) (\*|[1-9]|1[0-2]|\*/([1-9]|1[0-2])) (\*|[0-6]|\*/[1-6])$`)
-
 func ValidateCronExpression(cron string) error {
 	if cron == "" {
 		return errors.New("cron expression cannot be empty")
@@ -267,6 +265,8 @@ func ValidateCronExpression(cron string) error {
 		}
 		return fmt.Errorf("harbor requires exactly 6 fields in cron expressions (seconds minute hour day month weekday), got %d", len(fields))
 	}
+
+	cronRegex := regexp.MustCompile(`^(\*|[0-9]|[1-5][0-9]|\*/([1-9]|[1-5][0-9])) (\*|[0-9]|[1-5][0-9]|\*/([1-9]|[1-5][0-9])) (\*|[0-9]|1[0-9]|2[0-3]|\*/([1-9]|1[0-9]|2[0-3])) (\*|[1-9]|[12][0-9]|3[01]|\*/([1-9]|[12][0-9]|3[01])) (\*|[1-9]|1[0-2]|\*/([1-9]|1[0-2])) (\*|[0-6]|\*/[1-6])$`)
 
 	if !cronRegex.MatchString(cron) {
 		return errors.New("invalid cron expression format\n" +

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -251,3 +251,29 @@ func RemoveColumns(columns []table.Column, colsToRemove []string) []table.Column
 
 	return filteredColumns
 }
+
+// ValidateCronExpression ensures the provided cron string matches Harbor's 6-field requirements.
+var cronRegex = regexp.MustCompile(`^(\*|[0-9]|[1-5][0-9]|\*/([1-9]|[1-5][0-9])) (\*|[0-9]|[1-5][0-9]|\*/([1-9]|[1-5][0-9])) (\*|[0-9]|1[0-9]|2[0-3]|\*/([1-9]|1[0-9]|2[0-3])) (\*|[1-9]|[12][0-9]|3[01]|\*/([1-9]|[12][0-9]|3[01])) (\*|[1-9]|1[0-2]|\*/([1-9]|1[0-2])) (\*|[0-6]|\*/[1-6])$`)
+
+func ValidateCronExpression(cron string) error {
+	if cron == "" {
+		return errors.New("cron expression cannot be empty")
+	}
+	fields := strings.Fields(cron)
+	if len(fields) != 6 {
+		if len(fields) == 5 {
+			return fmt.Errorf("you entered a 5-field cron expression, but Harbor requires 6 fields (with seconds)\n"+
+				"Please add a seconds field at the beginning. For example: '0 %s'", cron)
+		}
+		return fmt.Errorf("harbor requires exactly 6 fields in cron expressions (seconds minute hour day month weekday), got %d", len(fields))
+	}
+
+	if !cronRegex.MatchString(cron) {
+		return errors.New("invalid cron expression format\n" +
+			"Examples:\n" +
+			"  0 0 0 * * *    - Daily at midnight\n" +
+			"  0 0 */6 * * *  - Every 6 hours\n" +
+			"  0 0 0 * * 0    - Weekly on Sunday at midnight")
+	}
+	return nil
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -252,6 +252,8 @@ func RemoveColumns(columns []table.Column, colsToRemove []string) []table.Column
 	return filteredColumns
 }
 
+var cronExpressionRegex = regexp.MustCompile(`^(\*|[0-9]|[1-5][0-9]|\*/([1-9]|[1-5][0-9])) (\*|[0-9]|[1-5][0-9]|\*/([1-9]|[1-5][0-9])) (\*|[0-9]|1[0-9]|2[0-3]|\*/([1-9]|1[0-9]|2[0-3])) (\*|[1-9]|[12][0-9]|3[01]|\*/([1-9]|[12][0-9]|3[01])) (\*|[1-9]|1[0-2]|\*/([1-9]|1[0-2])) (\*|[0-6]|\*/[1-6])$`)
+
 // ValidateCronExpression ensures the provided cron string matches Harbor's 6-field requirements.
 func ValidateCronExpression(cron string) error {
 	if cron == "" {
@@ -263,12 +265,11 @@ func ValidateCronExpression(cron string) error {
 			return fmt.Errorf("you entered a 5-field cron expression, but Harbor requires 6 fields (with seconds)\n"+
 				"Please add a seconds field at the beginning. For example: '0 %s'", cron)
 		}
-		return fmt.Errorf("harbor requires exactly 6 fields in cron expressions (seconds minute hour day month weekday), got %d", len(fields))
+		return fmt.Errorf("harbor requires exactly 6 fields in cron expressions (seconds minute hour day-of-month month day-of-week), got %d", len(fields))
 	}
 
-	cronRegex := regexp.MustCompile(`^(\*|[0-9]|[1-5][0-9]|\*/([1-9]|[1-5][0-9])) (\*|[0-9]|[1-5][0-9]|\*/([1-9]|[1-5][0-9])) (\*|[0-9]|1[0-9]|2[0-3]|\*/([1-9]|1[0-9]|2[0-3])) (\*|[1-9]|[12][0-9]|3[01]|\*/([1-9]|[12][0-9]|3[01])) (\*|[1-9]|1[0-2]|\*/([1-9]|1[0-2])) (\*|[0-6]|\*/[1-6])$`)
-
-	if !cronRegex.MatchString(cron) {
+	normalizedCron := strings.Join(fields, " ")
+	if !cronExpressionRegex.MatchString(normalizedCron) {
 		return errors.New("invalid cron expression format\n" +
 			"Examples:\n" +
 			"  0 0 0 * * *    - Daily at midnight\n" +

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -145,3 +145,34 @@ func TestStorageStringToBytes(t *testing.T) {
 	_, err := utils.StorageStringToBytes("1025TiB")
 	assert.Error(t, err, "Expected error for input exceeding 1024TiB but got none")
 }
+
+func TestValidateCronExpression(t *testing.T) {
+	tests := []struct {
+		name    string
+		cron    string
+		wantErr bool
+	}{
+		{"Empty string", "", true},
+		{"5 fields (missing seconds)", "0 0 * * *", true},
+		{"7 fields (too many)", "0 0 0 * * * *", true},
+		{"Valid daily midnight", "0 0 0 * * *", false},
+		{"Valid every 6 hours", "0 0 */6 * * *", false},
+		{"Valid weekly Sunday", "0 0 0 * * 0", false},
+		{"Invalid character", "0 0 A * * *", true},
+		{"Invalid step 0", "0 0 */0 * * *", true},
+		{"Invalid second > 59", "60 0 0 * * *", true},
+		{"Invalid minute > 59", "0 60 0 * * *", true},
+		{"Invalid hour > 23", "0 0 24 * * *", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := utils.ValidateCronExpression(tt.cron)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/views/scan-all/update/view.go
+++ b/pkg/views/scan-all/update/view.go
@@ -14,12 +14,8 @@
 package update
 
 import (
-	"errors"
-	"fmt"
-	"regexp"
-	"strings"
-
 	"github.com/charmbracelet/huh"
+	"github.com/goharbor/harbor-cli/pkg/utils"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -32,7 +28,7 @@ func UpdateSchedule(cron *string) {
 				Description("Standard 6-field cron format: second minute hour day-of-month month day-of-week").
 				Placeholder("0 0 0 * * *"). // Daily at midnight with seconds
 				Value(cron).
-				Validate(validateCronExpression),
+				Validate(utils.ValidateCronExpression),
 		),
 	).WithTheme(theme).Run()
 
@@ -41,25 +37,3 @@ func UpdateSchedule(cron *string) {
 	}
 }
 
-func validateCronExpression(cron string) error {
-	if cron == "" {
-		return errors.New("cron expression cannot be empty")
-	}
-	fields := strings.Fields(cron)
-	if len(fields) != 6 {
-		if len(fields) == 5 {
-			return fmt.Errorf("you entered a 5-field cron expression, but Harbor requires 6 fields (with seconds)\n"+
-				"Please add a seconds field at the beginning. For example: '0 %s'", cron)
-		}
-		return fmt.Errorf("harbor requires exactly 6 fields in cron expressions (seconds minute hour day month weekday), got %d", len(fields))
-	}
-	cronRegex := regexp.MustCompile(`^(\*|[0-9]|[1-5][0-9]|\*/[0-9]+) (\*|[0-9]|[1-5][0-9]|\*/[0-9]+) (\*|[0-9]|1[0-9]|2[0-3]|\*/[0-9]+) (\*|[1-9]|[12][0-9]|3[01]|\*/[0-9]+) (\*|[1-9]|1[0-2]|\*/[0-9]+) (\*|[0-6]|\*/[0-9]+)$`)
-	if !cronRegex.MatchString(cron) {
-		return errors.New("invalid cron expression format\n" +
-			"Examples:\n" +
-			"  0 0 0 * * *    - Daily at midnight\n" +
-			"  0 0 */6 * * *  - Every 6 hours\n" +
-			"  0 0 0 * * 0    - Weekly on Sunday at midnight")
-	}
-	return nil
-}

--- a/pkg/views/scan-all/update/view.go
+++ b/pkg/views/scan-all/update/view.go
@@ -36,4 +36,3 @@ func UpdateSchedule(cron *string) {
 		log.Fatal(err)
 	}
 }
-


### PR DESCRIPTION
## Description
This PR centralizes the cron expression validation logic for the Harbor CLI to ensure consistent behavior across both the interactive UI views and the command-line flags.

Previously, pkg/views/scan-all/update/view.go used a strict regex validation, while cmd/harbor/root/scan_all/update_schedule.go only checked the number of fields. By centralizing this into the utils package, we remove code duplication and ensure standard Harbor cron requirements are strictly enforced everywhere.

- Fixes #863

## Type of Change
Please select the relevant type.

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
- Created ValidateCronExpression in pkg/utils/utils.go to act as the single source of truth for Harbor cron validation.
- Refactored pkg/views/scan-all/update/view.go to use the new centralized utility and removed unused packages (errors, fmt, regexp, strings) to keep the build clean.
- Refactored cmd/harbor/root/scan_all/update_schedule.go to use the centralized utility, removing the weaker local validation function.
