### PR TITLE
fix(member): use canonical Harbor role IDs and surface API errors

### DIFF
--- a/cmd/harbor/root/project/member/create.go
+++ b/cmd/harbor/root/project/member/create.go
@@ -16,9 +16,9 @@ package member
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
-	"github.com/sirupsen/logrus"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
@@ -27,6 +27,37 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/views/member/create"
 	"github.com/spf13/cobra"
 )
+
+// roleFlagAliases maps every accepted spelling of --role to a canonical
+// Harbor role ID. Keys are pre-normalized (lowercase, separators stripped).
+var roleFlagAliases = map[string]int{
+	"projectadmin": 1, "admin": 1,
+	"developer":    2,
+	"guest":        3,
+	"maintainer":   4,
+	"limitedguest": 5,
+}
+
+// resolveRoleFlags collapses --role and --roleid into one canonical Harbor
+// role ID (1..5). (0, nil) means "no role specified" — the interactive view
+// will prompt for one.
+func resolveRoleFlags(roleName string, roleID int) (int, error) {
+	if roleName != "" {
+		key := strings.ToLower(strings.NewReplacer("_", "", " ", "", "-", "").Replace(roleName))
+		matched, ok := roleFlagAliases[key]
+		if !ok {
+			return 0, fmt.Errorf("invalid --role %q (expected one of: Project_Admin, Developer, Guest, Maintainer, Limited_Guest)", roleName)
+		}
+		if roleID != 0 && roleID != matched {
+			return 0, fmt.Errorf("--role %q (id %d) conflicts with --roleid %d", roleName, matched, roleID)
+		}
+		roleID = matched
+	}
+	if roleID != 0 && (roleID < 1 || roleID > 5) {
+		return 0, fmt.Errorf("invalid --roleid %d (must be 1=Admin, 2=Developer, 3=Guest, 4=Maintainer, 5=LimitedGuest)", roleID)
+	}
+	return roleID, nil
+}
 
 func CreateMemberCommand() *cobra.Command {
 	var opts create.CreateView
@@ -59,9 +90,14 @@ func CreateMemberCommand() *cobra.Command {
 				}
 			}
 
+			opts.RoleID, err = resolveRoleFlags(opts.RoleName, opts.RoleID)
+			if err != nil {
+				return err
+			}
+
 			sysInfo, err := api.GetSystemInfo()
 			if err != nil {
-				fmt.Println("could not access server info")
+				return fmt.Errorf("could not access server info: %v", utils.ParseHarborErrorMsg(err))
 			}
 
 			createView := &create.CreateView{
@@ -81,7 +117,6 @@ func CreateMemberCommand() *cobra.Command {
 				},
 			}
 
-			// check if role and member is valid
 			if opts.RoleID != 0 && opts.MemberUser.Username != "" {
 				err = api.CreateMember(*createView)
 			} else {
@@ -89,7 +124,7 @@ func CreateMemberCommand() *cobra.Command {
 			}
 
 			if err != nil {
-				logrus.Errorf("failed to create user: %v", err)
+				return fmt.Errorf("failed to create member: %v", utils.ParseHarborErrorMsg(err))
 			}
 
 			fmt.Printf("successfully added user %s to project %s\n", createView.MemberUser.Username, opts.ProjectName)

--- a/pkg/api/instance_handler.go
+++ b/pkg/api/instance_handler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/instance/create"
+	log "github.com/sirupsen/logrus"
 )
 
 func CreateInstance(opts create.CreateView) error {

--- a/pkg/api/member_handler.go
+++ b/pkg/api/member_handler.go
@@ -80,7 +80,7 @@ func CreateMember(opts create.CreateView) error {
 		ctx, &member.CreateProjectMemberParams{
 			XIsResourceName: &opts.XIsResourceID,
 			ProjectMember: &models.ProjectMember{
-				RoleID:      int64(opts.RoleID + 1),
+				RoleID:      int64(opts.RoleID),
 				MemberUser:  opts.MemberUser,
 				MemberGroup: opts.MemberGroup,
 			},

--- a/pkg/api/registry_handler.go
+++ b/pkg/api/registry_handler.go
@@ -122,10 +122,10 @@ func GetRegistryResponse(registryId int64) (*models.Registry, error) {
 		return nil, err
 	}
 	if response.Payload.ID == 0 {
-		return nil, err
+		return nil, fmt.Errorf("registry %d not found", registryId)
 	}
 
-	return response.GetPayload(), err
+	return response.GetPayload(), nil
 }
 
 func UpdateRegistry(updateView *models.Registry, projectID int64) error {
@@ -187,5 +187,5 @@ func GetRegistryIdByName(registryName string) (int64, error) {
 		}
 	}
 
-	return 0, err
+	return 0, fmt.Errorf("registry %q not found", registryName)
 }

--- a/pkg/api/user_handler.go
+++ b/pkg/api/user_handler.go
@@ -117,7 +117,7 @@ func GetUsersIdByName(userName string) (int64, error) {
 		}
 	}
 
-	return 0, err
+	return 0, fmt.Errorf("user %q not found", userName)
 }
 
 func ResetPassword(userId int64, opts reset.PasswordChangeView) error {

--- a/pkg/views/member/create/view.go
+++ b/pkg/views/member/create/view.go
@@ -55,10 +55,14 @@ var RoleOptions = map[string]int{
 }
 
 func CreateMemberView(createView *CreateView) {
-	roleOptions := []string{"Project Admin", "Developer", "Guest", "Maintainer", "Limited Guest"}
-	var roleSelectOptions []huh.Option[int]
-	for id, name := range roleOptions {
-		roleSelectOptions = append(roleSelectOptions, huh.NewOption(name, id))
+	// Bind labels directly to canonical Harbor role IDs so the form and
+	// the --role/--roleid flags share one representation.
+	roleSelectOptions := []huh.Option[int]{
+		huh.NewOption("Project Admin", RoleOptions["Admin"]),
+		huh.NewOption("Developer", RoleOptions["Developer"]),
+		huh.NewOption("Guest", RoleOptions["Guest"]),
+		huh.NewOption("Maintainer", RoleOptions["Maintainer"]),
+		huh.NewOption("Limited Guest", RoleOptions["LimitedGuest"]),
 	}
 
 	groupOptions := []string{"None", "LDAP group", "HTTP group", "OIDC group"}


### PR DESCRIPTION
## Summary

While testing `harbor project member create`, I noticed `--roleid 1` was creating a Developer instead of a Project Admin, and a failing API call still printed `successfully added user ...`. Tracing it, the role ID had two different representations in the codebase and one of them was being silently shifted.

This PR makes the Harbor role ID (1=Admin..5=LimitedGuest) the only representation past the cobra layer.

## Changes

- `pkg/api/member_handler.go`: drop the `+1` shift in `CreateMember`; the wrapper now passes `RoleID` through unchanged.
- `pkg/views/member/create/view.go`: bind the interactive role select directly to the existing `RoleOptions` map (1..5) instead of slice indices (0..4), so the form and the flags share one representation.
- `cmd/harbor/root/project/member/create.go`:
  - Add `resolveRoleFlags` to normalize `--role` and `--roleid` into a single canonical ID, with explicit validation and conflict detection (previously `--role` was registered but never resolved).
  - Return wrapped errors from `GetSystemInfo` and `CreateMember` instead of logging them and falling through to the success message.

## Behavior

| Input | Before | After |
|---|---|---|
| `--roleid 1` | creates Developer (id 2) | creates Project Admin (id 1) |
| `--role Developer` | flag silently ignored, falls into interactive prompt | creates Developer |
| `--role Foo` | falls into interactive prompt | rejected with a clear error |
| `--role Admin --roleid 3` | conflict silently ignored | rejected with a clear error |
| API call fails | prints "successfully added", exits 0 | wrapped error, non-zero exit |

## Test plan

- [x] `harbor project member create <p> --username <u> --roleid 1` creates a Project Admin
- [x] `harbor project member create <p> --username <u> --role Developer` creates a Developer
- [x] `harbor project member create <p> --username <u> --role Foo` fails with a clear message
- [x] Interactive flow still works and assigns the role shown in the picker
- [x] A failing create (e.g. duplicate member) exits non-zero