### PR TITLE
fix(doc): update missing man pages and doc entry

### DIFF
--- a/doc/cli-docs/harbor-repo-update.md
+++ b/doc/cli-docs/harbor-repo-update.md
@@ -34,7 +34,7 @@ harbor repo update [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
-  -o, --output-format string   Output format. One of: json|yaml
+  -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```
 

--- a/doc/man-docs/man1/harbor-repo-update.1
+++ b/doc/man-docs/man1/harbor-repo-update.1
@@ -37,7 +37,7 @@ Examples:
 
 .PP
 \fB-o\fP, \fB--output-format\fP=""
-	Output format. One of: json|yaml
+	Output format. One of: json|yaml|csv
 
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]


### PR DESCRIPTION
## Description
This PR contain changes to the documentations of `harbor repo update` command, which fixes the failure of the `lint` job in the CI pipeline.

- Fixes #892 

## Type of Change
Please select the relevant type.

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation update
- [x] Chore / maintenance

## Overview

The issue originated from this PR #714, where the author added and updated the docs before when the `csv` is added as an additional global output format in this [commit](https://github.com/goharbor/harbor-cli/commit/936dc97fb180cad192f333a607cfe75eab51b139).

Hence, the documentations of the `harbor repo update` command are missing, so the **Generate Document** step updates them, which is then conflicting with the next **Check for changes** step, causing the failure.

### Steps to reproduce
1. Sync the local `main` branch with the upstream.
2. Rebase the branch that you are working on the `main`. _(Optional, can be done on `main` itself, but just mentioning what exactly I did)_
3. From the project root, If `dagger` installed,
    - Run `dagger call run-doc --source=. export --path=doc`
4. Else
    - Run `cd ./doc`
    - Run `go run doc.go`
    - Run `go run man-docs/man_doc.go`
8. Now run, `git diff --name-staus HEAD..main`, then you will see the following as the output.

```fish
❯ git diff --name-status HEAD..main
M       doc/cli-docs/harbor-repo-update.md
M       doc/man-docs/man1/harbor-repo-update.1
```

## Changes
- `harbor-repo-update.md` CLI docs

  ```diff
  - -o, --output-format string   Output format. One of: json|yaml
  + -o, --output-format string   Output format. One of: json|yaml|csv
  ```
- `harbor-repo-update.1` man1 docs
  ```diff
  - Output format. One of: json|yaml
  + Output format. One of: json|yaml|csv
  ```

cc: @bupd