### PR TITLE
fix: return errors instead of panicking in list command

### DIFF
--- a/cmd/harbor/root/project/robot/list.go
+++ b/cmd/harbor/root/project/robot/list.go
@@ -83,7 +83,10 @@ Examples:
 			if len(args) > 0 {
 				project, err := api.GetProject(args[0], false)
 				if err != nil {
-					log.Errorf("Invalid Project Name: %v", err)
+					return fmt.Errorf("failed to get project by name %s: %v", args[0], utils.ParseHarborErrorMsg(err))
+				}
+				if project == nil || project.Payload == nil {
+					return fmt.Errorf("failed to get project by name %s: empty project response", args[0])
 				}
 				opts.ProjectID = int64(project.Payload.ProjectID)
 				opts.Q = projectQString + strconv.FormatInt(opts.ProjectID, 10)
@@ -101,7 +104,7 @@ Examples:
 
 			robots, err := api.ListRobot(opts)
 			if err != nil {
-				log.Errorf("failed to get robots list: %v", err)
+				return fmt.Errorf("failed to get robots list: %v", utils.ParseHarborErrorMsg(err))
 			}
 
 			formatFlag := viper.GetString("output-format")


### PR DESCRIPTION
## Description
This PR fixes a panic in the harbor project robot list command where errors from API calls were logged but execution continued, leading to a nil pointer dereference.

Specifically
- api.GetProject() errors were logged but project.Payload was still accessed
- api.ListRobot() errors were logged but robots.Payload was still used

Fixes #862 

## Type of Change
Please select the relevant type.

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
- Return error on api.GetProject() failure instead of continuing execution
- Added nil check for project.Payload before accessing ProjectID
- Return error on api.ListRobot() failure instead of continuing execution
- Ensured CLI exits gracefully with a proper error message instead of panicking

## Verification
Command: 
```bash
env XDG_CONFIG_HOME=/tmp/harbor-cli-verify/config XDG_DATA_HOME=/tmp/harbor-cli-verify/data ./bin/harbor-cli project robot list does-not-exist
```

observed(before fix):

<img width="1115" height="495" alt="Screenshot From 2026-05-03 11-20-32" src="https://github.com/user-attachments/assets/6b63d860-bd7b-4bfb-99c4-7aecb3f349bd" />

---

(After fix): 

<img width="1345" height="85" alt="Screenshot From 2026-05-04 00-57-17" src="https://github.com/user-attachments/assets/fbdda62a-addd-40a8-82b5-c3b1593ad673" />



