### PR TITLE
Feat: support --registry-name for proxy cache project creation

### DIFF
--- a/cmd/harbor/root/project/create.go
+++ b/cmd/harbor/root/project/create.go
@@ -26,6 +26,7 @@ import (
 // CreateProjectCommand creates a new `harbor create project` command
 func CreateProjectCommand() *cobra.Command {
 	var opts create.CreateView
+	var registryName string
 
 	cmd := &cobra.Command{
 		Use:   "create [project name]",
@@ -37,9 +38,19 @@ func CreateProjectCommand() *cobra.Command {
 			if len(args) > 0 {
 				opts.ProjectName = args[0]
 			}
+			if registryName != "" {
+				registryID, err := api.GetRegistryIdByName(registryName)
+				if err != nil {
+					return fmt.Errorf("failed to get registry ID for name %s: %v", registryName, err)
+				}
+				if registryID == 0 {
+					return fmt.Errorf("registry with name %s not found", registryName)
+				}
+				opts.RegistryID = fmt.Sprintf("%d", registryID)
+			}
 
 			if opts.ProxyCache && opts.RegistryID == "" {
-				return fmt.Errorf("proxy cache selected but no registry ID provided. Use --registry-id")
+				return fmt.Errorf("proxy cache selected but no registry ID or registry name provided. Use --registry-id or --registry-name")
 			}
 
 			if !opts.ProxyCache && opts.RegistryID != "" {
@@ -75,6 +86,7 @@ func CreateProjectCommand() *cobra.Command {
 	flags := cmd.Flags()
 	flags.BoolVarP(&opts.Public, "public", "", false, "Project is public or private")
 	flags.StringVarP(&opts.RegistryID, "registry-id", "", "", "ID of referenced registry when creating the proxy cache project")
+	flags.StringVarP(&registryName, "registry-name", "", "", "Name of referenced registry when creating the proxy cache project (alternative to --registry-id)")
 	flags.StringVarP(&opts.StorageLimit, "storage-limit", "", "", "Storage quota of the project")
 	flags.BoolVarP(&opts.ProxyCache, "proxy-cache", "", false, "Whether the project is a proxy cache project")
 

--- a/cmd/harbor/root/project/create.go
+++ b/cmd/harbor/root/project/create.go
@@ -38,6 +38,10 @@ func CreateProjectCommand() *cobra.Command {
 			if len(args) > 0 {
 				opts.ProjectName = args[0]
 			}
+			if opts.RegistryID != "" && registryName != "" {
+				return fmt.Errorf("cannot provide both --registry-id and --registry-name. Please use only one")
+			}
+
 			if registryName != "" {
 				registryID, err := api.GetRegistryIdByName(registryName)
 				if err != nil {
@@ -86,7 +90,7 @@ func CreateProjectCommand() *cobra.Command {
 	flags := cmd.Flags()
 	flags.BoolVarP(&opts.Public, "public", "", false, "Project is public or private")
 	flags.StringVarP(&opts.RegistryID, "registry-id", "", "", "ID of referenced registry when creating the proxy cache project")
-	flags.StringVarP(&registryName, "registry-name", "", "", "Name of referenced registry when creating the proxy cache project (alternative to --registry-id)")
+	flags.StringVarP(&registryName, "registry-name", "", "", "Name of referenced registry when creating the proxy cache project")
 	flags.StringVarP(&opts.StorageLimit, "storage-limit", "", "", "Storage quota of the project")
 	flags.BoolVarP(&opts.ProxyCache, "proxy-cache", "", false, "Whether the project is a proxy cache project")
 

--- a/pkg/views/project/create/view.go
+++ b/pkg/views/project/create/view.go
@@ -68,8 +68,8 @@ func CreateProjectView(createView *CreateView) error {
 	for id, name := range registryOptions {
 		registrySelectOptions = append(registrySelectOptions, huh.NewOption(name, id))
 	}
-
-	err = huh.NewForm(
+	var groups []*huh.Group
+	groups = append(groups,
 		huh.NewGroup(
 			huh.NewInput().
 				Title("Project Name").
@@ -108,23 +108,28 @@ func CreateProjectView(createView *CreateView) error {
 				Affirmative("yes").
 				Negative("no"),
 		),
-		huh.NewGroup(
-			huh.NewSelect[string]().
-				Validate(func(str string) error {
-					if createView.ProxyCache && str == "" {
-						return errors.New("registry ID cannot be empty")
-					}
-					return nil
-				}).
-				Description("Select a registry to reference when creating the proxy cache project").
-				Title("Registry ID").
-				Value(&createView.RegistryID).
-				Options(registrySelectOptions...),
-		).WithHideFunc(func() bool {
-			return !createView.ProxyCache || len(registryOptions) == 0
-		}),
-	).WithTheme(theme).Run()
-
+	)
+if createView.ProxyCache &&
+	createView.RegistryID == "" &&
+	len(registryOptions) > 0 {
+		groups = append(groups,
+			huh.NewGroup(
+				huh.NewSelect[string]().
+					Validate(func(str string) error {
+						if str == "" {
+							return errors.New("registry ID cannot be empty")
+						}
+						return nil
+					}).
+					Description("Select a registry to reference when creating the proxy cache project").
+					Title("Registry ID").
+					Value(&createView.RegistryID).
+					Options(registrySelectOptions...),
+			),
+		)
+	}
+	form := huh.NewForm(groups...)
+	err = form.WithTheme(theme).Run()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description
Previously, users had to manually list registries, parse the registry ID, and pass `--registry-id` during project creation. With this update, users can now directly provide the registry name and the CLI will internally resolve it to the corresponding registry ID before sending the request to Harbor. 
This keeps the existing Harbor architecture unchanged, since Harbor still internally operates using `registry_id`.

- Fixes #900 

- [x] New feature

## Changes
### 1. Added `--registry-name` flag

Added support for a new CLI flag:

- `--registry-name`
### 2. Added registry name to ID resolution

Added logic to resolve registry names using:

- `api.GetRegistryIdByName(..)`
### 3. Updated validation logic

Updated proxy cache validation to support both:

- `--registry-id`

- `--registry-name`
---

<img width="1286" height="372" alt="Untitled design(3)" src="https://github.com/user-attachments/assets/51ff953a-672b-4a7c-8585-06f7021e874e" />

---------------
-------
<img width="1526" height="1216" alt="Untitled design(4)" src="https://github.com/user-attachments/assets/d31da21a-cacd-4ef6-a588-ff64d5cececd" />

