### PR TITLE
refactor(utils): extract shared pagination validation helper

### DIFF
--- a/cmd/harbor/root/artifact/list.go
+++ b/cmd/harbor/root/artifact/list.go
@@ -43,15 +43,8 @@ Supports pagination, search queries, and sorting using flags.`,
 
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if opts.Page < 1 {
-				return fmt.Errorf("page number must be greater than or equal to 1")
-			}
-			if opts.PageSize < 0 {
-				return fmt.Errorf("page size must be greater than or equal to 0")
-			}
-
-			if opts.PageSize > 100 {
-				return fmt.Errorf("page size should be less than or equal to 100")
+			if err := utils.ValidatePagination(opts.Page, opts.PageSize); err != nil {
+				return err
 			}
 			var err error
 			var artifacts artifact.ListArtifactsOK

--- a/cmd/harbor/root/project/list.go
+++ b/cmd/harbor/root/project/list.go
@@ -44,16 +44,8 @@ func ListProjectCommand() *cobra.Command {
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Debug("Starting project list command")
-			if opts.Page < 1 {
-				return fmt.Errorf("page number must be greater than or equal to 1")
-			}
-
-			if opts.PageSize < 0 {
-				return fmt.Errorf("page size must be greater than or equal to 0")
-			}
-
-			if opts.PageSize > 100 {
-				return fmt.Errorf("page size should be less than or equal to 100")
+			if err := utils.ValidatePagination(opts.Page, opts.PageSize); err != nil {
+				return err
 			}
 
 			if private && public {

--- a/cmd/harbor/root/registry/list.go
+++ b/cmd/harbor/root/registry/list.go
@@ -39,7 +39,7 @@ func ListRegistryCommand() *cobra.Command {
 			registry, err := api.ListRegistries(opts)
 
 			if err != nil {
-				return fmt.Errorf("failed to get projects list: %v", err)
+				return fmt.Errorf("failed to get registry list: %v", err)
 			}
 			if len(registry.Payload) == 0 {
 				fmt.Println("No registries found")

--- a/cmd/harbor/root/registry/list.go
+++ b/cmd/harbor/root/registry/list.go
@@ -33,15 +33,8 @@ func ListRegistryCommand() *cobra.Command {
 		Short: "list registry",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if opts.Page < 1 {
-				return fmt.Errorf("page number must be greater than or equal to 1")
-			}
-			if opts.PageSize < 0 {
-				return fmt.Errorf("page size must be greater than or equal to 0")
-			}
-
-			if opts.PageSize > 100 {
-				return fmt.Errorf("page size should be less than or equal to 100")
+			if err := utils.ValidatePagination(opts.Page, opts.PageSize); err != nil {
+				return err
 			}
 			registry, err := api.ListRegistries(opts)
 

--- a/cmd/harbor/root/user/list.go
+++ b/cmd/harbor/root/user/list.go
@@ -35,16 +35,8 @@ func UserListCmd() *cobra.Command {
 		Args:    cobra.ExactArgs(0),
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if opts.Page < 1 {
-				return fmt.Errorf("page number must be greater than or equal to 1")
-			}
-
-			if opts.PageSize < 0 {
-				return fmt.Errorf("page size must be greater than or equal to 0")
-			}
-
-			if opts.PageSize > 100 {
-				return fmt.Errorf("page size should be less than or equal to 100")
+			if err := utils.ValidatePagination(opts.Page, opts.PageSize); err != nil {
+				return err
 			}
 
 			if opts.PageSize == 0 {

--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -177,6 +177,9 @@ func ValidateRegistryName(rn string) bool {
 	return re.MatchString(rn)
 }
 
+// MaxPageSize is the maximum supported value for the page size parameter.
+const MaxPageSize int64 = 100
+
 // ValidatePagination validates page and page size parameters.
 func ValidatePagination(page, pageSize int64) error {
 	if page < 1 {
@@ -187,8 +190,8 @@ func ValidatePagination(page, pageSize int64) error {
 		return fmt.Errorf("page size must be greater than or equal to 0")
 	}
 
-	if pageSize > 100 {
-		return fmt.Errorf("page size should be less than or equal to 100")
+	if pageSize > MaxPageSize {
+		return fmt.Errorf("page size should be less than or equal to %d", MaxPageSize)
 	}
 
 	return nil

--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -177,6 +177,23 @@ func ValidateRegistryName(rn string) bool {
 	return re.MatchString(rn)
 }
 
+// ValidatePagination validates page and page size parameters.
+func ValidatePagination(page, pageSize int64) error {
+	if page < 1 {
+		return fmt.Errorf("page number must be greater than or equal to 1")
+	}
+
+	if pageSize < 0 {
+		return fmt.Errorf("page size must be greater than or equal to 0")
+	}
+
+	if pageSize > 100 {
+		return fmt.Errorf("page size should be less than or equal to 100")
+	}
+
+	return nil
+}
+
 // ValidateURL checks if the URL has valid format, non-empty host, and host is a valid IP or domain.
 // Domain regex: labels must start/end with alphanumeric, can contain hyphens, max 63 chars, TLD min 2 letters.
 func ValidateURL(rawURL string) error {

--- a/pkg/utils/helper_test.go
+++ b/pkg/utils/helper_test.go
@@ -129,6 +129,35 @@ func TestValidateRegistryName(t *testing.T) {
 	assert.False(t, utils.ValidateRegistryName("-bad"))
 }
 
+func TestValidatePagination(t *testing.T) {
+	tests := []struct {
+		name      string
+		page      int64
+		pageSize  int64
+		expectErr bool
+		errMsg    string
+	}{
+		{"valid page and size", 1, 10, false, ""},
+		{"page less than 1", 0, 10, true, "page number must be greater than or equal to 1"},
+		{"page size negative", 1, -1, true, "page size must be greater than or equal to 0"},
+		{"page size greater than 100", 1, 101, true, "page size should be less than or equal to 100"},
+		{"page size zero", 1, 0, false, ""},
+		{"page size 100", 1, 100, false, ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := utils.ValidatePagination(tc.page, tc.pageSize)
+			if tc.expectErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestValidateURL(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/utils/helper_test.go
+++ b/pkg/utils/helper_test.go
@@ -149,8 +149,7 @@ func TestValidatePagination(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			err := utils.ValidatePagination(tc.page, tc.pageSize)
 			if tc.expectErr {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), tc.errMsg)
+				assert.EqualError(t, err, tc.errMsg)
 			} else {
 				assert.NoError(t, err)
 			}


### PR DESCRIPTION
## Description
This PR centralizes and standardizes the pagination validation logic across multiple CLI commands. Currently, logic to validate `page` and `pageSize` is duplicated in several `list.go` files, leading to inconsistent error messages and maintenance overhead.

By moving this logic to a shared utility helper, we ensure a "Single Source of Truth" for pagination constraints, improve code reusability, and simplify the implementation of future commands.

- Fixes #894 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
- Created ValidatePagination(page, pageSize int64) error in pkg/utils/helper.go.
- Added comprehensive table-driven unit tests in pkg/utils/helper_test.go covering edge cases (page < 1, negative pageSize, and max pageSize).
- Refactored user list, project list, registry list, and artifact list to use the new centralized validation helper.
- Standardized pagination error messages across the CLI to improve User Experience (UX).
