### PR TITLE
refactor(output): replace log.Info and log.Infof statements with Printf and log.Debugf statements

### DIFF
--- a/cmd/harbor/root/context/delete.go
+++ b/cmd/harbor/root/context/delete.go
@@ -81,9 +81,9 @@ If you specify --name, that credential (rather than the "current" one) will be u
 				}
 
 				if found {
-					logrus.Infof("Removed credential '%s' and cleared CurrentCredentialName", currentName)
+					logrus.Debugf("Removed credential '%s' and cleared CurrentCredentialName", currentName)
 				} else {
-					logrus.Infof("No credential named '%s' found; cleared CurrentCredentialName anyway", currentName)
+					logrus.Debugf("No credential named '%s' found; cleared CurrentCredentialName anyway", currentName)
 				}
 
 				return nil

--- a/cmd/harbor/root/context/update.go
+++ b/cmd/harbor/root/context/update.go
@@ -69,8 +69,7 @@ If you specify --name, that credential (rather than the "current" one) will be u
 
 			// 5. Confirm to the user (logrus.Info is fine here; no error)
 			canonicalPath := strings.Join(actualSegments, ".")
-			logrus.Infof("Successfully updated %s to '%s'", canonicalPath, newValue)
-
+			fmt.Printf("Successfully updated %s to '%s'\n", canonicalPath, newValue)
 			return nil
 		},
 	}

--- a/cmd/harbor/root/project/list.go
+++ b/cmd/harbor/root/project/list.go
@@ -93,7 +93,7 @@ func ListProjectCommand() *cobra.Command {
 
 			log.WithField("count", len(allProjects)).Debug("Number of projects fetched")
 			if len(allProjects) == 0 {
-				log.Info("No projects found")
+				fmt.Println("No projects found")
 				return nil
 			}
 			formatFlag := viper.GetString("output-format")

--- a/cmd/harbor/root/project/robot/create.go
+++ b/cmd/harbor/root/project/robot/create.go
@@ -102,7 +102,7 @@ Examples:
 				if loadErr != nil {
 					return fmt.Errorf("failed to load robot config from file: %v", loadErr)
 				}
-				logrus.Info("Successfully loaded robot configuration")
+				logrus.Debug("Successfully loaded robot configuration")
 				opts = *loadedOpts
 				if opts.ProjectName == "" {
 					opts.ProjectName = opts.Permissions[0].Namespace
@@ -196,7 +196,7 @@ Examples:
 				return fmt.Errorf("failed to create robot: %v", utils.ParseHarborErrorMsg(err))
 			}
 
-			logrus.Infof("Successfully created robot account '%s' (ID: %d)",
+			fmt.Printf("Successfully created robot account '%s' (ID: %d)\n",
 				response.Payload.Name, response.Payload.ID)
 
 			FormatFlag := viper.GetString("output-format")
@@ -209,7 +209,7 @@ Examples:
 			name, secret := response.Payload.Name, response.Payload.Secret
 
 			if exportToFile {
-				logrus.Info("Exporting robot credentials to file")
+				fmt.Printf("Exporting robot credentials to file\n")
 				exportSecretToFile(name, secret, response.Payload.CreationTime.String(), response.Payload.ExpiresAt)
 				return nil
 			} else {

--- a/cmd/harbor/root/project/robot/refresh.go
+++ b/cmd/harbor/root/project/robot/refresh.go
@@ -106,7 +106,7 @@ Examples:
 				return fmt.Errorf("failed to refresh robot secret: %v\n", err)
 			}
 
-			log.Info("Secret updated successfully.")
+			fmt.Println("Secret updated successfully.")
 
 			if response.Payload.Secret != "" {
 				secret = response.Payload.Secret

--- a/cmd/harbor/root/quota/update.go
+++ b/cmd/harbor/root/quota/update.go
@@ -22,7 +22,6 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/quota/update"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -80,7 +79,7 @@ func UpdateQuotaCommand() *cobra.Command {
 				return fmt.Errorf("failed to update quota: %v", err)
 			}
 
-			log.Infof("quota updated successfully!")
+			fmt.Println("Quota updated successfully!")
 
 			return nil
 		},

--- a/cmd/harbor/root/registry/list.go
+++ b/cmd/harbor/root/registry/list.go
@@ -49,7 +49,7 @@ func ListRegistryCommand() *cobra.Command {
 				return fmt.Errorf("failed to get projects list: %v", err)
 			}
 			if len(registry.Payload) == 0 {
-				log.Info("No registries found")
+				fmt.Println("No registries found")
 				return nil
 			}
 			formatFlag := viper.GetString("output-format")

--- a/cmd/harbor/root/replication/executions/list.go
+++ b/cmd/harbor/root/replication/executions/list.go
@@ -68,7 +68,7 @@ func ListCommand() *cobra.Command {
 
 			log.WithField("count", len(executions.Payload)).Debug("Number of executions fetched")
 			if len(executions.Payload) == 0 {
-				log.Info("No executions found")
+				fmt.Println("No executions found")
 				return nil
 			}
 

--- a/cmd/harbor/root/replication/policies/list.go
+++ b/cmd/harbor/root/replication/policies/list.go
@@ -52,7 +52,7 @@ func ListCommand() *cobra.Command {
 
 			log.WithField("count", len(allPolicies.Payload)).Debug("Number of policies fetched")
 			if len(allPolicies.Payload) == 0 {
-				log.Info("No policies found")
+				fmt.Println("No policies found")
 				return nil
 			}
 

--- a/cmd/harbor/root/replication/policies/update.go
+++ b/cmd/harbor/root/replication/policies/update.go
@@ -96,7 +96,7 @@ func UpdateCommand() *cobra.Command {
 				}
 			}
 
-			log.Infof("Updating replication policy: %s (ID: %d)", existingPolicy.Payload.Name, policyID)
+			log.Debugf("Updating replication policy: %s (ID: %d)", existingPolicy.Payload.Name, policyID)
 			create.CreateRPolicyView(createView, true)
 
 			var updatedPolicy *models.ReplicationPolicy
@@ -114,7 +114,7 @@ func UpdateCommand() *cobra.Command {
 				return fmt.Errorf("failed to update replication policy: %w", err)
 			}
 
-			log.Infof("Successfully updated replication policy: %s (ID: %d)", updatedPolicy.Name, policyID)
+			fmt.Printf("Successfully updated replication policy: %s (ID: %d)\n", updatedPolicy.Name, policyID)
 			return nil
 		},
 	}

--- a/cmd/harbor/root/repository/list.go
+++ b/cmd/harbor/root/repository/list.go
@@ -65,7 +65,7 @@ func ListRepositoryCommand() *cobra.Command {
 				return fmt.Errorf("failed to list repositories: %v", err)
 			}
 			if len(repos.Payload) == 0 {
-				log.Info("No repositories found")
+				fmt.Println("No repositories found")
 				return nil
 			}
 			FormatFlag := viper.GetString("output-format")

--- a/cmd/harbor/root/robot/create.go
+++ b/cmd/harbor/root/robot/create.go
@@ -129,7 +129,7 @@ func loadFromConfigFile(opts *create.CreateView, configFile string, permissions 
 		return fmt.Errorf("failed to load robot config from file: %v", err)
 	}
 
-	logrus.Info("Successfully loaded robot configuration")
+	logrus.Debug("Successfully loaded robot configuration")
 	*opts = *loadedOpts
 
 	if opts.Level != "system" {
@@ -158,7 +158,7 @@ func loadFromConfigFile(opts *create.CreateView, configFile string, permissions 
 		}
 	}
 
-	logrus.Infof("Loaded system robot with %d system permissions and %d project-specific permissions",
+	logrus.Debugf("Loaded system robot with %d system permissions and %d project-specific permissions",
 		len(*permissions), len(projectPermissionsMap))
 
 	return nil
@@ -326,7 +326,7 @@ func createRobotAndHandleResponse(opts *create.CreateView, exportToFile bool) er
 		}
 	}
 
-	logrus.Infof("Successfully created robot account '%s' (ID: %d)",
+	fmt.Printf("Successfully created robot account '%s' (ID: %d)\n",
 		response.Payload.Name, response.Payload.ID)
 
 	// Handle output format
@@ -340,7 +340,7 @@ func createRobotAndHandleResponse(opts *create.CreateView, exportToFile bool) er
 	name, secret := response.Payload.Name, response.Payload.Secret
 
 	if exportToFile {
-		logrus.Info("Exporting robot credentials to file")
+		fmt.Printf("Exporting robot credentials to file\n")
 		exportSecretToFile(name, secret, response.Payload.CreationTime.String(), response.Payload.ExpiresAt)
 		return nil
 	}

--- a/cmd/harbor/root/robot/refresh.go
+++ b/cmd/harbor/root/robot/refresh.go
@@ -107,7 +107,7 @@ Examples:
 				}
 			}
 
-			log.Info("Secret updated successfully.")
+			fmt.Println("Secret updated successfully.")
 
 			if response.Payload.Secret != "" {
 				secret = response.Payload.Secret

--- a/cmd/harbor/root/robot/update.go
+++ b/cmd/harbor/root/robot/update.go
@@ -144,7 +144,7 @@ Examples:
 				}
 			}
 
-			logrus.Infof("Loaded robot with %d system permissions and %d project-specific permissions",
+			logrus.Debugf("Loaded robot with %d system permissions and %d project-specific permissions",
 				len(permissions), len(projectPermissionsMap))
 
 			// Handle configuration from file or interactive input
@@ -187,7 +187,7 @@ func loadFromConfigFileForUpdate(opts *update.UpdateView, configFile string, per
 		return fmt.Errorf("failed to load robot config from file: %v", err)
 	}
 
-	logrus.Info("Successfully loaded robot configuration")
+	logrus.Debug("Successfully loaded robot configuration")
 
 	// Only update fields that should be updated from the config file
 	// IMPORTANT: Do not update name or level as the Harbor API doesn't allow this
@@ -230,7 +230,7 @@ func loadFromConfigFileForUpdate(opts *update.UpdateView, configFile string, per
 		}
 	}
 
-	logrus.Infof("Loaded robot update with %d system permissions and %d project-specific permissions",
+	logrus.Debugf("Loaded robot update with %d system permissions and %d project-specific permissions",
 		len(*permissions), len(projectPermissionsMap))
 
 	return nil
@@ -264,7 +264,7 @@ func handleInteractiveInputForUpdate(opts *update.UpdateView, all bool, permissi
 	}
 
 	if !updatePerms {
-		logrus.Info("Keeping existing permissions")
+		logrus.Debug("Keeping existing permissions")
 		return nil
 	}
 
@@ -296,7 +296,7 @@ func getSystemPermissionsForUpdate(all bool, permissions *[]models.Permission) e
 	}
 
 	if !updateSystem {
-		logrus.Info("Keeping existing system permissions")
+		logrus.Debug("Keeping existing system permissions")
 		return nil
 	}
 
@@ -328,10 +328,10 @@ func getProjectPermissionsForUpdate(opts *update.UpdateView, projectPermissionsM
 
 	switch permissionMode {
 	case "keep":
-		logrus.Info("Keeping existing project permissions")
+		logrus.Debug("Keeping existing project permissions")
 		return nil
 	case "clear":
-		logrus.Info("Clearing all project permissions")
+		logrus.Debug("Clearing all project permissions")
 		// Clear the map to remove all project permissions
 		for k := range projectPermissionsMap {
 			delete(projectPermissionsMap, k)
@@ -583,7 +583,7 @@ func updateRobotAndHandleResponse(opts *update.UpdateView) error {
 		return fmt.Errorf("failed to update robot: %v", utils.ParseHarborErrorMsg(err))
 	}
 
-	logrus.Infof("Successfully updated robot account '%s' (ID: %d)", opts.Name, opts.ID)
+	fmt.Printf("Successfully updated robot account '%s' (ID: %d)\n", opts.Name, opts.ID)
 
 	// Handle output format
 	if formatFlag := viper.GetString("output-format"); formatFlag != "" {

--- a/cmd/harbor/root/scan_all/metrics.go
+++ b/cmd/harbor/root/scan_all/metrics.go
@@ -54,7 +54,7 @@ Examples:
   harbor-cli scan-all metrics --output-format json`,
 		Args: cobra.MaximumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			logrus.Info("Retrieving scan all metrics")
+			logrus.Debug("Retrieving scan all metrics")
 			metrics, err := api.GetScanAllMetrics(scheduled)
 			if err != nil {
 				logrus.Errorf("Failed to retrieve scan all metrics: %v", utils.ParseHarborErrorMsg(err))

--- a/cmd/harbor/root/scan_all/run.go
+++ b/cmd/harbor/root/scan_all/run.go
@@ -54,7 +54,7 @@ The scan progress and results can be monitored through the metrics command
 or through the Harbor web interface.`,
 		Args: cobra.MaximumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			logrus.Info("Initiating manual scan of all artifacts")
+			logrus.Debug("Initiating manual scan of all artifacts")
 			// Random cron expression and random time need to be passed to the API, even though they are not used, otherwise it returns bad request
 			randomCron := "0 * * * * *"
 			randomTime := strfmt.DateTime{}
@@ -62,7 +62,7 @@ or through the Harbor web interface.`,
 			if err != nil {
 				return fmt.Errorf("failed to start scan all operation: %v", utils.ParseHarborErrorMsg(err))
 			}
-			logrus.Info("Successfully started scan all operation")
+			fmt.Printf("Successfully started scan all operation\n")
 			return nil
 		},
 	}

--- a/cmd/harbor/root/scan_all/stop.go
+++ b/cmd/harbor/root/scan_all/stop.go
@@ -14,6 +14,8 @@
 package scan_all
 
 import (
+	"fmt"
+
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/sirupsen/logrus"
@@ -37,13 +39,13 @@ Examples:
   harbor-cli scan-all stop && harbor-cli scan-all metrics`,
 		Args: cobra.MaximumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			logrus.Info("Stopping scan all operation")
+			logrus.Debug("Stopping scan all operation")
 			err := api.StopScanAll()
 			if err != nil {
 				logrus.Errorf("Failed to stop scan all operation: %v", utils.ParseHarborErrorMsg(err))
 				return err
 			}
-			logrus.Info("Successfully stopped scan all operation")
+			fmt.Printf("Successfully stopped scan all operation\n")
 			return nil
 		},
 	}

--- a/cmd/harbor/root/scan_all/update_schedule.go
+++ b/cmd/harbor/root/scan_all/update_schedule.go
@@ -84,7 +84,7 @@ Note: For custom schedules, if you provide a 5-field cron expression, the CLI wi
 				return fmt.Errorf("invalid schedule type: %s. Valid types are: none, hourly, daily, weekly, custom", args[0])
 			}
 
-			logrus.Infof("Updating scan all schedule to type: %s", scheduleType)
+			logrus.Debugf("Updating scan all schedule to type: %s", scheduleType)
 
 			switch scheduleType {
 			case "None":
@@ -108,17 +108,17 @@ Note: For custom schedules, if you provide a 5-field cron expression, the CLI wi
 }
 
 func updateScheduleToNone() error {
-	logrus.Info("Setting scan all schedule to None (disabled)")
+	logrus.Debug("Setting scan all schedule to None (disabled)")
 	err := api.UpdateScanAllSchedule(models.ScheduleObj{Type: "None"})
 	if err != nil {
 		return fmt.Errorf("failed to disable scan schedule: %v", utils.ParseHarborErrorMsg(err))
 	}
-	logrus.Info("Successfully disabled scan all schedule")
+	fmt.Printf("Successfully disabled scan all schedule\n")
 	return nil
 }
 
 func updatePredefinedSchedule(scheduleType string) error {
-	logrus.Infof("Setting scan all schedule to %s", scheduleType)
+	logrus.Debugf("Setting scan all schedule to %s", scheduleType)
 
 	// Random cron expression and time needed by API
 	randomCron := "0 0 * * * * "
@@ -134,13 +134,13 @@ func updatePredefinedSchedule(scheduleType string) error {
 		return fmt.Errorf("failed to update scan schedule: %v", utils.ParseHarborErrorMsg(err))
 	}
 
-	logrus.Infof("Successfully set scan all schedule to %s", scheduleType)
+	fmt.Printf("Successfully set scan all schedule to %s\n", scheduleType)
 	return nil
 }
 
 func updateCustomSchedule(cron string) error {
 	if cron == "" {
-		logrus.Info("Opening interactive form for custom schedule configuration")
+		logrus.Debug("Opening interactive form for custom schedule configuration")
 		update.UpdateSchedule(&cron)
 	}
 
@@ -148,7 +148,7 @@ func updateCustomSchedule(cron string) error {
 		return err
 	}
 
-	logrus.Infof("Setting scan all schedule with custom cron expression: %s", cron)
+	logrus.Debugf("Setting scan all schedule with custom cron expression: %s", cron)
 
 	// Random time needed by API
 	randomTime := strfmt.DateTime{}
@@ -166,7 +166,7 @@ func updateCustomSchedule(cron string) error {
 		return fmt.Errorf("failed to update scan schedule: %v", errMsg)
 	}
 
-	logrus.Info("Successfully set scan all schedule with custom cron expression")
+	fmt.Printf("Successfully set scan all schedule with custom cron expression\n")
 	return nil
 }
 
@@ -177,7 +177,7 @@ func validateCron(cron string) error {
 	fields := strings.Fields(cron)
 	if len(fields) < 6 {
 		if len(fields) == 5 {
-			logrus.Infof("Converting 5-field cron to 6-field by adding '0' for seconds")
+			logrus.Debugf("Converting 5-field cron to 6-field by adding '0' for seconds")
 			return fmt.Errorf("harbor requires 6-field cron format (including seconds). Try: '0 %s'", cron)
 		}
 		return fmt.Errorf("harbor requires 6-field cron format (seconds minute hour day month weekday)")

--- a/cmd/harbor/root/scan_all/view_schedule.go
+++ b/cmd/harbor/root/scan_all/view_schedule.go
@@ -50,7 +50,7 @@ You can use this command to verify changes after updating the schedule with the 
 		Args:    cobra.MaximumNArgs(0),
 		Aliases: []string{"vs"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			logrus.Info("Retrieving scan all schedule configuration")
+			logrus.Debug("Retrieving scan all schedule configuration")
 			schedule, err := api.GetScanAllSchedule()
 			if err != nil {
 				logrus.Errorf("Failed to retrieve scan all schedule: %v", utils.ParseHarborErrorMsg(err))

--- a/cmd/harbor/root/scanner/delete.go
+++ b/cmd/harbor/root/scanner/delete.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -58,7 +57,7 @@ Examples:
 			if err != nil {
 				return fmt.Errorf("failed to delete scanner: %v", err)
 			}
-			log.Infof("Scanner deleted successfully")
+				fmt.Printf("Scanner deleted successfully\n")
 			return nil
 		},
 	}

--- a/cmd/harbor/root/scanner/delete.go
+++ b/cmd/harbor/root/scanner/delete.go
@@ -57,7 +57,7 @@ Examples:
 			if err != nil {
 				return fmt.Errorf("failed to delete scanner: %v", err)
 			}
-				fmt.Printf("Scanner deleted successfully\n")
+			fmt.Printf("Scanner deleted successfully\n")
 			return nil
 		},
 	}

--- a/cmd/harbor/root/scanner/list.go
+++ b/cmd/harbor/root/scanner/list.go
@@ -19,7 +19,6 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	list "github.com/goharbor/harbor-cli/pkg/views/scanner/list"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -37,7 +36,7 @@ func ListScannerCommand() *cobra.Command {
 
 			scanners := scannersResp.Payload
 			if len(scanners) == 0 {
-				log.Info("No scanners found")
+				fmt.Println("No scanners found")
 				return nil
 			}
 

--- a/cmd/harbor/root/scanner/update.go
+++ b/cmd/harbor/root/scanner/update.go
@@ -23,7 +23,6 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/scanner/create"
 	"github.com/goharbor/harbor-cli/pkg/views/scanner/update"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -117,7 +116,7 @@ Only the fields passed through flags will be updated; other fields will retain t
 				return fmt.Errorf("failed to update scanner: %v", err)
 			}
 
-			log.Infof("Scanner %q updated successfully", updateView.Name)
+				fmt.Printf("Scanner %q updated successfully\n", updateView.Name)
 			return nil
 		},
 	}

--- a/cmd/harbor/root/scanner/update.go
+++ b/cmd/harbor/root/scanner/update.go
@@ -116,7 +116,7 @@ Only the fields passed through flags will be updated; other fields will retain t
 				return fmt.Errorf("failed to update scanner: %v", err)
 			}
 
-				fmt.Printf("Scanner %q updated successfully\n", updateView.Name)
+			fmt.Printf("Scanner %q updated successfully\n", updateView.Name)
 			return nil
 		},
 	}

--- a/cmd/harbor/root/user/list.go
+++ b/cmd/harbor/root/user/list.go
@@ -78,7 +78,7 @@ func UserListCmd() *cobra.Command {
 				allUsers = response.Payload
 			}
 			if len(allUsers) == 0 {
-				log.Info("No users found")
+				fmt.Println("No users found")
 				return nil
 			}
 			formatFlag := viper.GetString("output-format")

--- a/cmd/harbor/root/vulnerability/list.go
+++ b/cmd/harbor/root/vulnerability/list.go
@@ -49,7 +49,7 @@ func ListVulnerabilitiesCommand() *cobra.Command {
 			}
 
 			if len(allVulnerabilities) == 0 {
-				log.Info("No vulnerabilities found")
+				fmt.Println("No vulnerabilities found")
 				return nil
 			}
 

--- a/pkg/api/artifact_handler.go
+++ b/pkg/api/artifact_handler.go
@@ -14,6 +14,8 @@
 package api
 
 import (
+	"fmt"
+
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/artifact"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/scan"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
@@ -38,7 +40,7 @@ func DeleteArtifact(projectName, repoName, reference string) error {
 		return err
 	}
 
-	log.Infof("Artifact deleted successfully: %s/%s@%s", projectName, repoName, reference)
+	fmt.Printf("Artifact deleted successfully: %s/%s@%s\n", projectName, repoName, reference)
 	return nil
 }
 
@@ -107,7 +109,7 @@ func StartScanArtifact(projectName, repoName, reference string) error {
 		return err
 	}
 
-	log.Infof("Scan started successfully: %s/%s@%s", projectName, repoName, reference)
+	fmt.Printf("Scan started successfully: %s/%s@%s\n", projectName, repoName, reference)
 	return nil
 }
 
@@ -128,7 +130,7 @@ func StopScanArtifact(projectName, repoName, reference string) error {
 		return err
 	}
 
-	log.Infof("Scan stopped successfully: %s/%s@%s", projectName, repoName, reference)
+	fmt.Printf("Scan stopped successfully: %s/%s@%s\n", projectName, repoName, reference)
 	return nil
 }
 
@@ -150,7 +152,7 @@ func DeleteTag(projectName, repoName, reference, tag string) error {
 		return err
 	}
 
-	log.Infof("Tag deleted successfully: %s/%s@%s:%s", projectName, repoName, reference, tag)
+	fmt.Printf("Tag deleted successfully: %s/%s@%s:%s\n", projectName, repoName, reference, tag)
 	return nil
 }
 
@@ -193,7 +195,7 @@ func CreateTag(projectName, repoName, reference, tagName string) error {
 		log.Errorf("Failed to create tag: %v", err)
 		return err
 	}
-	log.Infof("Tag created successfully: %s/%s@%s:%s", projectName, repoName, reference, tagName)
+	fmt.Printf("Tag created successfully: %s/%s@%s:%s\n", projectName, repoName, reference, tagName)
 	return nil
 }
 

--- a/pkg/api/cveallowlist_handler.go
+++ b/pkg/api/cveallowlist_handler.go
@@ -14,6 +14,7 @@
 package api
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -21,7 +22,6 @@ import (
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/cveallowlist/update"
-	log "github.com/sirupsen/logrus"
 )
 
 func ListSystemCve() (system_cve_allowlist.GetSystemCVEAllowlistOK, error) {
@@ -66,7 +66,7 @@ func UpdateSystemCve(opts update.UpdateView) error {
 	}
 
 	if response != nil {
-		log.Info("cveallowlist added successfully")
+		fmt.Println("Cveallowlist added successfully")
 	}
 	return nil
 }

--- a/pkg/api/immutable_handler.go
+++ b/pkg/api/immutable_handler.go
@@ -14,11 +14,12 @@
 package api
 
 import (
+	"fmt"
+
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/immutable"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/immutable/create"
-	log "github.com/sirupsen/logrus"
 )
 
 func CreateImmutable(opts create.CreateView, projectName string) error {
@@ -46,7 +47,7 @@ func CreateImmutable(opts create.CreateView, projectName string) error {
 		return err
 	}
 
-	log.Info("Added Tag Immutability Rule")
+	fmt.Println("Added Tag Immutability Rule")
 	return nil
 }
 
@@ -73,7 +74,7 @@ func DeleteImmutable(projectName string, ImmutableID int64) error {
 		return err
 	}
 
-	log.Info("immutable rule deleted successfully")
+	fmt.Println("Immutable rule deleted successfully")
 
 	return nil
 }

--- a/pkg/api/instance_handler.go
+++ b/pkg/api/instance_handler.go
@@ -21,7 +21,6 @@ import (
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/instance/create"
-	log "github.com/sirupsen/logrus"
 )
 
 func CreateInstance(opts create.CreateView) error {
@@ -35,7 +34,7 @@ func CreateInstance(opts create.CreateView) error {
 		return err
 	}
 
-	log.Infof("Instance %s created", opts.Name)
+	fmt.Printf("Instance %s created\n", opts.Name)
 	return nil
 }
 
@@ -50,7 +49,7 @@ func DeleteInstance(instanceName string) error {
 		return err
 	}
 
-	log.Info("instance deleted successfully")
+	fmt.Println("Instance deleted successfully")
 
 	return nil
 }

--- a/pkg/api/member_handler.go
+++ b/pkg/api/member_handler.go
@@ -23,7 +23,6 @@ import (
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/member/create"
-	log "github.com/sirupsen/logrus"
 )
 
 // Function variables for testing - these can be swapped in tests
@@ -93,7 +92,7 @@ func CreateMember(opts create.CreateView) error {
 	}
 
 	if response != nil {
-		log.Info("Member created successfully")
+		fmt.Println("Member created successfully")
 	}
 
 	return nil
@@ -109,7 +108,7 @@ func DeleteAllMember(projectName string, xIsResourceName bool) error {
 
 	length := len(response.Payload)
 	if length < 1 {
-		log.Info("No members found in project")
+		fmt.Println("No members found in project")
 		return fmt.Errorf("no members found in project %s", projectName)
 	}
 
@@ -160,7 +159,7 @@ func DeleteMember(projectName string, memberID int64, xIsResourceName bool) erro
 		return err
 	}
 
-	log.Info("Member deleted successfully")
+	fmt.Println("Member deleted successfully")
 	return nil
 }
 
@@ -192,7 +191,7 @@ func DeleteMemberByUsername(projectName string, username string, xIsResourceName
 		return err
 	}
 
-	log.Info("Member deleted successfully")
+	fmt.Println("Member deleted successfully")
 	return nil
 }
 
@@ -214,7 +213,7 @@ func UpdateMember(opts UpdateMemberOptions) error {
 		return err
 	}
 
-	log.Info("member role updated successfully")
+	fmt.Println("Member role updated successfully")
 
 	return nil
 }

--- a/pkg/api/project_config_handler.go
+++ b/pkg/api/project_config_handler.go
@@ -14,12 +14,13 @@
 package api
 
 import (
+	"fmt"
+
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/project"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/project_metadata"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 )
 
 func ListConfig(isID bool, projectNameOrID string) (*project_metadata.ListProjectMetadatasOK, error) {
@@ -55,7 +56,7 @@ func UpdateConfig(isID bool, projectNameOrID string, metadata models.ProjectMeta
 		return err
 	}
 	if response != nil {
-		log.Info("Metadata updated successfully")
+		fmt.Println("Metadata updated successfully")
 	}
 
 	return nil

--- a/pkg/api/project_handler.go
+++ b/pkg/api/project_handler.go
@@ -14,6 +14,7 @@
 package api
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/project"
@@ -47,7 +48,7 @@ func CreateProject(opts create.CreateView) error {
 	}
 
 	if response != nil {
-		log.Info("Project created successfully")
+		fmt.Println("Project created successfully")
 	}
 	return nil
 }
@@ -138,7 +139,7 @@ func DeleteProject(projectNameOrID string, forceDelete bool, useProjectID bool) 
 		return err
 	}
 
-	log.Infof("Project %s deleted successfully", projectNameOrID)
+	fmt.Printf("Project %s deleted successfully\n", projectNameOrID)
 	return nil
 }
 

--- a/pkg/api/registry_handler.go
+++ b/pkg/api/registry_handler.go
@@ -19,7 +19,6 @@ import (
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/registry"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 )
 
 func ListRegistries(opts ...ListFlags) (*registry.ListRegistriesOK, error) {
@@ -75,7 +74,7 @@ func CreateRegistry(opts CreateRegView) error {
 		return err
 	}
 
-	log.Infof("Registry %s created", opts.Name)
+	fmt.Printf("Registry %s created\n", opts.Name)
 	return nil
 }
 
@@ -89,7 +88,7 @@ func DeleteRegistry(registryName int64) error {
 		return err
 	}
 
-	log.Info("registry deleted successfully")
+	fmt.Println("Registry deleted successfully")
 
 	return nil
 }
@@ -152,7 +151,7 @@ func UpdateRegistry(updateView *models.Registry, projectID int64) error {
 		return err
 	}
 
-	log.Info("registry updated successfully")
+	fmt.Println("Registry updated successfully")
 
 	return nil
 }

--- a/pkg/api/repository_handler.go
+++ b/pkg/api/repository_handler.go
@@ -14,10 +14,11 @@
 package api
 
 import (
+	"fmt"
+
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/repository"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/search"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 )
 
 func RepoDelete(projectNameOrID, repoName string, useProjectID bool) error {
@@ -40,7 +41,7 @@ func RepoDelete(projectNameOrID, repoName string, useProjectID bool) error {
 		return err
 	}
 
-	log.Infof("Repository %s/%s deleted successfully", projectName, repoName)
+	fmt.Printf("Repository %s/%s deleted successfully\n", projectName, repoName)
 	return nil
 }
 

--- a/pkg/api/robot_handler.go
+++ b/pkg/api/robot_handler.go
@@ -150,7 +150,7 @@ func DeleteRobot(robotID int64) error {
 		return err
 	}
 
-	log.Info("robot deleted successfully")
+	fmt.Println("Robot deleted successfully")
 	return nil
 }
 
@@ -191,7 +191,7 @@ func CreateRobot(opts create.CreateView) (*robot.CreateRobotCreated, error) {
 		return nil, fmt.Errorf("failed to create robot: %v", utils.ParseHarborErrorMsg(err))
 	}
 
-	log.Info("robot created successfully.")
+	fmt.Println("Robot created successfully.")
 	return response, nil
 }
 
@@ -237,7 +237,7 @@ func UpdateRobot(opts *update.UpdateView) error {
 		return err
 	}
 
-	log.Info("robot updated successfully.")
+	fmt.Println("Robot updated successfully.")
 	return nil
 }
 

--- a/pkg/api/scan_all_handler.go
+++ b/pkg/api/scan_all_handler.go
@@ -14,10 +14,11 @@
 package api
 
 import (
+	"fmt"
+
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/scan_all"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 )
 
 func CreateScanAllSchedule(schedule models.ScheduleObj) error {
@@ -34,7 +35,7 @@ func CreateScanAllSchedule(schedule models.ScheduleObj) error {
 
 	if response != nil {
 		// The CreateScanAllSchedule API is used only for scanning all artifacts now
-		log.Info("Scan started successfully")
+		fmt.Println("Scan started successfully")
 	}
 	return nil
 }
@@ -52,7 +53,7 @@ func UpdateScanAllSchedule(schedule models.ScheduleObj) error {
 	}
 
 	if response != nil {
-		log.Info("Schedule updated successfully")
+		fmt.Println("Schedule updated successfully")
 	}
 	return nil
 }
@@ -70,7 +71,7 @@ func StopScanAll() error {
 	}
 
 	if response != nil {
-		log.Info("Scan all stopped successfully")
+		fmt.Println("Scan all stopped successfully")
 	}
 	return nil
 }

--- a/pkg/api/user_handler.go
+++ b/pkg/api/user_handler.go
@@ -14,13 +14,13 @@
 package api
 
 import (
+	"fmt"
+
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/user"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/password/reset"
 	"github.com/goharbor/harbor-cli/pkg/views/user/create"
-
-	log "github.com/sirupsen/logrus"
 )
 
 func CreateUser(opts create.CreateView) error {
@@ -43,7 +43,7 @@ func CreateUser(opts create.CreateView) error {
 	}
 
 	if response != nil {
-		log.Infof("User `%s` created successfully", opts.Username)
+		fmt.Printf("User `%s` created successfully\n", opts.Username)
 	}
 
 	return nil
@@ -59,7 +59,7 @@ func DeleteUser(userId int64) error {
 	if err != nil {
 		return err
 	}
-	log.Infof("User deleted successfully with id %d", userId)
+	fmt.Printf("User deleted successfully with id %d\n", userId)
 	return nil
 }
 
@@ -76,7 +76,7 @@ func ElevateUser(userId int64) error {
 	if err != nil {
 		return err
 	}
-	log.Infof("user elevated role to admin successfully with id %d", userId)
+	fmt.Printf("user elevated role to admin successfully with id %d\n", userId)
 	return nil
 }
 
@@ -136,7 +136,7 @@ func ResetPassword(userId int64, opts reset.PasswordChangeView) error {
 		return err
 	}
 	if response != nil {
-		log.Infof("User password changed for userId %d", userId)
+		fmt.Printf("User password changed for userId %d\n", userId)
 	}
 	return nil
 }

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -257,7 +257,7 @@ func SetCurrentHarborConfig(config *HarborConfig) error {
 	// Update our global in-memory config
 	CurrentHarborConfig = config
 
-	log.Infof("Harbor configuration updated at %s", configPath)
+	fmt.Printf("Harbor configuration updated at %s", configPath)
 	return err
 }
 
@@ -304,7 +304,7 @@ func CreateDataFile(dataFilePath string, initialConfigPath string) error {
 			log.Fatalf("Failed to write data file: %v", err)
 		}
 
-		log.Infof("Data file created at %s with configPath: %s", dataFilePath, dataFile.ConfigPath)
+		fmt.Printf("Data file created at %s with configPath: %s\n", dataFilePath, dataFile.ConfigPath)
 	} else if err != nil {
 		log.Fatalf("Error checking data file: %v", err)
 	}
@@ -378,7 +378,7 @@ func UpdateDataFile(dataFilePath string, newConfigPath string) error {
 		log.Fatalf("failed to write updated data file: %v", err)
 	}
 
-	log.Infof("Data file at %s updated with new configPath: %s", dataFilePath, absConfigPath)
+	fmt.Printf("Data file at %s updated with new configPath: %s\n", dataFilePath, absConfigPath)
 	return nil
 }
 
@@ -405,7 +405,7 @@ func CreateConfigFile(configPath string) error {
 			log.Fatalf("failed to write config file: %v", err)
 		}
 
-		log.Infof("Config file created at %s", configPath)
+		fmt.Printf("Config file created at %s", configPath)
 	} else if err != nil {
 		log.Fatalf("error checking config file: %v", err)
 	}
@@ -421,7 +421,7 @@ func UpdateConfigFile(config *HarborConfig) error {
 
 	// Ensure we know where to write the config
 	if CurrentHarborData == nil {
-		return errors.New("harbor data is nil – check that your config initialization completed")
+		return errors.New("harbor data is nil, check that your config initialization completed")
 	}
 	configPath := CurrentHarborData.ConfigPath
 
@@ -452,7 +452,7 @@ func UpdateConfigFile(config *HarborConfig) error {
 	// Also update our global in-memory config
 	CurrentHarborConfig = config
 
-	log.Infof("Updated config file at %s", configPath)
+	fmt.Printf("Updated config file at %s\n", configPath)
 	return nil
 }
 
@@ -505,7 +505,7 @@ func AddCredentialsToConfigFile(credential Credential, configPath string) error 
 		log.Fatalf("failed to write updated config file: %v", err)
 	}
 
-	log.Infof("Added credential '%s' to config file at %s", credential.Name, configPath)
+	fmt.Printf("Added credential '%s' to config file at %s\n", credential.Name, configPath)
 	return nil
 }
 
@@ -550,7 +550,7 @@ func UpdateCredentialsInConfigFile(updatedCredential Credential, configPath stri
 		log.Fatalf("failed to write updated config file: %v", err)
 	}
 
-	log.Infof("Updated credential '%s' in config file at %s.", updatedCredential.Name, configPath)
-	log.Infof("Switched to context '%s'", updatedCredential.Name)
+	fmt.Printf("Updated credential '%s' in config file at %s.\n", updatedCredential.Name, configPath)
+	fmt.Printf("Switched to context '%s'\n", updatedCredential.Name)
 	return nil
 }

--- a/pkg/utils/encryption.go
+++ b/pkg/utils/encryption.go
@@ -153,7 +153,7 @@ func GetKeyringProvider() KeyringProvider {
 		BaseDir: filepath.Join(homeDir, ".harbor", "keyring"),
 	}
 
-	logrus.Info("System keyring not available, using file-based keyring")
+	logrus.Warn("System keyring not available, using file-based keyring")
 	return fileKeyring
 }
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -84,7 +84,7 @@ func ParseProjectRepo(projectRepo string) (project, repo string, err error) {
 }
 
 func ParseProjectRepoReference(projectRepoReference string) (project, repo, reference string, err error) {
-	log.Infof("Parsing input: %s", projectRepoReference)
+	log.Debugf("Parsing input: %s", projectRepoReference)
 
 	var ref string
 	var repoPath string


### PR DESCRIPTION


## Description
Briefly describe what this pull request does and why the change is needed.

- Fixes #883 

## Type of Change

To fulfill our effort to make Harbor CLI more user and developer friendly messy usage of log.Info statements were removed. It has been agreed on that user facing outputs about confirmation or related info shall not be go through a log, but directly be handled by the cobra output stream as of using Print statements of the fmt package.


- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
- all log.Info statements were assessed whether they should be user facing output or debug output
- most statements were classified as simple user feed using Printf with newline format
- two statements were adapted to log.Debugf statements because do not need to be seen by user
