### PR TITLE
refactor(utils): extract regular expressions to package scope

### DIFF
--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -25,6 +25,19 @@ import (
 	"unicode"
 )
 
+var (
+	emailRegex         = regexp.MustCompile(`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`)
+	configPathRegex    = regexp.MustCompile(`^[\w./-]{1,255}\.(yaml|yml)$`)
+	flRegex            = regexp.MustCompile(`^[A-Za-z]{1,20}\s[A-Za-z]{1,20}$`)
+	passwordLowerRegex = regexp.MustCompile(`([a-z])+`)
+	passwordUpperRegex = regexp.MustCompile(`([A-Z])+`)
+	passwordDigitRegex = regexp.MustCompile(`([0-9])+`)
+	tagNameRegex       = regexp.MustCompile(`^[\w][\w.-]{0,127}$`)
+	projectNameRegex   = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,254}$`)
+	registryNameRegex  = regexp.MustCompile(`^[\w][\w.-]{0,63}$`)
+	domainNameRegex    = regexp.MustCompile(`^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$`)
+)
+
 func pluralise(value int, unit string) string {
 	if value == 1 {
 		return fmt.Sprintf("%d %s ago", value, unit)
@@ -94,21 +107,15 @@ func ValidateUserName(username string) bool {
 }
 
 func ValidateEmail(email string) bool {
-	pattern := `^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`
-	re := regexp.MustCompile(pattern)
-	return re.MatchString(email)
+	return emailRegex.MatchString(email)
 }
 
 func ValidateConfigPath(configPath string) bool {
-	pattern := `^[\w./-]{1,255}\.(yaml|yml)$`
-	re := regexp.MustCompile(pattern)
-	return re.MatchString(configPath)
+	return configPathRegex.MatchString(configPath)
 }
 
 func ValidateFL(name string) bool {
-	pattern := `^[A-Za-z]{1,20}\s[A-Za-z]{1,20}$`
-	re := regexp.MustCompile(pattern)
-	return re.MatchString(name)
+	return flRegex.MatchString(name)
 }
 
 // check if the password format is valid
@@ -122,17 +129,17 @@ func ValidatePassword(password string) error {
 		return errors.New("wrong! the password length must be at least 8 characters and at most 256 characters")
 	}
 	// checking the password has a minimum of one lower case letter
-	if done, _ := regexp.MatchString("([a-z])+", password); !done {
+	if !passwordLowerRegex.MatchString(password) {
 		return errors.New("wrong! the password doesn't have a lowercase letter")
 	}
 
 	// checking the password has a minimum of one upper case letter
-	if done, _ := regexp.MatchString("([A-Z])+", password); !done {
+	if !passwordUpperRegex.MatchString(password) {
 		return errors.New("wrong! the password doesn't have an uppercase letter")
 	}
 
 	// checking if the password has a minimum of one digit
-	if done, _ := regexp.Match("([0-9])+", []byte(password)); !done {
+	if !passwordDigitRegex.MatchString(password) {
 		return errors.New("wrong! the password doesn't have a digit number")
 	}
 
@@ -141,20 +148,12 @@ func ValidatePassword(password string) error {
 
 // check if the tag name is valid
 func ValidateTagName(tagName string) bool {
-	pattern := `^[\w][\w.-]{0,127}$`
-
-	re := regexp.MustCompile(pattern)
-
-	return re.MatchString(tagName)
+	return tagNameRegex.MatchString(tagName)
 }
 
 // check if the project name is valid
 func ValidateProjectName(projectName string) bool {
-	pattern := `^[a-z0-9][a-z0-9._-]{0,254}$`
-
-	re := regexp.MustCompile(pattern)
-
-	return re.MatchString(projectName)
+	return projectNameRegex.MatchString(projectName)
 }
 
 func ValidateStorageLimit(sl string) error {
@@ -170,18 +169,12 @@ func ValidateStorageLimit(sl string) error {
 }
 
 func ValidateRegistryName(rn string) bool {
-	pattern := `^[\w][\w.-]{0,63}$`
-
-	re := regexp.MustCompile(pattern)
-
-	return re.MatchString(rn)
+	return registryNameRegex.MatchString(rn)
 }
 
 // ValidateURL checks if the URL has valid format, non-empty host, and host is a valid IP or domain.
 // Domain regex: labels must start/end with alphanumeric, can contain hyphens, max 63 chars, TLD min 2 letters.
 func ValidateURL(rawURL string) error {
-	var domainNameRegex = regexp.MustCompile(`^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$`)
-
 	parsedURL, err := url.ParseRequestURI(rawURL)
 	if err != nil {
 		return fmt.Errorf("invalid URL format: %v", err)


### PR DESCRIPTION
## Description
This PR refactors the validation functions in `pkg/utils/helper.go` to precompile their regular expressions at the package level instead of inside the function bodies. This is a small code-quality cleanup that aligns with standard Go best practices. Moving them to `var (...)` blocks prevents the regexes from being recompiled every time a validation function is called.

- Fixes #896 

## Type of Change
Please select the relevant type.

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
- Extracted regular expressions in `pkg/utils/helper.go` to package-level variables (e.g., `emailRegex`, `configPathRegex`).
- Updated the `Validate*` functions to use the precompiled variables.
- Replaced dynamic `regexp.MatchString` calls inside `ValidatePassword` with precompiled variables.
- Kept all regex patterns and validation logic exactly identical to preserve existing behavior.
- Verified all 16 unit tests in `pkg/utils` pass perfectly.