### PR TITLE
fix: Return errors from view command via RunE in `artifact` cmd

### DIFF
--- a/cmd/harbor/root/artifact/view.go
+++ b/cmd/harbor/root/artifact/view.go
@@ -14,12 +14,13 @@
 package artifact
 
 import (
+	"fmt"
+
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/artifact"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/artifact/view"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -30,7 +31,7 @@ func ViewArtifactCommmand() *cobra.Command {
 		Short:   "Get information of an artifact",
 		Long:    `Get information of an artifact`,
 		Example: `harbor artifact view <project>/<repository>:<tag> OR harbor artifact view <project>/<repository>@<digest>`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			var projectName, repoName, reference string
 			var artifact *artifact.GetArtifactOK
@@ -38,13 +39,12 @@ func ViewArtifactCommmand() *cobra.Command {
 			if len(args) > 0 {
 				projectName, repoName, reference, err = utils.ParseProjectRepoReference(args[0])
 				if err != nil {
-					log.Errorf("failed to parse project/repo/reference: %v", err)
+					return fmt.Errorf("failed to parse project/repo/reference: %v", err)
 				}
 			} else {
 				projectName, err = prompt.GetProjectNameFromUser()
 				if err != nil {
-					log.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
-					return
+					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
 				}
 				repoName = prompt.GetRepoNameFromUser(projectName)
 				reference = prompt.GetReferenceFromUser(repoName, projectName)
@@ -52,29 +52,27 @@ func ViewArtifactCommmand() *cobra.Command {
 
 			if reference == "" {
 				if len(args) > 0 {
-					log.Errorf("Invalid artifact reference format: %s", args[0])
-				} else {
-					log.Error("Invalid artifact reference format: no arguments provided")
+					return fmt.Errorf("invalid artifact reference format: %s", args[0])
 				}
+				return fmt.Errorf("invalid artifact reference format: no arguments provided")
 			}
 
 			artifact, err = api.ViewArtifact(projectName, repoName, reference, false)
 
 			if err != nil {
-				log.Errorf("failed to get info of an artifact: %v", err)
-				return
+				return fmt.Errorf("failed to get info of an artifact: %v", err)
 			}
 
 			FormatFlag := viper.GetString("output-format")
 			if FormatFlag != "" {
 				err = utils.PrintFormat(artifact, FormatFlag)
 				if err != nil {
-					log.Error(err)
-					return
+					return err
 				}
 			} else {
 				view.ViewArtifact(artifact.Payload)
 			}
+			return nil
 		},
 	}
 


### PR DESCRIPTION
## Description

Fixes command error handling in `harbor artifact view` so failures are returned to Cobra and the process exits non-zero instead of silently succeeding.

- Fixes #910 

## Type of Change
Please select the relevant type.

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
- Converted `artifact view command` from `Run` to `RunE` in `view.go`.
- Replaced log-and-return paths with explicit `return fmt.Errorf(...)` for parse, prompt, validation, and API failures.
- Preserved success behavior/output, but now error cases correctly return exit code `1` for script/CI reliability.
- Before : 
   
<img width="912" height="139" alt="Screenshot From 2026-05-10 00-32-55" src="https://github.com/user-attachments/assets/0c8be8aa-09dd-4a0b-8d93-1a600889f803" />

---

- After (fix):
  
  
<img width="911" height="162" alt="Screenshot From 2026-05-10 13-01-27" src="https://github.com/user-attachments/assets/b3fac1a2-1912-4a2f-b4e4-9ecaa96f2aee" />

