### PR TITLE
feat(ci): add Harbor E2E smoke test suite via Docker Compose in GH Actions

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,75 @@
+name: E2E Tests
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "*.md"
+      - "assets/**"
+  pull_request:
+    paths-ignore:
+      - "*.md"
+      - "assets/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Show Docker info
+        run: docker compose version
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Build CLI binary
+        run: go build -o harbor-dev ./cmd/harbor
+
+      - name: Generate Harbor E2E config
+        run: bash test/e2e/setup.sh
+
+      - name: Start Harbor
+        run: |
+          docker compose -f test/e2e/docker-compose.yml up -d
+          echo "Waiting for Harbor core to become healthy..."
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:8080/api/v2.0/health > /dev/null 2>&1; then
+              echo "Harbor is healthy after $((i * 5))s"
+              exit 0
+            fi
+            printf "  Attempt %d/60 ...\n" "$i"
+            sleep 5
+          done
+          echo "Harbor failed to become healthy after 5 minutes"
+          docker compose -f test/e2e/docker-compose.yml logs core
+          exit 1
+
+      - name: Run smoke tests
+        env:
+          HARBOR_BIN: ./harbor-dev
+          HARBOR_URL: http://localhost:8080
+        run: bash test/e2e/smoke_test.sh
+
+      - name: Collect Harbor logs on failure
+        if: failure()
+        run: |
+          echo "=== Harbor core logs ==="
+          docker compose -f test/e2e/docker-compose.yml logs core
+          echo "=== PostgreSQL logs ==="
+          docker compose -f test/e2e/docker-compose.yml logs postgresql
+
+      - name: Tear down Harbor
+        if: always()
+        run: docker compose -f test/e2e/docker-compose.yml down -v

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ go.work
 /bin
 
 /harbor
+/harbor-dev
 dist/
 /dagger.gen.go
 /internal/*
+test/e2e/config/

--- a/test/e2e/docker-compose.yml
+++ b/test/e2e/docker-compose.yml
@@ -1,0 +1,74 @@
+name: harbor-cli-e2e
+
+services:
+  postgresql:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_PASSWORD: &db_pass root123
+      POSTGRES_DB: registry
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d registry"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    image: redis:7-alpine
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+
+  registry:
+    image: registry:2
+    environment:
+      REGISTRY_HTTP_SECRET: registry-test-secret
+    volumes:
+      - registry_data:/var/lib/registry
+
+  core:
+    image: goharbor/harbor-core:v2.12.2
+    environment:
+      HARBOR_ADMIN_PASSWORD: Harbor12345
+      POSTGRESQL_HOST: postgresql
+      POSTGRESQL_PORT: "5432"
+      POSTGRESQL_USERNAME: postgres
+      POSTGRESQL_PASSWORD: *db_pass
+      POSTGRESQL_DATABASE: registry
+      POSTGRESQL_SSLMODE: disable
+      _REDIS_URL_CORE: redis:6379
+      _REDIS_URL_REG: redis:6379
+      CORE_URL: http://core:8080
+      CORE_LOCAL_URL: http://core:8080
+      JOBSERVICE_URL: http://core:8080
+      REGISTRY_URL: http://registry:5000
+      TOKEN_SERVICE_URL: http://core:8080/service/token
+      CORE_SECRET: core-secret-for-e2e-testing-32chars!!
+      JOBSERVICE_SECRET: jobservice-secret-for-e2e-test!!
+      SYNC_REGISTRY: "false"
+      SYNC_QUOTA: "false"
+      NOTARY_URL: ""
+      LOG_LEVEL: info
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./config/core/app.conf:/etc/core/app.conf:ro
+      - ./config/core/key:/etc/core/key:ro
+      - ./config/core/private_key.pem:/etc/core/private_key.pem:ro
+      - core_data:/data
+    depends_on:
+      postgresql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-fk", "http://localhost:8080/api/v2.0/health"]
+      interval: 5s
+      timeout: 10s
+      retries: 30
+      start_period: 20s
+
+volumes:
+  registry_data:
+  core_data:

--- a/test/e2e/setup.sh
+++ b/test/e2e/setup.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Generate Harbor configuration files for local E2E testing.
+# This script creates the minimal config files needed by Harbor core.
+
+set -euo pipefail
+
+CONFIG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/config/core"
+
+mkdir -p "${CONFIG_DIR}"
+
+# --- app.conf ---
+cat > "${CONFIG_DIR}/app.conf" <<'EOF'
+appname = Harbor
+runmode = prod
+enablegzip = true
+
+[prod]
+httpport = 8080
+EOF
+
+# --- Core encryption key (16-byte hex → 32 hex chars) ---
+# This key encrypts DB passwords and secrets stored in Harbor's DB.
+cat > "${CONFIG_DIR}/key" <<'EOF'
+deadbeefcafebabedeadbeefcafebabe
+EOF
+
+# --- RSA private key for token signing ---
+# Generate a fresh key each time so tokens are valid across restarts.
+openssl genrsa -out "${CONFIG_DIR}/private_key.pem" 2048 2>/dev/null
+
+echo "Harbor E2E config generated in ${CONFIG_DIR}"

--- a/test/e2e/smoke_test.sh
+++ b/test/e2e/smoke_test.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Harbor CLI E2E smoke test.
+# Requires a running Harbor instance. Set HARBOR_URL, HARBOR_USERNAME, HARBOR_PASSWORD env vars.
+#
+# Usage:
+#   HARBOR_BIN=./harbor-dev HARBOR_URL=http://localhost:8080 bash test/e2e/smoke_test.sh
+
+set -euo pipefail
+
+# --- Configuration ---
+HARBOR_BIN="${HARBOR_BIN:-./harbor-dev}"
+HARBOR_URL="${HARBOR_URL:-http://localhost:8080}"
+HARBOR_USERNAME="${HARBOR_USERNAME:-admin}"
+HARBOR_PASSWORD="${HARBOR_PASSWORD:-Harbor12345}"
+
+# Temp directory for CLI config (isolated from user config)
+CONFIG_DIR="$(mktemp -d)"
+export HARBOR_CLI_CONFIG="${CONFIG_DIR}/config.yaml"
+
+# 32-byte base64-encoded key for password encryption in CI
+export HARBOR_ENCRYPTION_KEY="${HARBOR_ENCRYPTION_KEY:-$(printf 'e2e-test-key-123456789012345678' | base64)}"
+
+# Log prefix for better output in CI
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+
+cleanup() {
+    rm -rf "${CONFIG_DIR}"
+}
+trap cleanup EXIT
+
+run_test() {
+    local description="$1"
+    shift
+    printf "  %s ... " "${description}"
+    if output=$("$@" 2>&1); then
+        printf "${GREEN}PASS${NC}\n"
+        PASS=$((PASS + 1))
+        return 0
+    else
+        printf "${RED}FAIL${NC}\n"
+        printf "    Command: %s\n" "$*"
+        printf "    Output: %s\n" "${output}"
+        FAIL=$((FAIL + 1))
+        return 1
+    fi
+}
+
+echo "=== Harbor CLI E2E Smoke Tests ==="
+echo "Server:   ${HARBOR_URL}"
+echo "User:     ${HARBOR_USERNAME}"
+echo "Binary:   ${HARBOR_BIN}"
+echo "Config:   ${CONFIG_DIR}"
+echo ""
+
+# Test 1: Login
+run_test "harbor login" \
+    "${HARBOR_BIN}" login "${HARBOR_URL}" \
+    --username "${HARBOR_USERNAME}" \
+    --password "${HARBOR_PASSWORD}"
+
+# Test 2: Health check
+run_test "harbor health" \
+    "${HARBOR_BIN}" health
+
+# Test 3: Project list (should succeed, may be empty)
+run_test "harbor project list" \
+    "${HARBOR_BIN}" project list
+
+# Test 4: Create a project (--storage-limit required for non-interactive mode)
+run_test "harbor project create" \
+    "${HARBOR_BIN}" project create "e2e-smoke-test" --public --storage-limit "-1"
+
+# Test 5: Project list (should include the new project)
+run_test "harbor project list (verify new project)" \
+    "${HARBOR_BIN}" project list --output-format json
+
+# Test 6: Repository list within the project (should be empty, but command must succeed)
+run_test "harbor repo list" \
+    "${HARBOR_BIN}" repo list "e2e-smoke-test"
+
+# Test 7: Delete the project
+run_test "harbor project delete" \
+    "${HARBOR_BIN}" project delete "e2e-smoke-test"
+
+# Test 8: User list (requires admin)
+run_test "harbor user list" \
+    "${HARBOR_BIN}" user list
+
+# Test 9: Create a user
+TEST_USER="e2e-test-user"
+TEST_EMAIL="e2e-test@harbor.local"
+run_test "harbor user create" \
+    "${HARBOR_BIN}" user create \
+    --username "${TEST_USER}" \
+    --email "${TEST_EMAIL}" \
+    --realname "E2E Test User" \
+    --password "TestPass123"
+
+# Test 10: User list (should include new user)
+run_test "harbor user list (verify new user)" \
+    "${HARBOR_BIN}" user list --output-format json
+
+# Test 11: Delete the user
+run_test "harbor user delete" \
+    "${HARBOR_BIN}" user delete "${TEST_USER}"
+
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+
+if [ "${FAIL}" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Implements #670 — adds an end-to-end smoke test pipeline that starts a real Harbor instance in GitHub Actions, authenticates the CLI against it, and validates core commands.

## What changed

### New files
- **`test/e2e/docker-compose.yml`** — Minimal Harbor stack (postgres, redis, registry, harbor-core v2.12.2) with health checks and env-var-based configuration
- **`test/e2e/setup.sh`** — Generates Harbor config files (`app.conf`, encryption key, RSA keypair) before compose starts
- **`test/e2e/smoke_test.sh`** — 11-test smoke suite covering login, health, project CRUD, repo list, user CRUD
- **`.github/workflows/e2e.yaml`** — CI job that builds the CLI, deploys Harbor, runs tests, collects logs on failure, and tears down

### Modified files
- **`.gitignore`** — Added `harbor-dev` binary and generated `test/e2e/config/` directory

## Details

**Smoke test coverage:**
1. `harbor login` (non-interactive, using env-var-based encryption key)
2. `harbor health`
3. `harbor project list`
4. `harbor project create e2e-smoke-test`
5. `harbor project list --output-format json`
6. `harbor repo list e2e-smoke-test`
7. `harbor project delete e2e-smoke-test`
8. `harbor user list`
9. `harbor user create e2e-test-user`
10. `harbor user list --output-format json`
11. `harbor user delete e2e-test-user`

**Key design decisions:**
- Encryption key via `HARBOR_ENCRYPTION_KEY` env var (EnvironmentKeyring provider) — avoids CI needing OS keychain
- Config isolation via `HARBOR_CLI_CONFIG` pointing to a temp file
- `--storage-limit "-1"` flag on project create to bypass interactive TUI
- Harbor config generated fresh each run via `setup.sh` (not committed)
- Health polling: 60 attempts × 5s (5 min timeout) — sufficient for DB migrations
- Log collection on failure + always-teardown cleanup

**Triggers:** PR, push to main, manual `workflow_dispatch`

Closes #670