### PR TITLE
fix: replace reflect.Ptr with reflect.Pointer to fix govet inline

### DIFF
--- a/cmd/harbor/root/context/delete.go
+++ b/cmd/harbor/root/context/delete.go
@@ -187,7 +187,7 @@ func deleteValueInConfig(
 func deleteNestedValue(obj interface{}, path []string, actualSegments *[]string) error {
 	// We require obj to be a pointer to a struct so we can modify it.
 	val := reflect.ValueOf(obj)
-	if val.Kind() != reflect.Ptr {
+	if val.Kind() != reflect.Pointer {
 		return fmt.Errorf("object must be a pointer to a struct, got %s", val.Kind())
 	}
 	val = val.Elem() // dereference pointer
@@ -219,12 +219,12 @@ func deleteNestedValue(obj interface{}, path []string, actualSegments *[]string)
 		// If this is NOT the last path segment, move deeper
 		if i < len(path)-1 {
 			// If the field is a pointer and nil, we can't go deeper
-			if fieldValue.Kind() == reflect.Ptr && fieldValue.IsNil() {
+			if fieldValue.Kind() == reflect.Pointer && fieldValue.IsNil() {
 				return fmt.Errorf("field '%s' is nil and cannot be traversed", field.Name)
 			}
 			// Descend
 			val = fieldValue
-			if val.Kind() == reflect.Ptr {
+			if val.Kind() == reflect.Pointer {
 				val = val.Elem()
 			}
 			continue

--- a/cmd/harbor/root/context/get.go
+++ b/cmd/harbor/root/context/get.go
@@ -155,7 +155,7 @@ func getNestedValue(obj interface{}, path []string, actualSegments *[]string) (i
 
 	for _, key := range path {
 		// If it's a pointer, dereference
-		if current.Kind() == reflect.Ptr {
+		if current.Kind() == reflect.Pointer {
 			current = current.Elem()
 		}
 		if current.Kind() != reflect.Struct {
@@ -189,7 +189,7 @@ func getNestedValue(obj interface{}, path []string, actualSegments *[]string) (i
 	}
 
 	// Finally, if we ended on a pointer, dereference it
-	if current.Kind() == reflect.Ptr {
+	if current.Kind() == reflect.Pointer {
 		current = current.Elem()
 	}
 	return current.Interface(), nil

--- a/cmd/harbor/root/context/update.go
+++ b/cmd/harbor/root/context/update.go
@@ -142,7 +142,7 @@ func setValueInConfig(
 func setNestedValue(obj interface{}, path []string, newValue string, actualSegments *[]string) error {
 	// We require obj to be a pointer to a struct so we can modify it.
 	val := reflect.ValueOf(obj)
-	if val.Kind() != reflect.Ptr {
+	if val.Kind() != reflect.Pointer {
 		return fmt.Errorf("object must be a pointer to a struct, got %s", val.Kind())
 	}
 	val = val.Elem() // dereference pointer
@@ -174,13 +174,13 @@ func setNestedValue(obj interface{}, path []string, newValue string, actualSegme
 		// If this is NOT the last path segment, move deeper
 		if i < len(path)-1 {
 			// If the field is a pointer and nil, allocate a new instance
-			if fieldValue.Kind() == reflect.Ptr && fieldValue.IsNil() {
+			if fieldValue.Kind() == reflect.Pointer && fieldValue.IsNil() {
 				newElem := reflect.New(fieldValue.Type().Elem())
 				fieldValue.Set(newElem)
 			}
 			// Descend
 			val = fieldValue
-			if val.Kind() == reflect.Ptr {
+			if val.Kind() == reflect.Pointer {
 				val = val.Elem()
 			}
 			continue

--- a/pkg/utils/error.go
+++ b/pkg/utils/error.go
@@ -34,7 +34,7 @@ func ParseHarborErrorMsg(err error) string {
 	}
 
 	val := reflect.ValueOf(err)
-	if val.Kind() == reflect.Ptr {
+	if val.Kind() == reflect.Pointer {
 		val = val.Elem()
 	}
 	field := val.FieldByName("Payload")

--- a/pkg/utils/reflect.go
+++ b/pkg/utils/reflect.go
@@ -133,7 +133,7 @@ func ExtractConfigValues[T ConfigType](cfg T) map[string]any {
 		field := v.Field(i)
 		fieldName := t.Field(i).Name
 		// Skip nil pointers
-		if field.Kind() == reflect.Ptr && field.IsNil() {
+		if field.Kind() == reflect.Pointer && field.IsNil() {
 			continue
 		}
 		configItem := field.Interface()
@@ -154,7 +154,7 @@ func ExtractConfigValues[T ConfigType](cfg T) map[string]any {
 		default:
 			// Handle generic pointer types using reflection
 			val := reflect.ValueOf(configItem)
-			if val.Kind() == reflect.Ptr && !val.IsNil() {
+			if val.Kind() == reflect.Pointer && !val.IsNil() {
 				deref := val.Elem()
 				// Only include non-zero values
 				if deref.IsValid() && !deref.IsZero() {

--- a/pkg/views/info/list/view.go
+++ b/pkg/views/info/list/view.go
@@ -111,7 +111,7 @@ func renderSectionTable(title string, data interface{}) {
 func createRows(data interface{}, rows *[]table.Row) {
 	val := reflect.ValueOf(data)
 
-	if val.Kind() == reflect.Ptr {
+	if val.Kind() == reflect.Pointer {
 		val = val.Elem()
 	}
 
@@ -127,7 +127,7 @@ func createRows(data interface{}, rows *[]table.Row) {
 		fieldType := typ.Field(i)
 		fieldName := fieldType.Name
 
-		if field.Kind() == reflect.Ptr && !field.IsNil() {
+		if field.Kind() == reflect.Pointer && !field.IsNil() {
 			field = field.Elem()
 		}
 


### PR DESCRIPTION

The updated golangci-lint govet analyzer flags reflect.Ptr as a deprecated alias that should be replaced with the canonical reflect.Pointer constant (introduced in Go 1.18).

Affected files:
- pkg/utils/error.go
- pkg/utils/reflect.go

## Description
Briefly describe what this pull request does and why the change is needed.

- Fixes #870 

## Type of Change
Please select the relevant type.

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
- changed if val.Kind() == reflect.Ptr to if val.Kind() == reflect.Pointer
- 
- 
