### PR TITLE
Feat : implements the `harbor project summary` command

### DIFF
--- a/.dagger/publishimage.go
+++ b/.dagger/publishimage.go
@@ -43,10 +43,10 @@ func (m *HarborCli) PublishImageAndSign(
 		// Generate SBOM (SPDX JSON) for the published image
 		sbom := m.GenerateSBOM(
 			ctx,
-			addr, 
-			registryUsername, 
+			addr,
+			registryUsername,
 			registryPassword,
-		);
+		)
 
 		// Attest SBOM to the image using Cosign in-toto attestation
 		if _, err := m.AttestSBOM(

--- a/cmd/harbor/root/project/cmd.go
+++ b/cmd/harbor/root/project/cmd.go
@@ -29,6 +29,7 @@ func Project() *cobra.Command {
 		CreateProjectCommand(),
 		DeleteProjectCommand(),
 		ListProjectCommand(),
+		SummaryCommand(),
 		ViewCommand(),
 		LogsProjectCommmand(),
 		config.ProjectConfigCommand(),

--- a/cmd/harbor/root/project/summary.go
+++ b/cmd/harbor/root/project/summary.go
@@ -1,0 +1,102 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package project
+
+import (
+	"fmt"
+
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/prompt"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/goharbor/harbor-cli/pkg/views/project/summary"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var getProjectSummaryFunc = api.GetProjectSummary
+
+func SummaryCommand() *cobra.Command {
+	var isID bool
+	cmd := &cobra.Command{
+		Use:   "summary [PROJECT_NAME|PROJECT_ID]",
+		Short: "Get summary of a project",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var projectName string
+			var err error
+
+			if len(args) > 0 {
+				projectName = args[0]
+			} else {
+				projectName, err = prompt.GetProjectNameFromUser()
+				if err != nil {
+					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
+				}
+			}
+
+			log.Debugf("Fetching project metadata: %s", projectName)
+			projectData, err := api.GetProject(projectName, isID)
+			if err != nil {
+				return fmt.Errorf("failed to get project details: %v", utils.ParseHarborErrorMsg(err))
+			}
+
+			log.Debugf("Fetching project summary: %s", projectName)
+			projectSummary, err := getProjectSummaryFunc(projectName, isID)
+			if err != nil {
+				if utils.ParseHarborErrorCode(err) == "404" {
+					return fmt.Errorf("project %s does not exist", projectName)
+				}
+				return fmt.Errorf("failed to get project summary: %v", utils.ParseHarborErrorMsg(err))
+			}
+
+			FormatFlag := viper.GetString("output-format")
+			if FormatFlag != "" {
+				log.WithField("output_format", FormatFlag).Debug("Output format selected")
+				if FormatFlag == "csv" {
+					type combinedCSV struct {
+						Project *models.Project        `json:"project" csv:"project"`
+						Summary *models.ProjectSummary `json:"summary" csv:"summary"`
+					}
+					combined := []combinedCSV{{
+						Project: projectData.Payload,
+						Summary: projectSummary.Payload,
+					}}
+					err = utils.PrintFormat(combined, FormatFlag)
+				} else {
+					combined := map[string]interface{}{
+						"project": projectData.Payload,
+						"summary": projectSummary.Payload,
+					}
+					err = utils.PrintFormat(combined, FormatFlag)
+				}
+				if err != nil {
+					return err
+				}
+			} else {
+				log.Debug("Showing project summary using default view")
+				err = summary.ViewProjectSummary(projectData.Payload, projectSummary.Payload)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVarP(&isID, "id", "i", false, "Identify project by ID instead of name")
+
+	return cmd
+}

--- a/cmd/harbor/root/project/summary.go
+++ b/cmd/harbor/root/project/summary.go
@@ -50,16 +50,13 @@ func SummaryCommand() *cobra.Command {
 			log.Debugf("Fetching project metadata: %s", projectName)
 			projectData, err := api.GetProject(projectName, isID)
 			if err != nil {
-				return fmt.Errorf("failed to get project details: %v", utils.ParseHarborErrorMsg(err))
+				return handleProjectError(err, projectName, "get details of")
 			}
 
 			log.Debugf("Fetching project summary: %s", projectName)
 			projectSummary, err := getProjectSummaryFunc(projectName, isID)
 			if err != nil {
-				if utils.ParseHarborErrorCode(err) == "404" {
-					return fmt.Errorf("project %s does not exist", projectName)
-				}
-				return fmt.Errorf("failed to get project summary: %v", utils.ParseHarborErrorMsg(err))
+				return handleProjectError(err, projectName, "get summary of")
 			}
 
 			FormatFlag := viper.GetString("output-format")
@@ -99,4 +96,20 @@ func SummaryCommand() *cobra.Command {
 	cmd.Flags().BoolVarP(&isID, "id", "i", false, "Identify project by ID instead of name")
 
 	return cmd
+}
+
+func handleProjectError(err error, name string, action string) error {
+	errorCode := utils.ParseHarborErrorCode(err)
+	switch errorCode {
+	case "401":
+		return fmt.Errorf("unauthorized: please login to Harbor")
+	case "403":
+		return fmt.Errorf("forbidden: you do not have permission to %s project %s", action, name)
+	case "404":
+		return fmt.Errorf("project %s does not exist", name)
+	case "500":
+		return fmt.Errorf("internal server error: please contact your administrator")
+	default:
+		return fmt.Errorf("failed to %s project %s: %v", action, name, utils.ParseHarborErrorMsg(err))
+	}
 }

--- a/cmd/harbor/root/project/summary.go
+++ b/cmd/harbor/root/project/summary.go
@@ -89,4 +89,3 @@ func SummaryCommand() *cobra.Command {
 
 	return cmd
 }
-

--- a/cmd/harbor/root/project/summary.go
+++ b/cmd/harbor/root/project/summary.go
@@ -16,24 +16,24 @@ package project
 import (
 	"fmt"
 
-	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/project/summary"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
-var getProjectSummaryFunc = api.GetProjectSummary
-
+// SummaryCommand creates a new harbor project summary command
 func SummaryCommand() *cobra.Command {
 	var isID bool
 	cmd := &cobra.Command{
-		Use:   "summary [PROJECT_NAME|PROJECT_ID]",
-		Short: "Get summary of a project",
-		Args:  cobra.MaximumNArgs(1),
+		Use:     "summary [NAME|ID]",
+		Short:   "Get summary of a project",
+		Long:    "Get summary of a project by name or ID. If no arguments are provided, it will prompt for the project name. Use --id to specify the project ID instead of the name.",
+		Example: "harbor project summary my-project or harbor project summary 1 --id",
+		Args:    cobra.MaximumNArgs(1),
+
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var projectName string
 			var err error
@@ -47,69 +47,46 @@ func SummaryCommand() *cobra.Command {
 				}
 			}
 
-			log.Debugf("Fetching project metadata: %s", projectName)
 			projectData, err := api.GetProject(projectName, isID)
 			if err != nil {
-				return handleProjectError(err, projectName, "get details of")
+				if utils.ParseHarborErrorCode(err) == "404" {
+					return fmt.Errorf("project %s does not exist", projectName)
+				}
+				return fmt.Errorf("failed to get project details: %v", utils.ParseHarborErrorMsg(err))
 			}
 
-			log.Debugf("Fetching project summary: %s", projectName)
-			projectSummary, err := getProjectSummaryFunc(projectName, isID)
+			projectSummary, err := api.GetProjectSummary(projectName, isID)
 			if err != nil {
-				return handleProjectError(err, projectName, "get summary of")
+				if utils.ParseHarborErrorCode(err) == "404" {
+					return fmt.Errorf("project %s does not exist", projectName)
+				}
+				return fmt.Errorf("failed to get project summary: %v", utils.ParseHarborErrorMsg(err))
 			}
 
 			FormatFlag := viper.GetString("output-format")
 			if FormatFlag != "" {
-				log.WithField("output_format", FormatFlag).Debug("Output format selected")
-				if FormatFlag == "csv" {
-					type combinedCSV struct {
-						Project *models.Project        `json:"project" csv:"project"`
-						Summary *models.ProjectSummary `json:"summary" csv:"summary"`
-					}
-					combined := []combinedCSV{{
-						Project: projectData.Payload,
-						Summary: projectSummary.Payload,
-					}}
-					err = utils.PrintFormat(combined, FormatFlag)
-				} else {
-					combined := map[string]interface{}{
-						"project": projectData.Payload,
-						"summary": projectSummary.Payload,
-					}
-					err = utils.PrintFormat(combined, FormatFlag)
+				combined := map[string]interface{}{
+					"project": projectData.Payload,
+					"summary": projectSummary.Payload,
 				}
+				err = utils.PrintFormat(combined, FormatFlag)
 				if err != nil {
 					return err
 				}
 			} else {
-				log.Debug("Showing project summary using default view")
 				err = summary.ViewProjectSummary(projectData.Payload, projectSummary.Payload)
 				if err != nil {
 					return err
 				}
 			}
+
 			return nil
 		},
 	}
 
-	cmd.Flags().BoolVarP(&isID, "id", "i", false, "Identify project by ID instead of name")
+	flags := cmd.Flags()
+	flags.BoolVar(&isID, "id", false, "Get project by id")
 
 	return cmd
 }
 
-func handleProjectError(err error, name string, action string) error {
-	errorCode := utils.ParseHarborErrorCode(err)
-	switch errorCode {
-	case "401":
-		return fmt.Errorf("unauthorized: please login to Harbor")
-	case "403":
-		return fmt.Errorf("forbidden: you do not have permission to %s project %s", action, name)
-	case "404":
-		return fmt.Errorf("project %s does not exist", name)
-	case "500":
-		return fmt.Errorf("internal server error: please contact your administrator")
-	default:
-		return fmt.Errorf("failed to %s project %s: %v", action, name, utils.ParseHarborErrorMsg(err))
-	}
-}

--- a/cmd/harbor/root/project/summary_test.go
+++ b/cmd/harbor/root/project/summary_test.go
@@ -1,0 +1,108 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package project
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/project"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSummaryCommand_Success(t *testing.T) {
+	originalFunc := getProjectSummaryFunc
+	defer func() { getProjectSummaryFunc = originalFunc }()
+
+	getProjectSummaryFunc = func(projectNameOrID string, useProjectID bool) (*project.GetProjectSummaryOK, error) {
+		return &project.GetProjectSummaryOK{
+			Payload: &models.ProjectSummary{
+				RepoCount:         1,
+				ProjectAdminCount: 1,
+				Quota: &models.ProjectSummaryQuota{
+					Hard: models.ResourceList{"storage": 1024 * 1024 * 1024},
+					Used: models.ResourceList{"storage": 512},
+				},
+				Registry: &models.Registry{
+					Name:   "test-registry",
+					URL:    "https://registry.test",
+					Type:   "docker-hub",
+					Status: "healthy",
+				},
+			},
+		}, nil
+	}
+
+	cmd := SummaryCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"test-project"})
+
+	err := cmd.Execute()
+	assert.NoError(t, err)
+}
+
+func TestSummaryCommand_Errors(t *testing.T) {
+	tests := []struct {
+		name          string
+		mockErr       error
+		expectedError string
+	}{
+		{
+			name:          "404 Not Found",
+			mockErr:       fmt.Errorf("[GET /projects/{project_name}/summary][404] getProjectSummaryNotFound"),
+			expectedError: "project test-project does not exist",
+		},
+		{
+			name:          "401 Unauthorized",
+			mockErr:       fmt.Errorf("[GET /projects/{project_name}/summary][401] getProjectSummaryUnauthorized"),
+			expectedError: "failed to get project summary",
+		},
+		{
+			name:          "403 Forbidden",
+			mockErr:       fmt.Errorf("[GET /projects/{project_name}/summary][403] getProjectSummaryForbidden"),
+			expectedError: "failed to get project summary",
+		},
+		{
+			name:          "Connection Refused",
+			mockErr:       errors.New("connection refused"),
+			expectedError: "failed to get project summary: connection refused",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalFunc := getProjectSummaryFunc
+			defer func() { getProjectSummaryFunc = originalFunc }()
+
+			getProjectSummaryFunc = func(projectNameOrID string, useProjectID bool) (*project.GetProjectSummaryOK, error) {
+				return nil, tt.mockErr
+			}
+
+			cmd := SummaryCommand()
+			var buf bytes.Buffer
+			cmd.SetOut(&buf)
+			cmd.SetErr(&buf)
+			cmd.SetArgs([]string{"test-project"})
+
+			err := cmd.Execute()
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedError)
+		})
+	}
+}

--- a/cmd/harbor/root/project/summary_test.go
+++ b/cmd/harbor/root/project/summary_test.go
@@ -42,8 +42,6 @@ func TestSummaryCommand_ValidArgs(t *testing.T) {
 
 	err := cmd.Execute()
 	assert.Error(t, err)
-	// It should fail with a connection error or unauthorized, as no real Harbor instance is running.
-	// We are just testing that the inputs were accepted by Cobra.
 }
 
 func TestSummaryCommand_Flags(t *testing.T) {
@@ -55,7 +53,5 @@ func TestSummaryCommand_Flags(t *testing.T) {
 
 	err := cmd.Execute()
 	assert.Error(t, err)
-	// It should fail with a connection error or unauthorized, as no real Harbor instance is running.
-	// We are just testing that the flags were parsed without error by Cobra.
 }
 

--- a/cmd/harbor/root/project/summary_test.go
+++ b/cmd/harbor/root/project/summary_test.go
@@ -15,38 +15,25 @@ package project
 
 import (
 	"bytes"
-	"errors"
-	"fmt"
 	"testing"
 
-	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/project"
-	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/stretchr/testify/assert"
+
 )
 
-func TestSummaryCommand_Success(t *testing.T) {
-	originalFunc := getProjectSummaryFunc
-	defer func() { getProjectSummaryFunc = originalFunc }()
+func TestSummaryCommand_InvalidArgs(t *testing.T) {
+	cmd := SummaryCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"arg1", "arg2"})
 
-	getProjectSummaryFunc = func(projectNameOrID string, useProjectID bool) (*project.GetProjectSummaryOK, error) {
-		return &project.GetProjectSummaryOK{
-			Payload: &models.ProjectSummary{
-				RepoCount:         1,
-				ProjectAdminCount: 1,
-				Quota: &models.ProjectSummaryQuota{
-					Hard: models.ResourceList{"storage": 1024 * 1024 * 1024},
-					Used: models.ResourceList{"storage": 512},
-				},
-				Registry: &models.Registry{
-					Name:   "test-registry",
-					URL:    "https://registry.test",
-					Type:   "docker-hub",
-					Status: "healthy",
-				},
-			},
-		}, nil
-	}
+	err := cmd.Execute()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "accepts at most 1 arg(s), received 2")
+}
 
+func TestSummaryCommand_ValidArgs(t *testing.T) {
 	cmd := SummaryCommand()
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
@@ -54,55 +41,21 @@ func TestSummaryCommand_Success(t *testing.T) {
 	cmd.SetArgs([]string{"test-project"})
 
 	err := cmd.Execute()
-	assert.NoError(t, err)
+	assert.Error(t, err)
+	// It should fail with a connection error or unauthorized, as no real Harbor instance is running.
+	// We are just testing that the inputs were accepted by Cobra.
 }
 
-func TestSummaryCommand_Errors(t *testing.T) {
-	tests := []struct {
-		name          string
-		mockErr       error
-		expectedError string
-	}{
-		{
-			name:          "404 Not Found",
-			mockErr:       fmt.Errorf("[GET /projects/{project_name}/summary][404] getProjectSummaryNotFound"),
-			expectedError: "project test-project does not exist",
-		},
-		{
-			name:          "401 Unauthorized",
-			mockErr:       fmt.Errorf("[GET /projects/{project_name}/summary][401] getProjectSummaryUnauthorized"),
-			expectedError: "failed to get project summary",
-		},
-		{
-			name:          "403 Forbidden",
-			mockErr:       fmt.Errorf("[GET /projects/{project_name}/summary][403] getProjectSummaryForbidden"),
-			expectedError: "failed to get project summary",
-		},
-		{
-			name:          "Connection Refused",
-			mockErr:       errors.New("connection refused"),
-			expectedError: "failed to get project summary: connection refused",
-		},
-	}
+func TestSummaryCommand_Flags(t *testing.T) {
+	cmd := SummaryCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"1", "--id"})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			originalFunc := getProjectSummaryFunc
-			defer func() { getProjectSummaryFunc = originalFunc }()
-
-			getProjectSummaryFunc = func(projectNameOrID string, useProjectID bool) (*project.GetProjectSummaryOK, error) {
-				return nil, tt.mockErr
-			}
-
-			cmd := SummaryCommand()
-			var buf bytes.Buffer
-			cmd.SetOut(&buf)
-			cmd.SetErr(&buf)
-			cmd.SetArgs([]string{"test-project"})
-
-			err := cmd.Execute()
-			assert.Error(t, err)
-			assert.Contains(t, err.Error(), tt.expectedError)
-		})
-	}
+	err := cmd.Execute()
+	assert.Error(t, err)
+	// It should fail with a connection error or unauthorized, as no real Harbor instance is running.
+	// We are just testing that the flags were parsed without error by Cobra.
 }
+

--- a/cmd/harbor/root/project/summary_test.go
+++ b/cmd/harbor/root/project/summary_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
 )
 
 func TestSummaryCommand_InvalidArgs(t *testing.T) {
@@ -54,4 +53,3 @@ func TestSummaryCommand_Flags(t *testing.T) {
 	err := cmd.Execute()
 	assert.Error(t, err)
 }
-

--- a/doc/cli-docs/harbor-project-summary.md
+++ b/doc/cli-docs/harbor-project-summary.md
@@ -8,15 +8,25 @@ weight: 15
 
 ##### Get summary of a project
 
+### Synopsis
+
+Get summary of a project by name or ID. If no arguments are provided, it will prompt for the project name. Use --id to specify the project ID instead of the name.
+
 ```sh
-harbor project summary [PROJECT_NAME|PROJECT_ID] [flags]
+harbor project summary [NAME|ID] [flags]
+```
+
+### Examples
+
+```sh
+harbor project summary my-project or harbor project summary 1 --id
 ```
 
 ### Options
 
 ```sh
   -h, --help   help for summary
-  -i, --id     Identify project by ID instead of name
+      --id     Get project by id
 ```
 
 ### Options inherited from parent commands

--- a/doc/cli-docs/harbor-project-summary.md
+++ b/doc/cli-docs/harbor-project-summary.md
@@ -1,0 +1,33 @@
+---
+title: harbor project summary
+weight: 15
+---
+## harbor project summary
+
+### Description
+
+##### Get summary of a project
+
+```sh
+harbor project summary [PROJECT_NAME|PROJECT_ID] [flags]
+```
+
+### Options
+
+```sh
+  -h, --help   help for summary
+  -i, --id     Identify project by ID instead of name
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml|csv
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor project](harbor-project.md)	 - Manage projects and assign resources to them
+

--- a/doc/cli-docs/harbor-project.md
+++ b/doc/cli-docs/harbor-project.md
@@ -43,5 +43,6 @@ Manage projects in Harbor
 * [harbor project member](harbor-project-member.md)	 - Manage members in a Project
 * [harbor project robot](harbor-project-robot.md)	 - Manage robot accounts
 * [harbor project search](harbor-project-search.md)	 - search project based on their names
+* [harbor project summary](harbor-project-summary.md)	 - Get summary of a project
 * [harbor project view](harbor-project-view.md)	 - get project by name or id
 

--- a/doc/cli-docs/harbor-project.md
+++ b/doc/cli-docs/harbor-project.md
@@ -44,5 +44,6 @@ Manage projects in Harbor
 * [harbor project preheat](harbor-project-preheat.md)	 - Manage project preheat resources
 * [harbor project robot](harbor-project-robot.md)	 - Manage robot accounts
 * [harbor project search](harbor-project-search.md)	 - search project based on their names
+* [harbor project summary](harbor-project-summary.md)	 - Get summary of a project
 * [harbor project view](harbor-project-view.md)	 - get project by name or id
 

--- a/doc/man-docs/man1/harbor-project-summary.1
+++ b/doc/man-docs/man1/harbor-project-summary.1
@@ -6,11 +6,11 @@ harbor-project-summary - Get summary of a project
 
 
 .SH SYNOPSIS
-\fBharbor project summary [PROJECT_NAME|PROJECT_ID] [flags]\fP
+\fBharbor project summary [NAME|ID] [flags]\fP
 
 
 .SH DESCRIPTION
-Get summary of a project
+Get summary of a project by name or ID. If no arguments are provided, it will prompt for the project name. Use --id to specify the project ID instead of the name.
 
 
 .SH OPTIONS
@@ -18,8 +18,8 @@ Get summary of a project
 	help for summary
 
 .PP
-\fB-i\fP, \fB--id\fP[=false]
-	Identify project by ID instead of name
+\fB--id\fP[=false]
+	Get project by id
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
@@ -33,6 +33,12 @@ Get summary of a project
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]
 	verbose output
+
+
+.SH EXAMPLE
+.EX
+harbor project summary my-project or harbor project summary 1 --id
+.EE
 
 
 .SH SEE ALSO

--- a/doc/man-docs/man1/harbor-project-summary.1
+++ b/doc/man-docs/man1/harbor-project-summary.1
@@ -1,0 +1,39 @@
+.nh
+.TH "HARBOR" "1"  "Harbor Community" "Harbor User Manuals"
+
+.SH NAME
+harbor-project-summary - Get summary of a project
+
+
+.SH SYNOPSIS
+\fBharbor project summary [PROJECT_NAME|PROJECT_ID] [flags]\fP
+
+
+.SH DESCRIPTION
+Get summary of a project
+
+
+.SH OPTIONS
+\fB-h\fP, \fB--help\fP[=false]
+	help for summary
+
+.PP
+\fB-i\fP, \fB--id\fP[=false]
+	Identify project by ID instead of name
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+\fB-c\fP, \fB--config\fP=""
+	config file (default is $HOME/.config/harbor-cli/config.yaml)
+
+.PP
+\fB-o\fP, \fB--output-format\fP=""
+	Output format. One of: json|yaml|csv
+
+.PP
+\fB-v\fP, \fB--verbose\fP[=false]
+	verbose output
+
+
+.SH SEE ALSO
+\fBharbor-project(1)\fP

--- a/doc/man-docs/man1/harbor-project.1
+++ b/doc/man-docs/man1/harbor-project.1
@@ -38,4 +38,4 @@ Manage projects in Harbor
 
 
 .SH SEE ALSO
-\fBharbor(1)\fP, \fBharbor-project-config(1)\fP, \fBharbor-project-create(1)\fP, \fBharbor-project-delete(1)\fP, \fBharbor-project-list(1)\fP, \fBharbor-project-logs(1)\fP, \fBharbor-project-member(1)\fP, \fBharbor-project-preheat(1)\fP, \fBharbor-project-robot(1)\fP, \fBharbor-project-search(1)\fP, \fBharbor-project-view(1)\fP
+\fBharbor(1)\fP, \fBharbor-project-config(1)\fP, \fBharbor-project-create(1)\fP, \fBharbor-project-delete(1)\fP, \fBharbor-project-list(1)\fP, \fBharbor-project-logs(1)\fP, \fBharbor-project-member(1)\fP, \fBharbor-project-robot(1)\fP, \fBharbor-project-search(1)\fP, \fBharbor-project-summary(1)\fP, \fBharbor-project-view(1)\fP

--- a/doc/man-docs/man1/harbor-project.1
+++ b/doc/man-docs/man1/harbor-project.1
@@ -38,4 +38,4 @@ Manage projects in Harbor
 
 
 .SH SEE ALSO
-\fBharbor(1)\fP, \fBharbor-project-config(1)\fP, \fBharbor-project-create(1)\fP, \fBharbor-project-delete(1)\fP, \fBharbor-project-list(1)\fP, \fBharbor-project-logs(1)\fP, \fBharbor-project-member(1)\fP, \fBharbor-project-robot(1)\fP, \fBharbor-project-search(1)\fP, \fBharbor-project-view(1)\fP
+\fBharbor(1)\fP, \fBharbor-project-config(1)\fP, \fBharbor-project-create(1)\fP, \fBharbor-project-delete(1)\fP, \fBharbor-project-list(1)\fP, \fBharbor-project-logs(1)\fP, \fBharbor-project-member(1)\fP, \fBharbor-project-robot(1)\fP, \fBharbor-project-search(1)\fP, \fBharbor-project-summary(1)\fP, \fBharbor-project-view(1)\fP

--- a/doc/man-docs/man1/harbor-project.1
+++ b/doc/man-docs/man1/harbor-project.1
@@ -38,4 +38,4 @@ Manage projects in Harbor
 
 
 .SH SEE ALSO
-\fBharbor(1)\fP, \fBharbor-project-config(1)\fP, \fBharbor-project-create(1)\fP, \fBharbor-project-delete(1)\fP, \fBharbor-project-list(1)\fP, \fBharbor-project-logs(1)\fP, \fBharbor-project-member(1)\fP, \fBharbor-project-robot(1)\fP, \fBharbor-project-search(1)\fP, \fBharbor-project-summary(1)\fP, \fBharbor-project-view(1)\fP
+\fBharbor(1)\fP, \fBharbor-project-config(1)\fP, \fBharbor-project-create(1)\fP, \fBharbor-project-delete(1)\fP, \fBharbor-project-list(1)\fP, \fBharbor-project-logs(1)\fP, \fBharbor-project-member(1)\fP, \fBharbor-project-preheat(1)\fP, \fBharbor-project-robot(1)\fP, \fBharbor-project-search(1)\fP, \fBharbor-project-summary(1)\fP, \fBharbor-project-view(1)\fP

--- a/pkg/api/project_handler.go
+++ b/pkg/api/project_handler.go
@@ -213,3 +213,21 @@ func LogsProject(projectName string, opts ...ListFlags) (*project.GetLogExtsOK, 
 
 	return response, nil
 }
+
+func GetProjectSummary(projectNameOrID string, useProjectID bool) (*project.GetProjectSummaryOK, error) {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return nil, err
+	}
+	useResourceName := !useProjectID
+
+	response, err := client.Project.GetProjectSummary(ctx, &project.GetProjectSummaryParams{
+		ProjectNameOrID: projectNameOrID,
+		XIsResourceName: &useResourceName,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/project_handler.go
+++ b/pkg/api/project_handler.go
@@ -212,3 +212,21 @@ func LogsProject(projectName string, opts ...ListFlags) (*project.GetLogExtsOK, 
 
 	return response, nil
 }
+
+func GetProjectSummary(projectNameOrID string, useProjectID bool) (*project.GetProjectSummaryOK, error) {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return nil, err
+	}
+	useResourceName := !useProjectID
+
+	response, err := client.Project.GetProjectSummary(ctx, &project.GetProjectSummaryParams{
+		ProjectNameOrID: projectNameOrID,
+		XIsResourceName: &useResourceName,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}

--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -65,6 +65,9 @@ func FormatUrl(url string) string {
 }
 
 func FormatSize(size int64) string {
+	if size < 0 {
+		return "Unlimited"
+	}
 	const (
 		_         = iota
 		KiB int64 = 1 << (10 * iota)
@@ -85,6 +88,13 @@ func FormatSize(size int64) string {
 	default:
 		return fmt.Sprintf("%dB", size)
 	}
+}
+
+func FormatCount(count int64) string {
+	if count < 0 {
+		return "Unlimited"
+	}
+	return strconv.FormatInt(count, 10)
 }
 
 // ValidateUserName checks if the username is valid by length and allowed characters.

--- a/pkg/utils/helper_test.go
+++ b/pkg/utils/helper_test.go
@@ -55,9 +55,15 @@ func TestFormatUrl(t *testing.T) {
 }
 
 func TestFormatSize(t *testing.T) {
-	// 1048576 bytes == 1 MiB
 	assert.Equal(t, "1.00MiB", utils.FormatSize(1024*1024))
 	assert.Equal(t, "0B", utils.FormatSize(0))
+	assert.Equal(t, "Unlimited", utils.FormatSize(-1))
+}
+
+func TestFormatCount(t *testing.T) {
+	assert.Equal(t, "100", utils.FormatCount(100))
+	assert.Equal(t, "0", utils.FormatCount(0))
+	assert.Equal(t, "Unlimited", utils.FormatCount(-1))
 }
 
 func TestValidateUserName(t *testing.T) {

--- a/pkg/views/project/summary/view.go
+++ b/pkg/views/project/summary/view.go
@@ -25,23 +25,40 @@ import (
 )
 
 var columns = []table.Column{
-	{Title: "Metric", Width: tablelist.WidthXXL},
-	{Title: "Value", Width: tablelist.WidthXXL},
+	{Title: "Property", Width: tablelist.WidthL},
+	{Title: "Value", Width: tablelist.Width3XL},
+}
+
+
+var order = []string{
+	"Project Name",
+	"Project ID",
+	"Visibility",
+	"Repositories",
+	"Project Admin Count",
+	"Maintainer Count",
+	"Developer Count",
+	"Guest Count",
+	"Limited Guest Count",
 }
 
 func ViewProjectSummary(project *models.Project, summary *models.ProjectSummary) error {
+	summaryMap := map[string]string{
+		"Project Name":        project.Name,
+		"Project ID":          strconv.FormatInt(int64(project.ProjectID), 10),
+		"Visibility":          project.Metadata.Public,
+		"Repositories":        strconv.FormatInt(summary.RepoCount, 10),
+		"Project Admin Count": strconv.FormatInt(summary.ProjectAdminCount, 10),
+		"Maintainer Count":    strconv.FormatInt(summary.MaintainerCount, 10),
+		"Developer Count":     strconv.FormatInt(summary.DeveloperCount, 10),
+		"Guest Count":         strconv.FormatInt(summary.GuestCount, 10),
+		"Limited Guest Count": strconv.FormatInt(summary.LimitedGuestCount, 10),
+	}
+
 	var rows []table.Row
-
-	rows = append(rows, table.Row{"Project Name", project.Name})
-	rows = append(rows, table.Row{"Project ID", strconv.FormatInt(int64(project.ProjectID), 10)})
-	rows = append(rows, table.Row{"Visibility", project.Metadata.Public})
-
-	rows = append(rows, table.Row{"Repositories", strconv.FormatInt(summary.RepoCount, 10)})
-	rows = append(rows, table.Row{"Project Admin Count", strconv.FormatInt(summary.ProjectAdminCount, 10)})
-	rows = append(rows, table.Row{"Maintainer Count", strconv.FormatInt(summary.MaintainerCount, 10)})
-	rows = append(rows, table.Row{"Developer Count", strconv.FormatInt(summary.DeveloperCount, 10)})
-	rows = append(rows, table.Row{"Guest Count", strconv.FormatInt(summary.GuestCount, 10)})
-	rows = append(rows, table.Row{"Limited Guest Count", strconv.FormatInt(summary.LimitedGuestCount, 10)})
+	for _, key := range order {
+		rows = append(rows, table.Row{key, summaryMap[key]})
+	}
 
 	if summary.Quota != nil {
 		for resource, hardValue := range summary.Quota.Hard {

--- a/pkg/views/project/summary/view.go
+++ b/pkg/views/project/summary/view.go
@@ -1,0 +1,80 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package summary
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/goharbor/harbor-cli/pkg/views/base/tablelist"
+)
+
+var columns = []table.Column{
+	{Title: "Metric", Width: tablelist.WidthXXL},
+	{Title: "Value", Width: tablelist.WidthXXL},
+}
+
+func ViewProjectSummary(project *models.Project, summary *models.ProjectSummary) error {
+	var rows []table.Row
+
+	rows = append(rows, table.Row{"Project Name", project.Name})
+	rows = append(rows, table.Row{"Project ID", strconv.FormatInt(int64(project.ProjectID), 10)})
+	rows = append(rows, table.Row{"Visibility", project.Metadata.Public})
+
+	rows = append(rows, table.Row{"Repositories", strconv.FormatInt(summary.RepoCount, 10)})
+	rows = append(rows, table.Row{"Project Admin Count", strconv.FormatInt(summary.ProjectAdminCount, 10)})
+	rows = append(rows, table.Row{"Maintainer Count", strconv.FormatInt(summary.MaintainerCount, 10)})
+	rows = append(rows, table.Row{"Developer Count", strconv.FormatInt(summary.DeveloperCount, 10)})
+	rows = append(rows, table.Row{"Guest Count", strconv.FormatInt(summary.GuestCount, 10)})
+	rows = append(rows, table.Row{"Limited Guest Count", strconv.FormatInt(summary.LimitedGuestCount, 10)})
+
+	if summary.Quota != nil {
+		for resource, hardValue := range summary.Quota.Hard {
+			usedValue := summary.Quota.Used[resource]
+			label := fmt.Sprintf("Quota: %s", resource)
+			val := ""
+			if resource == "storage" {
+				val = fmt.Sprintf("%v / %v", utils.FormatSize(usedValue), utils.FormatSize(hardValue))
+			} else {
+				val = fmt.Sprintf("%v / %v", utils.FormatCount(usedValue), utils.FormatCount(hardValue))
+			}
+			rows = append(rows, table.Row{label, val})
+		}
+	}
+
+	if summary.Registry != nil {
+		rows = append(rows, table.Row{"Registry ID", strconv.FormatInt(summary.Registry.ID, 10)})
+		rows = append(rows, table.Row{"Registry Name", summary.Registry.Name})
+		rows = append(rows, table.Row{"Registry URL", summary.Registry.URL})
+		rows = append(rows, table.Row{"Registry Type", summary.Registry.Type})
+		if summary.Registry.Credential != nil {
+			rows = append(rows, table.Row{"Registry Credential Type", summary.Registry.Credential.Type})
+		}
+		rows = append(rows, table.Row{"Registry Description", summary.Registry.Description})
+		rows = append(rows, table.Row{"Registry Insecure", strconv.FormatBool(summary.Registry.Insecure)})
+		rows = append(rows, table.Row{"Registry Status", summary.Registry.Status})
+		rows = append(rows, table.Row{"Registry Updated", summary.Registry.UpdateTime.String()})
+	}
+
+	m := tablelist.NewModel(columns, rows, len(rows))
+
+	if _, err := tea.NewProgram(m).Run(); err != nil {
+		return fmt.Errorf("error running program: %v", err)
+	}
+	return nil
+}

--- a/pkg/views/project/summary/view.go
+++ b/pkg/views/project/summary/view.go
@@ -29,7 +29,6 @@ var columns = []table.Column{
 	{Title: "Value", Width: tablelist.Width3XL},
 }
 
-
 var order = []string{
 	"Project Name",
 	"Project ID",


### PR DESCRIPTION
## Description
This pull request implements the `harbor project summary` command, providing a detailed overview of a project's status, including member statistics, resource quotas, and registry information. It integrates data from multiple Harbor API endpoints to provide a comprehensive report in both interactive and machine-readable formats.

- Fixes #866 

## Type of Change
- [x] New feature
- [x] Refactor
- [x] Documentation update

## Changes
- **New Feature**: Added `harbor project summary` command with support for both project name and ID.
- **API Support**: Added `GetProjectSummary` handler in `pkg/api` to interface with Harbor's project summary endpoint.
- **UI Implementation**: Created a new table-based view for displaying project metrics, member counts, and registry details.
- **Structured Output**: Added support for `--output-format` (JSON, YAML, CSV) for the summary command, allowing for easy data export and automation.
- **Utilities**: 
    - Added `FormatCount` and `FormatSize` helpers with support for "Unlimited" quota values.
    - Refactored `PrintFormat` utility to use generics for broader compatibility.
- **Documentation**: Generated man pages and markdown CLI documentation for the new command.
- **Testing**: Added unit tests for the summary command and utility functions.

------------------
Few ScreeenShots : 
<img width="963" height="449" alt="Screenshot (673)" src="https://github.com/user-attachments/assets/40d2f47f-a790-4618-8559-27ae64b38f32" />
<img width="800" height="358" alt="Screenshot (674)" src="https://github.com/user-attachments/assets/83888021-89c0-47d9-b4da-43a4f55e2c5e" />
<img width="800" height="364" alt="Screenshot (675)" src="https://github.com/user-attachments/assets/03119716-5bfc-454d-9f84-11221ba66309" />
<img width="727" height="191" alt="Screenshot (676)" src="https://github.com/user-attachments/assets/437eec8e-1c00-4a7b-9f67-721989dcf7a1" />
<img width="1424" height="291" alt="Screenshot (677)" src="https://github.com/user-attachments/assets/6d42b773-708a-47df-a64a-f2ad0ec20482" />
<img width="800" height="552" alt="Screenshot (678)" src="https://github.com/user-attachments/assets/ed1090ee-4e20-478d-9300-ba3d384cd5de" />
