### PR TITLE
fix:duplicate tag immutable registered

### DIFF
--- a/cmd/harbor/root/tag/cmd.go
+++ b/cmd/harbor/root/tag/cmd.go
@@ -28,7 +28,6 @@ func TagCommand() *cobra.Command {
 
 	cmd.AddCommand(immutable.Immutable())
 	cmd.AddCommand(retention.Retention())
-	cmd.AddCommand(immutable.Immutable())
 
 	return cmd
 }

--- a/doc/cli-docs/harbor-tag.md
+++ b/doc/cli-docs/harbor-tag.md
@@ -30,6 +30,5 @@ Manage tags in the Harbor registry, including creating, listing, and deleting ru
 
 * [harbor](harbor.md)	 - Official Harbor CLI
 * [harbor tag immutable](harbor-tag-immutable.md)	 - Manage Immutability rules in the project
-* [harbor tag immutable](harbor-tag-immutable.md)	 - Manage Immutability rules in the project
 * [harbor tag retention](harbor-tag-retention.md)	 - Manage tag retention rules in the project
 

--- a/doc/man-docs/man1/harbor-tag.1
+++ b/doc/man-docs/man1/harbor-tag.1
@@ -32,4 +32,4 @@ Manage tags in the Harbor registry, including creating, listing, and deleting ru
 
 
 .SH SEE ALSO
-\fBharbor(1)\fP, \fBharbor-tag-immutable(1)\fP, \fBharbor-tag-immutable(1)\fP, \fBharbor-tag-retention(1)\fP
+\fBharbor(1)\fP, \fBharbor-tag-immutable(1)\fP, \fBharbor-tag-retention(1)\fP


### PR DESCRIPTION
## Description
Briefly describe what this pull request does and why the change is needed.
In `root/tag/cmd.go` Immutable subcommand was registered twice.

- Fixes #923

## Type of Change
Please select the relevant type.

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
- remove duplicate immutable tag from `root/tag/cmd.go`
- 
- 
