### PR TITLE
fix: return error on robot not found in delete command

### DIFF
--- a/cmd/harbor/root/project/robot/delete.go
+++ b/cmd/harbor/root/project/robot/delete.go
@@ -80,7 +80,7 @@ Examples:
 				robotName := args[0]
 				robot, err := api.GetRobotByName(robotName, ProjectName)
 				if err != nil {
-					fmt.Print(utils.ParseHarborErrorMsg(err))
+					return fmt.Errorf("failed to get robot: %v", utils.ParseHarborErrorMsg(err))
 				}
 				robotID = robot.ID
 			} else if ProjectName != "" {


### PR DESCRIPTION
## Description

Fixes a nil pointer panic in `harbor project robot delete` when a non-existent robot name is passed.

Previously, the command printed the error but continued execution, causing a crash on `robot.ID`. This change returns the error immediately and prevents the panic.

fixes #891
---

## Type of Change

Please select the relevant type.

[x] Bug fix
[ ] New feature
[ ] Refactor
[ ] Documentation update
[ ] Chore / maintenance

---

## Changes

* Added early return when `GetRobotByName()` fails
* Prevented nil pointer dereference on invalid robot names
* Improved CLI error handling
