### PR TITLE
fix(api): restore instance handler logger

### DIFF
--- a/pkg/api/instance_handler.go
+++ b/pkg/api/instance_handler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/instance/create"
+	log "github.com/sirupsen/logrus"
 )
 
 func CreateInstance(opts create.CreateView) error {


### PR DESCRIPTION
## Summary
- Restore the missing `logrus` import in the instance API handler so `UpdateInstance` compiles.
- Unblocks doc generation and test jobs that failed on `undefined: log`.

## Testing
- `go test ./pkg/api`
- `go test ./...`
- `go run doc.go` from `doc/`
- `go run ./man-docs/man_doc.go` from `doc/`
- `docker run --rm -v "$PWD":/src -w /src golangci/golangci-lint:latest-alpine golangci-lint run -v`
- `go build -o .opencode/tmp/harbor-dev ./cmd/harbor`