### PR TITLE
fix: default insecure flag to false for registry create

### DIFF
--- a/cmd/harbor/root/registry/create.go
+++ b/cmd/harbor/root/registry/create.go
@@ -73,7 +73,7 @@ func CreateRegistryCommand() *cobra.Command {
 		&opts.Insecure,
 		"insecure",
 		"",
-		true,
+		false,
 		"Whether Harbor will verify the server certificate",
 	)
 	flags.StringVarP(

--- a/doc/cli-docs/harbor-registry-create.md
+++ b/doc/cli-docs/harbor-registry-create.md
@@ -26,7 +26,7 @@ harbor registry create
       --credential-type string            Credential type, such as 'basic', 'oauth' (default "basic")
       --description string                Description of the registry
   -h, --help                              help for create
-      --insecure                          Whether Harbor will verify the server certificate (default true)
+      --insecure                          Whether Harbor will verify the server certificate
       --name string                       Name of the registry
       --type string                       Type of the registry
       --url string                        Registry endpoint URL

--- a/doc/man-docs/man1/harbor-registry-create.1
+++ b/doc/man-docs/man1/harbor-registry-create.1
@@ -34,7 +34,7 @@ create registry
 	help for create
 
 .PP
-\fB--insecure\fP[=true]
+\fB--insecure\fP[=false]
 	Whether Harbor will verify the server certificate
 
 .PP


### PR DESCRIPTION
## Summary

Fixes #899

The `--insecure` flag in `registry create` had its default set to `true`, which meant every registry was created as insecure even when the user didn't pass `--insecure`. Changed the default to `false` so registries are secure by default and the user has to opt in to insecure mode explicitly.

## Changes

- `cmd/harbor/root/registry/create.go`: changed `BoolVarP` default from `true` to `false`

## Test plan

- Run `harbor registry create --name test --type docker-hub --url https://docker.io` without `--insecure` and verify `insecure` is `false` in the output
- Run the same command with `--insecure` and verify `insecure` is `true`