### PR TITLE
fix: remove password policy check from login

### DIFF
--- a/pkg/views/login/create.go
+++ b/pkg/views/login/create.go
@@ -68,9 +68,6 @@ func CreateView(loginView *LoginView) {
 					if strings.TrimSpace(str) == "" {
 						return errors.New("password cannot be empty or only spaces")
 					}
-					if err := utils.ValidatePassword(str); err != nil {
-						return err
-					}
 					return nil
 				}),
 			huh.NewInput().


### PR DESCRIPTION
## Summary

- Removes `ValidatePassword()` call from the interactive login form's password field
- Password policy enforcement remains in place for user creation, password change, and password reset flows where it belongs
- Fixes the case where auto-generated passwords (e.g. from harbor-helm) get rejected at login even though the server accepts them

The login form still validates that the password is non-empty -- it just no longer enforces format rules like uppercase/lowercase/digit requirements, which is purely a creation-time concern.

Fixes #911