### PR TITLE
fix: resolve project member update by username and sync update/create wrappers

### DIFF
--- a/cmd/harbor/root/project/member/update.go
+++ b/cmd/harbor/root/project/member/update.go
@@ -53,36 +53,36 @@ func UpdateMemberCommand() *cobra.Command {
 				}
 			}
 
-			if memberName == "" {
-				opts.ID = prompt.GetMemberIDFromUser(opts.ProjectNameOrID, memberName)
-
-				if opts.ID == 0 {
-					return fmt.Errorf("No members found in project")
-				}
-			} else {
-				opts.ID, err = api.GetUsersIdByName(memberName)
-				if err != nil {
-					return err
-				}
-			}
-
 			if roleID == 0 {
 				roleID = prompt.GetRoleIDFromUser()
 			}
-			opts.RoleID = &models.RoleRequest{
-				RoleID: roleID,
-			}
+			role := &models.RoleRequest{RoleID: roleID}
 
 			// when set true parses projectNameOrID as projectName
 			// else it parses as an integer ID
 			opts.XIsResourceName = !isID
+			opts.RoleID = role
 
-			err = api.UpdateMember(opts)
-			if err != nil {
-				return fmt.Errorf("failed to get members list: %v", err)
+			if memberName != "" {
+				if err = api.UpdateMemberByUsername(opts.ProjectNameOrID, memberName, opts.XIsResourceName, role); err != nil {
+					return fmt.Errorf("failed to update member: %v", err)
+				}
+				fmt.Printf("successfully updated %s to role ID %d in project %s\n", memberName, roleID, opts.ProjectNameOrID)
+				return nil
 			}
 
-			fmt.Printf("successfully updated user with ID %d with role ID %d for project %s\n", opts.ID, opts.RoleID, opts.ProjectNameOrID)
+			if opts.ID == 0 {
+				opts.ID = prompt.GetMemberIDFromUser(opts.ProjectNameOrID, memberName)
+				if opts.ID == 0 {
+					return fmt.Errorf("No members found in project")
+				}
+			}
+
+			if err = api.UpdateMember(opts); err != nil {
+				return fmt.Errorf("failed to update member: %v", err)
+			}
+
+			fmt.Printf("successfully updated member ID %d to role ID %d in project %s\n", opts.ID, roleID, opts.ProjectNameOrID)
 			return nil
 		},
 	}

--- a/pkg/api/member_handler.go
+++ b/pkg/api/member_handler.go
@@ -195,6 +195,36 @@ func DeleteMemberByUsername(projectName string, username string, xIsResourceName
 	return nil
 }
 
+// UpdateMemberByUsername resolves a project-member entry by username and
+// updates its role. The Harbor UpdateProjectMember API takes the project
+// member ID (project_members.id), not the user ID — these are distinct and
+// must not be confused, so callers should prefer this helper over manually
+// looking up the user ID and passing it as Mid.
+func UpdateMemberByUsername(projectNameOrID, username string, xIsResourceName bool, role *models.RoleRequest) error {
+	members, err := ListMembers(projectNameOrID, username, true)
+	if err != nil {
+		return err
+	}
+
+	var memberID int64
+	for _, m := range members.Payload {
+		if m.EntityName == username {
+			memberID = m.ID
+			break
+		}
+	}
+	if memberID == 0 {
+		return fmt.Errorf("member with username %q not found in project %q", username, projectNameOrID)
+	}
+
+	return UpdateMember(UpdateMemberOptions{
+		ProjectNameOrID: projectNameOrID,
+		ID:              memberID,
+		XIsResourceName: xIsResourceName,
+		RoleID:          role,
+	})
+}
+
 func UpdateMember(opts UpdateMemberOptions) error {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {

--- a/pkg/api/scanner_handler.go
+++ b/pkg/api/scanner_handler.go
@@ -135,6 +135,10 @@ func UpdateScanner(registrationID string, opts models.ScannerRegistration) error
 		return err
 	}
 
+	if opts.Auth == "None" {
+		opts.Auth = ""
+	}
+
 	scannerRegReq := models.ScannerRegistrationReq{
 		Name:             &opts.Name,
 		Description:      opts.Description,

--- a/pkg/api/webhook_handler.go
+++ b/pkg/api/webhook_handler.go
@@ -113,7 +113,7 @@ func UpdateWebhook(opts *edit.EditView) error {
 			Name:        opts.Name,
 			Targets: []*models.WebhookTargetObject{
 				{
-					Address:        opts.EndpointURL,
+					Address:        strings.TrimSpace(opts.EndpointURL),
 					AuthHeader:     opts.AuthHeader,
 					PayloadFormat:  models.PayloadFormatType(opts.PayloadFormat),
 					SkipCertVerify: !opts.VerifyRemoteCertificate,


### PR DESCRIPTION
## Summary

Found three sibling-symmetry bugs while looking around the member, scanner, and webhook handlers — in each case a fix or normalization exists on the create path but was never replicated on the update path, so an update silently produces a wrong result.

## Changes

### `project member update --member <name>` was targeting the wrong row

`cmd/harbor/root/project/member/update.go` was resolving `--member <name>` via `api.GetUsersIdByName`, which returns a **user ID**, and passing it as `Mid` into `UpdateProjectMember` — but Harbor's API expects the **project member ID** (`project_members.id`). These are different rows and only line up by accident.

Introduced `api.UpdateMemberByUsername` (mirroring the existing `DeleteMemberByUsername`) which calls `ListMembers` and matches on `EntityName`, then routes the cmd through it. The numeric `[memberName]` positional and the interactive picker still use the existing `UpdateMember` path.

### `scanner update --auth None` was leaving the scanner with unrecognized auth

`pkg/api/scanner_handler.go::CreateScanner` normalizes `\"None\" -> \"\"`; `UpdateScanner` did not. Both the `--auth` flag and the interactive view surface the literal string `\"None\"`, so an update would persist that as the auth method and the scanner adapter could no longer authenticate. Added the same normalization to `UpdateScanner`.

### `webhook update` was not trimming the endpoint URL

`pkg/api/webhook_handler.go::CreateWebhook` calls `strings.TrimSpace` on the endpoint URL; `UpdateWebhook` did not. A trailing newline/space pasted into `--endpoint-url` would be stored verbatim. Added the trim.

## Test plan

- [ ] `harbor project member update <p> --member <user> --roleid 2` updates the role of `<user>` (and not whichever member happens to share that user's ID)
- [ ] `harbor project member update <p> <memberID> --roleid 2` still works (positional path unchanged)
- [ ] `harbor scanner update <name> --auth None` no longer leaves the scanner with `Auth: \"None\"` in Harbor
- [ ] `harbor webhook update ... --endpoint-url \"https://example.com/hook \"` stores the URL without trailing whitespace