### PR TITLE
feat  : project preheat task

### DIFF
--- a/cmd/harbor/root/project/preheat/task.go
+++ b/cmd/harbor/root/project/preheat/task.go
@@ -11,28 +11,23 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package project
+package preheat
 
 import (
-	"github.com/goharbor/harbor-cli/cmd/harbor/root/project/preheat"
+	"github.com/goharbor/harbor-cli/cmd/harbor/root/project/preheat/task"
 	"github.com/spf13/cobra"
 )
 
-func Preheat() *cobra.Command {
+func TaskCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "preheat",
-		Aliases: []string{"p2p"},
-		Short:   "Manage project preheat resources",
-		Long:    "Manage project-scoped P2P preheat policies, executions, and tasks in Harbor",
-		Example: `  harbor project preheat policy list [PROJECT_NAME]
-  harbor project preheat policy list [PROJECT_ID] --id
-  harbor project preheat policy create -f [CONFIG_FILE]
-  harbor project preheat policy start [PROJECT_NAME] [POLICY_NAME]`,
+		Use:     "task",
+		Short:   "Manage preheat tasks",
+		Long:    "Manage related tasks for the given preheat execution",
+		Example: `  harbor-cli project preheat task list [PROJECT_NAME|ID] [POLICY_NAME] [EXECUTION_ID]`,
 	}
+
 	cmd.AddCommand(
-		preheat.PolicyCommand(),
-		preheat.ExecutionCommand(),
-		preheat.TaskCommand(),
+		task.ListTaskCommand(),
 	)
 
 	return cmd

--- a/cmd/harbor/root/project/preheat/task.go
+++ b/cmd/harbor/root/project/preheat/task.go
@@ -28,6 +28,7 @@ func TaskCommand() *cobra.Command {
 
 	cmd.AddCommand(
 		task.ListTaskCommand(),
+		task.LogTaskCommand(),
 	)
 
 	return cmd

--- a/cmd/harbor/root/project/preheat/task/list.go
+++ b/cmd/harbor/root/project/preheat/task/list.go
@@ -123,7 +123,7 @@ func ListTaskCommand() *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.BoolVar(&isID, "id", false, "Get preheat tasks by project id")
+	flags.BoolVar(&isID, "id", false, "Use project ID instead of name")
 	flags.Int64VarP(&opts.Page, "page", "", 1, "Page number")
 	flags.Int64VarP(&opts.PageSize, "page-size", "", 10, "Size of per page")
 	flags.StringVarP(&opts.Q, "query", "q", "", "Query string to query resources")

--- a/cmd/harbor/root/project/preheat/task/list.go
+++ b/cmd/harbor/root/project/preheat/task/list.go
@@ -1,0 +1,133 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package task
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/prompt"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/goharbor/harbor-cli/pkg/views/preheat/task/list"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func ListTaskCommand() *cobra.Command {
+	var opts api.ListFlags
+	var isID bool
+
+	cmd := &cobra.Command{
+		Use:     "list [PROJECT_NAME|ID] [POLICY_NAME] [EXECUTION_ID]",
+		Short:   "List preheat tasks",
+		Long:    "List all tasks for a specific P2P preheat execution under a project",
+		Example: `  harbor-cli project preheat task list [NAME|ID] [POLICY_NAME] [EXECUTION_ID]`,
+		Args:    cobra.MaximumNArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+			var projectName, policyName string
+			var executionID int64
+
+			if opts.Page < 1 {
+				return fmt.Errorf("page number must be greater than or equal to 1")
+			}
+			if opts.PageSize <= 0 || opts.PageSize > 100 {
+				return fmt.Errorf("page size must be greater than 0 and less than or equal to 100")
+			}
+
+			if isID && len(args) == 0 {
+				return fmt.Errorf("project ID must be provided when using --id")
+			}
+
+			if len(args) >= 1 {
+				log.Debugf("Project name provided: %s", args[0])
+				projectName = args[0]
+			} else {
+				log.Debug("No project name provided, prompting user")
+				projectName, err = prompt.GetProjectNameFromUser()
+				if err != nil {
+					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
+				}
+			}
+			if isID {
+				project, err := api.GetProject(projectName, true)
+				if err != nil {
+					return fmt.Errorf("failed to resolve project ID: %v", utils.ParseHarborErrorMsg(err))
+				}
+				projectName = project.Payload.Name
+			}
+
+			if len(args) >= 2 {
+				log.Debugf("Policy name provided: %s", args[1])
+				policyName = args[1]
+			} else {
+				log.Debug("No policy name provided, prompting user")
+				policyName, err = prompt.GetPreheatPolicyNameFromUser(projectName)
+				if err != nil {
+					return fmt.Errorf("failed to get policy name: %v", utils.ParseHarborErrorMsg(err))
+				}
+			}
+
+			if len(args) >= 3 {
+				log.Debugf("Execution ID provided: %s", args[2])
+				executionID, err = strconv.ParseInt(args[2], 10, 64)
+				if err != nil {
+					return fmt.Errorf("invalid execution ID %q: %v", args[2], err)
+				}
+			} else {
+				log.Debug("No execution ID provided, prompting user")
+				executionID, err = prompt.GetPreheatPolicyExecIDFromUser(projectName, policyName)
+				if err != nil {
+					return fmt.Errorf("failed to get execution id: %v", utils.ParseHarborErrorMsg(err))
+				}
+			}
+
+			log.Debug("Fetching preheat execution tasks...")
+			resp, err := api.ListPreheatTasks(projectName, policyName, executionID, opts)
+			if err != nil {
+				if utils.ParseHarborErrorCode(err) == "404" {
+					return fmt.Errorf("no tasks found for execution %d of policy %s in project %s", executionID, policyName, projectName)
+				}
+				return fmt.Errorf("failed to list preheat execution tasks: %v", utils.ParseHarborErrorMsg(err))
+			}
+
+			if len(resp.Payload) == 0 {
+				fmt.Println("No tasks found")
+				return nil
+			}
+
+			FormatFlag := viper.GetString("output-format")
+			if FormatFlag != "" {
+				err = utils.PrintFormat(resp.Payload, FormatFlag)
+				if err != nil {
+					return err
+				}
+			} else {
+				list.ListTasks(resp.Payload)
+			}
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.BoolVar(&isID, "id", false, "Get preheat tasks by project id")
+	flags.Int64VarP(&opts.Page, "page", "", 1, "Page number")
+	flags.Int64VarP(&opts.PageSize, "page-size", "", 10, "Size of per page")
+	flags.StringVarP(&opts.Q, "query", "q", "", "Query string to query resources")
+	flags.StringVarP(&opts.Sort, "sort", "", "", "Sort the resource list in ascending or descending order")
+
+	return cmd
+}

--- a/cmd/harbor/root/project/preheat/task/log.go
+++ b/cmd/harbor/root/project/preheat/task/log.go
@@ -20,33 +20,23 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	"github.com/goharbor/harbor-cli/pkg/views/preheat/task/list"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
-func ListTaskCommand() *cobra.Command {
-	var opts api.ListFlags
+func LogTaskCommand() *cobra.Command {
 	var isID bool
 
 	cmd := &cobra.Command{
-		Use:     "list [PROJECT_NAME|ID] [POLICY_NAME] [EXECUTION_ID]",
-		Short:   "List preheat tasks",
-		Long:    "List all tasks for a specific P2P preheat execution under a project",
-		Example: `  harbor-cli project preheat task list [PROJECT_NAME|ID] [POLICY_NAME] [EXECUTION_ID]`,
-		Args:    cobra.MaximumNArgs(3),
+		Use:     "log [PROJECT_NAME|ID] [POLICY_NAME] [EXECUTION_ID] [TASK_ID]",
+		Short:   "Get preheat task log",
+		Long:    "Get the log for a specific P2P preheat task under a project",
+		Example: `  harbor-cli project preheat task log [PROJECT_NAME|ID] [POLICY_NAME] [EXECUTION_ID] [TASK_ID]`,
+		Args:    cobra.MaximumNArgs(4),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			var projectName, policyName string
-			var executionID int64
-
-			if opts.Page < 1 {
-				return fmt.Errorf("page number must be greater than or equal to 1")
-			}
-			if opts.PageSize <= 0 || opts.PageSize > 100 {
-				return fmt.Errorf("page size must be greater than 0 and less than or equal to 100")
-			}
+			var executionID, taskID int64
 
 			if isID && len(args) == 0 {
 				return fmt.Errorf("project ID must be provided when using --id")
@@ -95,39 +85,38 @@ func ListTaskCommand() *cobra.Command {
 				}
 			}
 
-			log.Debug("Fetching preheat execution tasks...")
-			resp, err := api.ListPreheatTasks(projectName, policyName, executionID, opts)
-			if err != nil {
-				if utils.ParseHarborErrorCode(err) == "404" {
-					return fmt.Errorf("no tasks found for execution %d of policy %s in project %s", executionID, policyName, projectName)
-				}
-				return fmt.Errorf("failed to list preheat execution tasks: %v", utils.ParseHarborErrorMsg(err))
-			}
-
-			if len(resp.Payload) == 0 {
-				fmt.Println("No tasks found")
-				return nil
-			}
-
-			FormatFlag := viper.GetString("output-format")
-			if FormatFlag != "" {
-				err = utils.PrintFormat(resp.Payload, FormatFlag)
+			if len(args) >= 4 {
+				log.Debugf("Task ID provided: %s", args[3])
+				taskID, err = strconv.ParseInt(args[3], 10, 64)
 				if err != nil {
-					return err
+					return fmt.Errorf("invalid task ID %q: %v", args[3], err)
 				}
 			} else {
-				list.ListTasks(resp.Payload)
+				log.Debug("No task ID provided, prompting user")
+				taskID, err = prompt.GetPreheatTaskIDFromUser(projectName, policyName, executionID)
+				if err != nil {
+					return fmt.Errorf("failed to get task id: %v", utils.ParseHarborErrorMsg(err))
+				}
+			}
+
+			log.Debug("Fetching preheat task log...")
+			resp, err := api.GetPreheatLog(projectName, policyName, executionID, taskID)
+			if err != nil {
+				if utils.ParseHarborErrorCode(err) == "404" {
+					return fmt.Errorf("preheat task %d for execution %d of policy %s in project %s not found", taskID, executionID, policyName, projectName)
+				}
+				return fmt.Errorf("failed to get preheat task log: %v", utils.ParseHarborErrorMsg(err))
+			}
+
+			if resp.Payload != "" {
+				fmt.Println(resp.Payload)
 			}
 			return nil
 		},
 	}
 
 	flags := cmd.Flags()
-	flags.BoolVar(&isID, "id", false, "Get preheat tasks by project id")
-	flags.Int64VarP(&opts.Page, "page", "", 1, "Page number")
-	flags.Int64VarP(&opts.PageSize, "page-size", "", 10, "Size of per page")
-	flags.StringVarP(&opts.Q, "query", "q", "", "Query string to query resources")
-	flags.StringVarP(&opts.Sort, "sort", "", "", "Sort the resource list in ascending or descending order")
+	flags.BoolVar(&isID, "id", false, "Use project ID instead of name")
 
 	return cmd
 }

--- a/doc/cli-docs/harbor-project-preheat-task-list.md
+++ b/doc/cli-docs/harbor-project-preheat-task-list.md
@@ -1,0 +1,47 @@
+---
+title: harbor project preheat task list
+weight: 65
+---
+## harbor project preheat task list
+
+### Description
+
+##### List preheat tasks
+
+### Synopsis
+
+List all tasks for a specific P2P preheat execution under a project
+
+```sh
+harbor project preheat task list [PROJECT_NAME|ID] [POLICY_NAME] [EXECUTION_ID] [flags]
+```
+
+### Examples
+
+```sh
+  harbor-cli project preheat task list [NAME|ID] [POLICY_NAME] [EXECUTION_ID]
+```
+
+### Options
+
+```sh
+  -h, --help            help for list
+      --id              Get preheat tasks by project id
+      --page int        Page number (default 1)
+      --page-size int   Size of per page (default 10)
+  -q, --query string    Query string to query resources
+      --sort string     Sort the resource list in ascending or descending order
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml|csv
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor project preheat task](harbor-project-preheat-task.md)	 - Manage preheat tasks
+

--- a/doc/cli-docs/harbor-project-preheat-task-list.md
+++ b/doc/cli-docs/harbor-project-preheat-task-list.md
@@ -26,7 +26,7 @@ harbor project preheat task list [PROJECT_NAME|ID] [POLICY_NAME] [EXECUTION_ID] 
 
 ```sh
   -h, --help            help for list
-      --id              Get preheat tasks by project id
+      --id              Use project ID instead of name
       --page int        Page number (default 1)
       --page-size int   Size of per page (default 10)
   -q, --query string    Query string to query resources

--- a/doc/cli-docs/harbor-project-preheat-task-list.md
+++ b/doc/cli-docs/harbor-project-preheat-task-list.md
@@ -19,7 +19,7 @@ harbor project preheat task list [PROJECT_NAME|ID] [POLICY_NAME] [EXECUTION_ID] 
 ### Examples
 
 ```sh
-  harbor-cli project preheat task list [NAME|ID] [POLICY_NAME] [EXECUTION_ID]
+  harbor-cli project preheat task list [PROJECT_NAME|ID] [POLICY_NAME] [EXECUTION_ID]
 ```
 
 ### Options

--- a/doc/cli-docs/harbor-project-preheat-task-log.md
+++ b/doc/cli-docs/harbor-project-preheat-task-log.md
@@ -1,0 +1,43 @@
+---
+title: harbor project preheat task log
+weight: 60
+---
+## harbor project preheat task log
+
+### Description
+
+##### Get preheat task log
+
+### Synopsis
+
+Get the log for a specific P2P preheat task under a project
+
+```sh
+harbor project preheat task log [PROJECT_NAME|ID] [POLICY_NAME] [EXECUTION_ID] [TASK_ID] [flags]
+```
+
+### Examples
+
+```sh
+  harbor-cli project preheat task log [PROJECT_NAME|ID] [POLICY_NAME] [EXECUTION_ID] [TASK_ID]
+```
+
+### Options
+
+```sh
+  -h, --help   help for log
+      --id     Use project ID instead of name
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml|csv
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor project preheat task](harbor-project-preheat-task.md)	 - Manage preheat tasks
+

--- a/doc/cli-docs/harbor-project-preheat-task.md
+++ b/doc/cli-docs/harbor-project-preheat-task.md
@@ -36,4 +36,5 @@ Manage related tasks for the given preheat execution
 
 * [harbor project preheat](harbor-project-preheat.md)	 - Manage project preheat resources
 * [harbor project preheat task list](harbor-project-preheat-task-list.md)	 - List preheat tasks
+* [harbor project preheat task log](harbor-project-preheat-task-log.md)	 - Get preheat task log
 

--- a/doc/cli-docs/harbor-project-preheat-task.md
+++ b/doc/cli-docs/harbor-project-preheat-task.md
@@ -1,0 +1,39 @@
+---
+title: harbor project preheat task
+weight: 5
+---
+## harbor project preheat task
+
+### Description
+
+##### Manage preheat tasks
+
+### Synopsis
+
+Manage related tasks for the given preheat execution
+
+### Examples
+
+```sh
+  harbor-cli project preheat task list [PROJECT_NAME|ID] [POLICY_NAME] [EXECUTION_ID]
+```
+
+### Options
+
+```sh
+  -h, --help   help for task
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml|csv
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor project preheat](harbor-project-preheat.md)	 - Manage project preheat resources
+* [harbor project preheat task list](harbor-project-preheat-task-list.md)	 - List preheat tasks
+

--- a/doc/cli-docs/harbor-project-preheat.md
+++ b/doc/cli-docs/harbor-project-preheat.md
@@ -40,4 +40,5 @@ Manage project-scoped P2P preheat policies, executions, and tasks in Harbor
 * [harbor project](harbor-project.md)	 - Manage projects and assign resources to them
 * [harbor project preheat execution](harbor-project-preheat-execution.md)	 - Manage preheat executions
 * [harbor project preheat policy](harbor-project-preheat-policy.md)	 - Manage preheat policies
+* [harbor project preheat task](harbor-project-preheat-task.md)	 - Manage preheat tasks
 

--- a/doc/man-docs/man1/harbor-project-preheat-task-list.1
+++ b/doc/man-docs/man1/harbor-project-preheat-task-list.1
@@ -19,7 +19,7 @@ List all tasks for a specific P2P preheat execution under a project
 
 .PP
 \fB--id\fP[=false]
-	Get preheat tasks by project id
+	Use project ID instead of name
 
 .PP
 \fB--page\fP=1

--- a/doc/man-docs/man1/harbor-project-preheat-task-list.1
+++ b/doc/man-docs/man1/harbor-project-preheat-task-list.1
@@ -53,7 +53,7 @@ List all tasks for a specific P2P preheat execution under a project
 
 .SH EXAMPLE
 .EX
-  harbor-cli project preheat task list [NAME|ID] [POLICY_NAME] [EXECUTION_ID]
+  harbor-cli project preheat task list [PROJECT_NAME|ID] [POLICY_NAME] [EXECUTION_ID]
 .EE
 
 

--- a/doc/man-docs/man1/harbor-project-preheat-task-list.1
+++ b/doc/man-docs/man1/harbor-project-preheat-task-list.1
@@ -1,0 +1,61 @@
+.nh
+.TH "HARBOR" "1"  "Harbor Community" "Harbor User Manuals"
+
+.SH NAME
+harbor-project-preheat-task-list - List preheat tasks
+
+
+.SH SYNOPSIS
+\fBharbor project preheat task list [PROJECT_NAME|ID] [POLICY_NAME] [EXECUTION_ID] [flags]\fP
+
+
+.SH DESCRIPTION
+List all tasks for a specific P2P preheat execution under a project
+
+
+.SH OPTIONS
+\fB-h\fP, \fB--help\fP[=false]
+	help for list
+
+.PP
+\fB--id\fP[=false]
+	Get preheat tasks by project id
+
+.PP
+\fB--page\fP=1
+	Page number
+
+.PP
+\fB--page-size\fP=10
+	Size of per page
+
+.PP
+\fB-q\fP, \fB--query\fP=""
+	Query string to query resources
+
+.PP
+\fB--sort\fP=""
+	Sort the resource list in ascending or descending order
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+\fB-c\fP, \fB--config\fP=""
+	config file (default is $HOME/.config/harbor-cli/config.yaml)
+
+.PP
+\fB-o\fP, \fB--output-format\fP=""
+	Output format. One of: json|yaml|csv
+
+.PP
+\fB-v\fP, \fB--verbose\fP[=false]
+	verbose output
+
+
+.SH EXAMPLE
+.EX
+  harbor-cli project preheat task list [NAME|ID] [POLICY_NAME] [EXECUTION_ID]
+.EE
+
+
+.SH SEE ALSO
+\fBharbor-project-preheat-task(1)\fP

--- a/doc/man-docs/man1/harbor-project-preheat-task-log.1
+++ b/doc/man-docs/man1/harbor-project-preheat-task-log.1
@@ -2,20 +2,24 @@
 .TH "HARBOR" "1"  "Harbor Community" "Harbor User Manuals"
 
 .SH NAME
-harbor-project-preheat-task - Manage preheat tasks
+harbor-project-preheat-task-log - Get preheat task log
 
 
 .SH SYNOPSIS
-\fBharbor project preheat task [flags]\fP
+\fBharbor project preheat task log [PROJECT_NAME|ID] [POLICY_NAME] [EXECUTION_ID] [TASK_ID] [flags]\fP
 
 
 .SH DESCRIPTION
-Manage related tasks for the given preheat execution
+Get the log for a specific P2P preheat task under a project
 
 
 .SH OPTIONS
 \fB-h\fP, \fB--help\fP[=false]
-	help for task
+	help for log
+
+.PP
+\fB--id\fP[=false]
+	Use project ID instead of name
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
@@ -33,9 +37,9 @@ Manage related tasks for the given preheat execution
 
 .SH EXAMPLE
 .EX
-  harbor-cli project preheat task list [PROJECT_NAME|ID] [POLICY_NAME] [EXECUTION_ID]
+  harbor-cli project preheat task log [PROJECT_NAME|ID] [POLICY_NAME] [EXECUTION_ID] [TASK_ID]
 .EE
 
 
 .SH SEE ALSO
-\fBharbor-project-preheat(1)\fP, \fBharbor-project-preheat-task-list(1)\fP, \fBharbor-project-preheat-task-log(1)\fP
+\fBharbor-project-preheat-task(1)\fP

--- a/doc/man-docs/man1/harbor-project-preheat-task.1
+++ b/doc/man-docs/man1/harbor-project-preheat-task.1
@@ -1,0 +1,41 @@
+.nh
+.TH "HARBOR" "1"  "Harbor Community" "Harbor User Manuals"
+
+.SH NAME
+harbor-project-preheat-task - Manage preheat tasks
+
+
+.SH SYNOPSIS
+\fBharbor project preheat task [flags]\fP
+
+
+.SH DESCRIPTION
+Manage related tasks for the given preheat execution
+
+
+.SH OPTIONS
+\fB-h\fP, \fB--help\fP[=false]
+	help for task
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+\fB-c\fP, \fB--config\fP=""
+	config file (default is $HOME/.config/harbor-cli/config.yaml)
+
+.PP
+\fB-o\fP, \fB--output-format\fP=""
+	Output format. One of: json|yaml|csv
+
+.PP
+\fB-v\fP, \fB--verbose\fP[=false]
+	verbose output
+
+
+.SH EXAMPLE
+.EX
+  harbor-cli project preheat task list [PROJECT_NAME|ID] [POLICY_NAME] [EXECUTION_ID]
+.EE
+
+
+.SH SEE ALSO
+\fBharbor-project-preheat(1)\fP, \fBharbor-project-preheat-task-list(1)\fP

--- a/doc/man-docs/man1/harbor-project-preheat.1
+++ b/doc/man-docs/man1/harbor-project-preheat.1
@@ -41,4 +41,4 @@ Manage project-scoped P2P preheat policies, executions, and tasks in Harbor
 
 
 .SH SEE ALSO
-\fBharbor-project(1)\fP, \fBharbor-project-preheat-execution(1)\fP, \fBharbor-project-preheat-policy(1)\fP
+\fBharbor-project(1)\fP, \fBharbor-project-preheat-execution(1)\fP, \fBharbor-project-preheat-policy(1)\fP, \fBharbor-project-preheat-task(1)\fP

--- a/pkg/api/preheat_handler.go
+++ b/pkg/api/preheat_handler.go
@@ -240,3 +240,21 @@ func ListPreheatTasks(projectName, policyName string, executionID int64, opts ..
 	}
 	return response, nil
 }
+
+func GetPreheatLog(projectName, policyName string, executionID, taskID int64) (*preheat.GetPreheatLogOK, error) {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := client.Preheat.GetPreheatLog(ctx, &preheat.GetPreheatLogParams{
+		ProjectName:       projectName,
+		PreheatPolicyName: policyName,
+		ExecutionID:       executionID,
+		TaskID:            taskID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}

--- a/pkg/api/preheat_handler.go
+++ b/pkg/api/preheat_handler.go
@@ -214,3 +214,29 @@ func StopPreheatExecution(projectName string, policyName string, executionID int
 	}
 	return nil
 }
+
+func ListPreheatTasks(projectName, policyName string, executionID int64, opts ...ListFlags) (*preheat.ListTasksOK, error) {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return nil, err
+	}
+
+	var listFlags ListFlags
+	if len(opts) > 0 {
+		listFlags = opts[0]
+	}
+
+	response, err := client.Preheat.ListTasks(ctx, &preheat.ListTasksParams{
+		ProjectName:       projectName,
+		PreheatPolicyName: policyName,
+		ExecutionID:       executionID,
+		Page:              &listFlags.Page,
+		PageSize:          &listFlags.PageSize,
+		Q:                 &listFlags.Q,
+		Sort:              &listFlags.Sort,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -39,6 +39,7 @@ import (
 
 	phexecutions "github.com/goharbor/harbor-cli/pkg/views/preheat/execution/select"
 	phpolicies "github.com/goharbor/harbor-cli/pkg/views/preheat/policy/select"
+	phtasks "github.com/goharbor/harbor-cli/pkg/views/preheat/task/select"
 
 	repoView "github.com/goharbor/harbor-cli/pkg/views/repository/select"
 	retview "github.com/goharbor/harbor-cli/pkg/views/retention/select"
@@ -540,5 +541,41 @@ func GetPreheatPolicyExecIDFromUser(projectName string, policyName string) (int6
 	}()
 
 	res := <-executionID
+	return res.id, res.err
+}
+
+func GetPreheatTaskIDFromUser(projectName, policyName string, executionID int64) (int64, error) {
+	type result struct {
+		id  int64
+		err error
+	}
+	taskID := make(chan result)
+
+	go func() {
+		response, err := api.ListPreheatTasks(projectName, policyName, executionID)
+		if err != nil {
+			taskID <- result{0, err}
+			return
+		}
+
+		if len(response.Payload) == 0 {
+			taskID <- result{0, errors.New("no preheat tasks found")}
+			return
+		}
+
+		id, err := phtasks.PreheatTaskList(response.Payload)
+		if err != nil {
+			if err == phtasks.ErrUserAborted {
+				taskID <- result{0, errors.New("user aborted task selection")}
+			} else {
+				taskID <- result{0, fmt.Errorf("error during task selection: %w", err)}
+			}
+			return
+		}
+
+		taskID <- result{id, nil}
+	}()
+
+	res := <-taskID
 	return res.id, res.err
 }

--- a/pkg/views/preheat/task/list/view.go
+++ b/pkg/views/preheat/task/list/view.go
@@ -1,0 +1,81 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package list
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/goharbor/harbor-cli/pkg/views/base/tablelist"
+)
+
+var columns = []table.Column{
+	{Title: "Task ID", Width: tablelist.WidthS},
+	{Title: "Exec ID", Width: tablelist.WidthS},
+	{Title: "Status", Width: tablelist.WidthS},
+	{Title: "Artifact", Width: tablelist.WidthXL},
+	{Title: "Digest", Width: tablelist.WidthXL},
+	{Title: "Type", Width: tablelist.WidthS},
+	{Title: "Start Time", Width: tablelist.WidthL},
+	{Title: "End Time", Width: tablelist.WidthL},
+}
+
+func ListTasks(tasks []*models.Task) {
+	var rows []table.Row
+	for _, task := range tasks {
+		startTime, _ := utils.FormatCreatedTime(task.StartTime)
+		endTime := "-"
+		if task.Status != "Running" && task.EndTime != "" {
+			endTime, _ = utils.FormatCreatedTime(task.EndTime)
+		}
+
+		artifact := getExtraAttr(task.ExtraAttrs, "artifact")
+		digest := getExtraAttr(task.ExtraAttrs, "digest")
+		kind := getExtraAttr(task.ExtraAttrs, "kind")
+
+		rows = append(rows, table.Row{
+			strconv.FormatInt(task.ID, 10),
+			strconv.FormatInt(task.ExecutionID, 10),
+			task.Status,
+			artifact,
+			digest,
+			kind,
+			startTime,
+			endTime,
+		})
+	}
+
+	m := tablelist.NewModel(columns, rows, len(rows))
+	if _, err := tea.NewProgram(m).Run(); err != nil {
+		fmt.Println("Error running program:", err)
+		os.Exit(1)
+	}
+}
+
+func getExtraAttr(attrs map[string]interface{}, key string) string {
+	if attrs == nil {
+		return "-"
+	}
+	if v, ok := attrs[key]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return "-"
+}

--- a/pkg/views/preheat/task/list/view.go
+++ b/pkg/views/preheat/task/list/view.go
@@ -39,9 +39,12 @@ var columns = []table.Column{
 func ListTasks(tasks []*models.Task) {
 	var rows []table.Row
 	for _, task := range tasks {
-		startTime, _ := utils.FormatCreatedTime(task.StartTime)
+		startTime := "-"
+		if task.StartTime != "" {
+			startTime, _ = utils.FormatCreatedTime(task.StartTime)
+		}
 		endTime := "-"
-		if task.Status != "Running" && task.EndTime != "" {
+		if task.EndTime != "" {
 			endTime, _ = utils.FormatCreatedTime(task.EndTime)
 		}
 

--- a/pkg/views/preheat/task/list/view.go
+++ b/pkg/views/preheat/task/list/view.go
@@ -36,15 +36,18 @@ var columns = []table.Column{
 	{Title: "End Time", Width: tablelist.WidthL},
 }
 
+// Go's zero time formatted as RFC3339, used by Harbor for unset time fields.
+const zeroTime = "0001-01-01T00:00:00Z"
+
 func ListTasks(tasks []*models.Task) {
 	var rows []table.Row
 	for _, task := range tasks {
 		startTime := "-"
-		if task.StartTime != "" {
+		if task.StartTime != zeroTime {
 			startTime, _ = utils.FormatCreatedTime(task.StartTime)
 		}
 		endTime := "-"
-		if task.EndTime != "" {
+		if task.EndTime != zeroTime {
 			endTime, _ = utils.FormatCreatedTime(task.EndTime)
 		}
 

--- a/pkg/views/preheat/task/select/view.go
+++ b/pkg/views/preheat/task/select/view.go
@@ -1,0 +1,59 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package task
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/views/base/selection"
+)
+
+var ErrUserAborted = errors.New("user aborted selection")
+
+func PreheatTaskList(tasks []*models.Task) (int64, error) {
+	items := make([]list.Item, len(tasks))
+	for i, t := range tasks {
+		items[i] = selection.Item(strconv.FormatInt(t.ID, 10))
+	}
+
+	m := selection.NewModel(items, "Preheat Task")
+
+	p, err := tea.NewProgram(m, tea.WithAltScreen()).Run()
+	if err != nil {
+		fmt.Println("Error running program:", err)
+		os.Exit(1)
+	}
+
+	if model, ok := p.(selection.Model); ok {
+		if model.Aborted {
+			return 0, ErrUserAborted
+		}
+		if model.Choice == "" {
+			return 0, errors.New("no task selected")
+		}
+		id, err := strconv.ParseInt(model.Choice, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("failed to parse task ID %q: %v", model.Choice, err)
+		}
+		return id, nil
+	}
+
+	return 0, errors.New("unexpected program result")
+}


### PR DESCRIPTION
> **Note** : This is the third PR for the issue #836 . This should be merged after the merging of #925 

## Description
Adds the harbor project preheat task command group to manage P2P preheat task of execution for a policy under a project. Harbor supports P2P (Peer-to-Peer) preheat distribution using engines like Dragonfly or Kraken. Users can create preheat policies under a project to preload container images into a P2P network before they are needed. The preheat command allows users to manage preheat policies, monitor executions, and inspect tasks from the terminal.

## Commands
- `harbor project preheat task list` — List preheat task
<img width="1168" height="270" alt="Kooha-2026-05-14-11-49-43" src="https://github.com/user-attachments/assets/5afd03d6-30f2-4569-9a17-c41f06771b96" />

- `harbor project preheat task log` — View logs of a particular task
<img width="1216" height="236" alt="Kooha-2026-05-14-11-50-31" src="https://github.com/user-attachments/assets/4821d0aa-b2fc-4e20-a434-1dab32029d62" />


## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance