### PR TITLE
feat(login): add --sso flag with OIDC device code flow (RFC 8628)

### DIFF
--- a/cmd/harbor/root/login.go
+++ b/cmd/harbor/root/login.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/goharbor/go-client/pkg/harbor"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/user"
@@ -34,6 +35,9 @@ var (
 	Password      string
 	Name          string
 	passwordStdin bool
+	sso           bool
+	oidcIssuer    string
+	oidcClientID  string
 )
 
 // LoginCommand creates a new `harbor login` command
@@ -46,6 +50,13 @@ func LoginCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				serverAddress = args[0]
+			}
+
+			if sso && Password != "" {
+				return fmt.Errorf("--password cannot be used with --sso")
+			}
+			if sso && Username != "" {
+				return fmt.Errorf("--username cannot be used with --sso")
 			}
 
 			if passwordStdin {
@@ -83,12 +94,19 @@ func LoginCommand() *cobra.Command {
 	flags.StringVarP(&Name, "context-name", "", "", "Login context name (optional)")
 	flags.StringVarP(&Password, "password", "p", "", "Password")
 	flags.BoolVar(&passwordStdin, "password-stdin", false, "Take the password from stdin")
+	flags.BoolVar(&sso, "sso", false, "Use OIDC device code flow for authentication")
+	flags.StringVar(&oidcIssuer, "oidc-issuer", "", "OIDC issuer URL (required with --sso)")
+	flags.StringVar(&oidcClientID, "oidc-client-id", "", "OIDC client ID (required with --sso)")
 
 	return cmd
 }
 
 // ProcessLogin applies a simplified decision logic to run login or launch an interactive view.
 func ProcessLogin(loginView login.LoginView, config *utils.HarborConfig) error {
+	if sso {
+		return RunSSOLogin(loginView)
+	}
+
 	// Auto-generate the name if not provided.
 	if loginView.Name == "" && loginView.Server != "" && loginView.Username != "" {
 		loginView.Name = fmt.Sprintf("%s@%s", loginView.Username, utils.SanitizeServerAddress(loginView.Server))
@@ -198,5 +216,88 @@ func RunLogin(opts login.LoginView) error {
 	}
 	log.Debugf("Credentials successfully added to the config file.")
 	fmt.Printf("Login successful for %s at %s\n", opts.Username, opts.Server)
+	return nil
+}
+
+func RunSSOLogin(opts login.LoginView) error {
+	if oidcIssuer == "" {
+		return fmt.Errorf("--oidc-issuer is required with --sso")
+	}
+	if oidcClientID == "" {
+		return fmt.Errorf("--oidc-client-id is required with --sso")
+	}
+
+	opts.Server = utils.FormatUrl(opts.Server)
+	if err := utils.ValidateURL(opts.Server); err != nil {
+		return fmt.Errorf("invalid server URL: %w", err)
+	}
+
+	tokenResp, err := utils.RunOIDCLogin(utils.OIDCFlowOptions{
+		IssuerURL: oidcIssuer,
+		ClientID:  oidcClientID,
+	})
+	if err != nil {
+		return fmt.Errorf("OIDC login failed: %w", err)
+	}
+
+	if err := utils.GenerateEncryptionKey(); err != nil {
+		fmt.Println("Encryption key already exists or could not be created:", err)
+	}
+
+	key, err := utils.GetEncryptionKey()
+	if err != nil {
+		return fmt.Errorf("failed to get encryption key: %w", err)
+	}
+
+	encryptedAccessToken, err := utils.Encrypt(key, []byte(tokenResp.AccessToken))
+	if err != nil {
+		return fmt.Errorf("failed to encrypt access token: %w", err)
+	}
+
+	encryptedRefreshToken, err := utils.Encrypt(key, []byte(tokenResp.RefreshToken))
+	if err != nil {
+		return fmt.Errorf("failed to encrypt refresh token: %w", err)
+	}
+
+	expiresAt := time.Now().Unix() + tokenResp.ExpiresIn
+
+	credName := opts.Name
+	if credName == "" {
+		credName = fmt.Sprintf("%s@%s", oidcClientID, utils.SanitizeServerAddress(opts.Server))
+	}
+
+	cred := utils.Credential{
+		Name:          credName,
+		Username:      oidcClientID,
+		ServerAddress: opts.Server,
+		AuthType:      "oidc",
+		OIDC: &utils.OIDCConfig{
+			IssuerURL:    oidcIssuer,
+			ClientID:     oidcClientID,
+			AccessToken:  encryptedAccessToken,
+			RefreshToken: encryptedRefreshToken,
+			ExpiresAt:    expiresAt,
+		},
+	}
+
+	harborData, err := utils.GetCurrentHarborData()
+	if err != nil {
+		return fmt.Errorf("failed to get current harbor data: %s", err)
+	}
+	configPath := harborData.ConfigPath
+
+	_, err = utils.GetCredentials(credName)
+	if err == nil {
+		if err = utils.UpdateCredentialsInConfigFile(cred, configPath); err != nil {
+			return fmt.Errorf("failed to update credentials: %w", err)
+		}
+		fmt.Printf("Login successful. OIDC context updated: %s\n", credName)
+		return nil
+	}
+
+	if err = utils.AddCredentialsToConfigFile(cred, configPath); err != nil {
+		return fmt.Errorf("failed to store credentials: %w", err)
+	}
+	fmt.Printf("Login successful. OIDC context created: %s\n", credName)
 	return nil
 }

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -27,10 +27,20 @@ import (
 )
 
 type Credential struct {
-	Name          string `yaml:"name"`
-	Username      string `yaml:"username"`
-	Password      string `yaml:"password"`
-	ServerAddress string `yaml:"serveraddress"`
+	Name          string      `yaml:"name"`
+	Username      string      `yaml:"username"`
+	Password      string      `yaml:"password"`
+	ServerAddress string      `yaml:"serveraddress"`
+	AuthType      string      `yaml:"auth-type,omitempty"` // "basic" (default) or "oidc"
+	OIDC          *OIDCConfig `yaml:"oidc,omitempty"`
+}
+
+type OIDCConfig struct {
+	IssuerURL    string `yaml:"issuer-url"`
+	ClientID     string `yaml:"client-id"`
+	AccessToken  string `yaml:"access-token,omitempty"`
+	RefreshToken string `yaml:"refresh-token,omitempty"`
+	ExpiresAt    int64  `yaml:"expires-at,omitempty"`
 }
 
 type HarborConfig struct {

--- a/pkg/utils/config_test.go
+++ b/pkg/utils/config_test.go
@@ -107,3 +107,34 @@ func Test_Config_Flag(t *testing.T) {
 	assert.NotNil(t, currentConfig.Credentials, "Credentials should not be nil")
 	assert.NotNil(t, data.ConfigPath, "ConfigPath should not be nil")
 }
+
+func TestCredential_OIDCFields(t *testing.T) {
+	cred := utils.Credential{
+		Name:          "test-oidc",
+		Username:      "my-client",
+		ServerAddress: "https://harbor.example.com",
+		AuthType:      "oidc",
+		OIDC: &utils.OIDCConfig{
+			IssuerURL:    "https://idp.example.com",
+			ClientID:     "my-client",
+			AccessToken:  "encrypted-at",
+			RefreshToken: "encrypted-rt",
+			ExpiresAt:    1712345678,
+		},
+	}
+	assert.Equal(t, "oidc", cred.AuthType)
+	assert.NotNil(t, cred.OIDC)
+	assert.Equal(t, "https://idp.example.com", cred.OIDC.IssuerURL)
+}
+
+func TestCredential_BasicAuthDefault(t *testing.T) {
+	cred := utils.Credential{
+		Name:          "test-basic",
+		Username:      "admin",
+		Password:      "enc-pass",
+		ServerAddress: "https://harbor.example.com",
+	}
+	// AuthType defaults to "" which means basic
+	assert.Equal(t, "", cred.AuthType)
+	assert.Nil(t, cred.OIDC)
+}

--- a/pkg/utils/oidc.go
+++ b/pkg/utils/oidc.go
@@ -1,0 +1,217 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	defaultOIDCScopes   = "openid profile email offline_access"
+	defaultPollInterval = 5 * time.Second
+)
+
+type OIDCDiscovery struct {
+	Issuer                      string   `json:"issuer"`
+	DeviceAuthorizationEndpoint string   `json:"device_authorization_endpoint"`
+	TokenEndpoint               string   `json:"token_endpoint"`
+	AuthorizationEndpoint       string   `json:"authorization_endpoint"`
+	ScopesSupported             []string `json:"scopes_supported"`
+	GrantTypesSupported         []string `json:"grant_types_supported"`
+}
+
+type DeviceAuthorizationResponse struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete"`
+	ExpiresIn               int    `json:"expires_in"`
+	Interval                int    `json:"interval,omitempty"`
+}
+
+type TokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int64  `json:"expires_in"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	IDToken      string `json:"id_token,omitempty"`
+}
+
+type DeviceFlowError struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+type OIDCFlowOptions struct {
+	IssuerURL string
+	ClientID  string
+	Scopes    string
+	Client    *http.Client
+}
+
+var oidcDiscoveryFunc = discoverOIDCProvider
+
+func discoverOIDCProvider(issuerURL string, client *http.Client) (*OIDCDiscovery, error) {
+	discoveryURL := strings.TrimRight(issuerURL, "/") + "/.well-known/openid-configuration"
+	resp, err := client.Get(discoveryURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover OIDC provider at %s: %w", discoveryURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("OIDC discovery failed (HTTP %d): %s", resp.StatusCode, string(body))
+	}
+
+	var discovery OIDCDiscovery
+	if err := json.NewDecoder(resp.Body).Decode(&discovery); err != nil {
+		return nil, fmt.Errorf("failed to parse OIDC discovery response: %w", err)
+	}
+	return &discovery, nil
+}
+
+var deviceAuthorizationFunc = requestDeviceAuthorization
+
+func requestDeviceAuthorization(endpoint, clientID, scopes string, client *http.Client) (*DeviceAuthorizationResponse, error) {
+	data := url.Values{
+		"client_id": {clientID},
+	}
+	if scopes != "" {
+		data.Set("scope", scopes)
+	}
+
+	resp, err := client.PostForm(endpoint, data)
+	if err != nil {
+		return nil, fmt.Errorf("device authorization request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		deviceErr, err := parseDeviceFlowError(resp)
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("device authorization failed: %s - %s", deviceErr.Error, deviceErr.ErrorDescription)
+	}
+
+	var deviceResp DeviceAuthorizationResponse
+	if err := json.NewDecoder(resp.Body).Decode(&deviceResp); err != nil {
+		return nil, fmt.Errorf("failed to parse device authorization response: %w", err)
+	}
+	return &deviceResp, nil
+}
+
+var pollTokenFunc = pollForToken
+
+func pollForToken(tokenEndpoint, deviceCode, clientID string, interval time.Duration, client *http.Client) (*TokenResponse, error) {
+	data := url.Values{
+		"grant_type":  {"urn:ietf:params:oauth:grant-type:device_code"},
+		"device_code": {deviceCode},
+		"client_id":   {clientID},
+	}
+
+	for {
+		resp, err := client.PostForm(tokenEndpoint, data)
+		if err != nil {
+			return nil, fmt.Errorf("token request failed: %w", err)
+		}
+
+		if resp.StatusCode == http.StatusOK {
+			var tokenResp TokenResponse
+			if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+				resp.Body.Close()
+				return nil, fmt.Errorf("failed to parse token response: %w", err)
+			}
+			resp.Body.Close()
+			return &tokenResp, nil
+		}
+
+		deviceErr, err := parseDeviceFlowError(resp)
+		resp.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+
+		if deviceErr.Error != "authorization_pending" && deviceErr.Error != "slow_down" {
+			return nil, fmt.Errorf("device authorization failed: %s - %s", deviceErr.Error, deviceErr.ErrorDescription)
+		}
+
+		if deviceErr.Error == "slow_down" {
+			interval += 5 * time.Second
+		}
+
+		time.Sleep(interval)
+	}
+}
+
+func parseDeviceFlowError(resp *http.Response) (*DeviceFlowError, error) {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read error response (HTTP %d): %w", resp.StatusCode, err)
+	}
+	var deviceErr DeviceFlowError
+	if err := json.Unmarshal(body, &deviceErr); err != nil {
+		return nil, fmt.Errorf("device authorization failed (HTTP %d): %s", resp.StatusCode, string(body))
+	}
+	return &deviceErr, nil
+}
+
+func RunOIDCLogin(opts OIDCFlowOptions) (*TokenResponse, error) {
+	client := opts.Client
+	if client == nil {
+		client = &http.Client{Timeout: 30 * time.Second}
+	}
+
+	if opts.Scopes == "" {
+		opts.Scopes = defaultOIDCScopes
+	}
+
+	discovery, err := oidcDiscoveryFunc(opts.IssuerURL, client)
+	if err != nil {
+		return nil, err
+	}
+
+	if discovery.DeviceAuthorizationEndpoint == "" {
+		return nil, fmt.Errorf("OIDC provider at %s does not support device authorization", opts.IssuerURL)
+	}
+
+	deviceResp, err := deviceAuthorizationFunc(discovery.DeviceAuthorizationEndpoint, opts.ClientID, opts.Scopes, client)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("\nTo complete login, open the following URL in your browser:\n\n")
+	fmt.Printf("  %s\n\n", deviceResp.VerificationURI)
+	fmt.Printf("And enter the code: %s\n\n", deviceResp.UserCode)
+	fmt.Printf("Waiting for authorization...\n")
+
+	pollInterval := time.Duration(deviceResp.Interval) * time.Second
+	if pollInterval == 0 {
+		pollInterval = defaultPollInterval
+	}
+
+	tokenResp, err := pollTokenFunc(discovery.TokenEndpoint, deviceResp.DeviceCode, opts.ClientID, pollInterval, client)
+	if err != nil {
+		return nil, err
+	}
+
+	return tokenResp, nil
+}

--- a/pkg/utils/oidc_test.go
+++ b/pkg/utils/oidc_test.go
@@ -1,0 +1,178 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package utils
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDiscoverOIDCProvider_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/.well-known/openid-configuration", r.URL.Path)
+		json.NewEncoder(w).Encode(OIDCDiscovery{
+			Issuer:                      "https://idp.example.com",
+			DeviceAuthorizationEndpoint: "https://idp.example.com/device/auth",
+			TokenEndpoint:               "https://idp.example.com/token",
+		})
+	}))
+	defer server.Close()
+
+	discovery, err := discoverOIDCProvider(server.URL, server.Client())
+	assert.NoError(t, err)
+	assert.Equal(t, "https://idp.example.com/device/auth", discovery.DeviceAuthorizationEndpoint)
+	assert.Equal(t, "https://idp.example.com/token", discovery.TokenEndpoint)
+}
+
+func TestDiscoverOIDCProvider_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	_, err := discoverOIDCProvider(server.URL, server.Client())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+}
+
+func TestRequestDeviceAuthorization_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(DeviceAuthorizationResponse{
+			DeviceCode:      "device-code-123",
+			UserCode:        "ABCD-EFGH",
+			VerificationURI: "https://idp.example.com/device",
+			ExpiresIn:       300,
+			Interval:        5,
+		})
+	}))
+	defer server.Close()
+
+	resp, err := requestDeviceAuthorization(server.URL, "test-client", "openid", server.Client())
+	assert.NoError(t, err)
+	assert.Equal(t, "ABCD-EFGH", resp.UserCode)
+	assert.Equal(t, "device-code-123", resp.DeviceCode)
+	assert.Equal(t, 5, resp.Interval)
+}
+
+func TestRequestDeviceAuthorization_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(DeviceFlowError{
+			Error:            "invalid_client",
+			ErrorDescription: "Client not found",
+		})
+	}))
+	defer server.Close()
+
+	_, err := requestDeviceAuthorization(server.URL, "bad-client", "openid", server.Client())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid_client")
+}
+
+func TestPollForToken_Success(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount < 3 {
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(DeviceFlowError{Error: "authorization_pending"})
+			return
+		}
+		json.NewEncoder(w).Encode(TokenResponse{
+			AccessToken:  "access-token-xyz",
+			TokenType:    "Bearer",
+			ExpiresIn:    3600,
+			RefreshToken: "refresh-token-xyz",
+		})
+	}))
+	defer server.Close()
+
+	resp, err := pollForToken(server.URL, "device-code", "client-id", 10*time.Millisecond, server.Client())
+	assert.NoError(t, err)
+	assert.Equal(t, "access-token-xyz", resp.AccessToken)
+	assert.Equal(t, "refresh-token-xyz", resp.RefreshToken)
+	assert.Equal(t, int64(3600), resp.ExpiresIn)
+	assert.Equal(t, 3, callCount)
+}
+
+func TestPollForToken_Denied(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(DeviceFlowError{
+			Error:            "access_denied",
+			ErrorDescription: "User denied the request",
+		})
+	}))
+	defer server.Close()
+
+	_, err := pollForToken(server.URL, "device-code", "client-id", 10*time.Millisecond, server.Client())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "access_denied")
+}
+
+func TestRunOIDCLogin_Integration(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(TokenResponse{
+			AccessToken:  "at-final",
+			TokenType:    "Bearer",
+			ExpiresIn:    3600,
+			RefreshToken: "rt-final",
+		})
+	}))
+	defer server.Close()
+
+	originalDiscover := oidcDiscoveryFunc
+	originalDeviceAuth := deviceAuthorizationFunc
+	originalPoll := pollTokenFunc
+	defer func() {
+		oidcDiscoveryFunc = originalDiscover
+		deviceAuthorizationFunc = originalDeviceAuth
+		pollTokenFunc = originalPoll
+	}()
+
+	oidcDiscoveryFunc = func(issuerURL string, client *http.Client) (*OIDCDiscovery, error) {
+		return &OIDCDiscovery{
+			Issuer:                      issuerURL,
+			DeviceAuthorizationEndpoint: server.URL + "/device-auth",
+			TokenEndpoint:               server.URL + "/token",
+		}, nil
+	}
+	deviceAuthorizationFunc = func(endpoint, clientID, scopes string, client *http.Client) (*DeviceAuthorizationResponse, error) {
+		return &DeviceAuthorizationResponse{
+			DeviceCode:      "dc-123",
+			UserCode:        "XYZW-1234",
+			VerificationURI: "https://idp.example.com/device",
+			ExpiresIn:       300,
+			Interval:        1,
+		}, nil
+	}
+	pollTokenFunc = func(tokenEndpoint, deviceCode, clientID string, interval time.Duration, client *http.Client) (*TokenResponse, error) {
+		return pollForToken(tokenEndpoint, deviceCode, clientID, interval, client)
+	}
+
+	resp, err := RunOIDCLogin(OIDCFlowOptions{
+		IssuerURL: "https://idp.example.com",
+		ClientID:  "test-client",
+		Scopes:    "openid",
+		Client:    server.Client(),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "at-final", resp.AccessToken)
+	assert.Equal(t, "rt-final", resp.RefreshToken)
+}


### PR DESCRIPTION
## Description

Adds `--sso` flag to `harbor login` with OAuth 2.0 Device Authorization Grant (RFC 8628), enabling browser-based OIDC authentication.

This is the foundational PR for the LFX project scope: [harbor-cli#821](https://github.com/goharbor/harbor-cli/issues/821) (OIDC Device-Flow Login).

### Usage

```bash
harbor login my-harbor.com --sso \
  --oidc-issuer https://idp.example.com \
  --oidc-client-id harbor-cli
```

### Flow

1. **Discovery** — `GET /.well-known/openid-configuration` to find device auth endpoint
2. **Device Authorization** — `POST device_authorization_endpoint` with `client_id` + `scope`
3. **User Prompt** — displays `verification_uri` + `user_code`
4. **Polling** — polls `token_endpoint` handling `authorization_pending` and `slow_down`
5. **Token Storage** — encrypts `access_token` + `refresh_token` using existing AES-256-GCM, stored in config with `auth-type: oidc`

### Changes

| File | Purpose |
|------|---------|
| `pkg/utils/config.go` | `Credential` extended with `AuthType` + `OIDCConfig` (backward-compatible, `omitempty`) |
| `pkg/utils/oidc.go` | Device code flow: discover, authorize, poll, token exchange |
| `pkg/utils/oidc_test.go` | 7 tests with `httptest.Server` + function variable mocking |
| `pkg/utils/config_test.go` | 2 tests for OIDC credential serialization |
| `cmd/harbor/root/login.go` | `--sso`, `--oidc-issuer`, `--oidc-client-id` flags + `RunSSOLogin()` |

### Design Decisions

- **No external OIDC library** — uses `net/http` + `encoding/json` only. Keeps dependencies minimal.
- **Function variables for mocking** — follows existing pattern (`member_handler_test.go`, `prompt.go`)
- **Reuses encryption pipeline** — same `Encrypt()` / `GetEncryptionKey()` as password storage
- **Backward compatible** — `AuthType` defaults to empty (`basic`); `OIDC` is nil for existing configs

### RFC 8628 Compliance

| Requirement | Implemented |
|-------------|-------------|
| Discovery via `.well-known/openid-configuration` | Yes |
| Device auth with `client_id` + `scope` | Yes |
| `grant_type=urn:ietf:params:oauth:grant-type:device_code` | Yes |
| Handle `authorization_pending` (keep polling) | Yes |
| Handle `slow_down` (increase interval) | Yes |
| Handle terminal errors (`access_denied`, etc.) | Yes |

## Type of Change

- [x] New feature

## Testing

- [x] 9 new unit tests (all passing)
- [x] Full test suite: no regressions
- [x] `go vet` clean
- [x] `gofmt` clean
- [x] Build succeeds

Signed-off-by: AdeshDeshmukh <adeshkd123@gmail.com>