### PR TITLE
fix: handle GetRobot error in robot create and update output path to prevent nil panic

### DIFF
--- a/cmd/harbor/root/project/robot/create.go
+++ b/cmd/harbor/root/project/robot/create.go
@@ -204,8 +204,7 @@ Examples:
 				name := response.Payload.Name
 				res, err := api.GetRobot(response.Payload.ID)
 				if err != nil {
-					return fmt.Errorf("failed to get robot details: %v",
-						utils.ParseHarborErrorMsg(err))
+					return fmt.Errorf("failed to get robot details: %v", utils.ParseHarborErrorMsg(err))
 				}
 				utils.SavePayloadJSON(name, res.Payload)
 				return nil

--- a/cmd/harbor/root/project/robot/create.go
+++ b/cmd/harbor/root/project/robot/create.go
@@ -202,7 +202,11 @@ Examples:
 			FormatFlag := viper.GetString("output-format")
 			if FormatFlag != "" {
 				name := response.Payload.Name
-				res, _ := api.GetRobot(response.Payload.ID)
+				res, err := api.GetRobot(response.Payload.ID)
+				if err != nil {
+					return fmt.Errorf("failed to get robot details: %v",
+						utils.ParseHarborErrorMsg(err))
+				}
 				utils.SavePayloadJSON(name, res.Payload)
 				return nil
 			}

--- a/cmd/harbor/root/robot/create.go
+++ b/cmd/harbor/root/robot/create.go
@@ -333,8 +333,7 @@ func createRobotAndHandleResponse(opts *create.CreateView, exportToFile bool) er
 	if formatFlag := viper.GetString("output-format"); formatFlag != "" {
 		res, err := api.GetRobot(response.Payload.ID)
 		if err != nil {
-			return fmt.Errorf("failed to get robot details: %v",
-				utils.ParseHarborErrorMsg(err))
+			return fmt.Errorf("failed to get robot details: %v", utils.ParseHarborErrorMsg(err))
 		}
 		utils.SavePayloadJSON(response.Payload.Name, res.Payload)
 		return nil

--- a/cmd/harbor/root/robot/create.go
+++ b/cmd/harbor/root/robot/create.go
@@ -331,7 +331,11 @@ func createRobotAndHandleResponse(opts *create.CreateView, exportToFile bool) er
 
 	// Handle output format
 	if formatFlag := viper.GetString("output-format"); formatFlag != "" {
-		res, _ := api.GetRobot(response.Payload.ID)
+		res, err := api.GetRobot(response.Payload.ID)
+		if err != nil {
+			return fmt.Errorf("failed to get robot details: %v",
+				utils.ParseHarborErrorMsg(err))
+		}
 		utils.SavePayloadJSON(response.Payload.Name, res.Payload)
 		return nil
 	}

--- a/cmd/harbor/root/robot/update.go
+++ b/cmd/harbor/root/robot/update.go
@@ -587,7 +587,11 @@ func updateRobotAndHandleResponse(opts *update.UpdateView) error {
 
 	// Handle output format
 	if formatFlag := viper.GetString("output-format"); formatFlag != "" {
-		res, _ := api.GetRobot(opts.ID)
+		res, err := api.GetRobot(opts.ID)
+		if err != nil {
+			return fmt.Errorf("failed to get robot details: %v",
+				utils.ParseHarborErrorMsg(err))
+		}
 		utils.SavePayloadJSON(opts.Name, res.Payload)
 	}
 

--- a/cmd/harbor/root/robot/update.go
+++ b/cmd/harbor/root/robot/update.go
@@ -589,8 +589,7 @@ func updateRobotAndHandleResponse(opts *update.UpdateView) error {
 	if formatFlag := viper.GetString("output-format"); formatFlag != "" {
 		res, err := api.GetRobot(opts.ID)
 		if err != nil {
-			return fmt.Errorf("failed to get robot details: %v",
-				utils.ParseHarborErrorMsg(err))
+			return fmt.Errorf("failed to get robot details: %v", utils.ParseHarborErrorMsg(err))
 		}
 		utils.SavePayloadJSON(opts.Name, res.Payload)
 	}


### PR DESCRIPTION
## Summary

Fixes three instances where `api.GetRobot()` error was silently
discarded with `_`, causing a nil pointer panic when the call
fails in the `-o json` or `-o yaml` output path.

Fixes #927

## Background

After a robot is created or updated, the code calls `GetRobot()`
to fetch the full `*models.Robot` representation for JSON/YAML
output. This is intentional — `CreateRobot` only returns
`*models.RobotCreated` (a subset without permissions), so a
second call is needed.

However in all 3 affected files the error was discarded:

```go
res, _ := api.GetRobot(response.Payload.ID) // error discarded
utils.SavePayloadJSON(name, res.Payload) // PANIC if res is nil
```

If `GetRobot` fails (network error, auth timeout, server error),
`res` is nil and `res.Payload` causes a nil pointer panic.
The CLI crashes instead of returning a clean error message.

## Files Changed

| File | Line | Change |
|---|---|---|
| `cmd/harbor/root/project/robot/create.go` | ~205 | Handle GetRobot error |
| `cmd/harbor/root/robot/create.go` | ~334 | Handle GetRobot error |
| `cmd/harbor/root/robot/update.go` | ~590 | Handle GetRobot error |

**Total: ~15 lines across 3 files.**

## Fix Applied (same pattern for all 3 locations)

```go
// Before (broken):
res, _ := api.GetRobot(response.Payload.ID)
utils.SavePayloadJSON(name, res.Payload)

// After (fixed):
res, err := api.GetRobot(response.Payload.ID)
if err != nil {
    return fmt.Errorf("failed to get robot details: %v",
        utils.ParseHarborErrorMsg(err))
}
utils.SavePayloadJSON(name, res.Payload)
```

## Pattern Alignment

This fix follows the exact pattern already used in the codebase
for the same `api.GetRobot()` call:

`cmd/harbor/root/project/robot/view.go`:
```go
robot, err = api.GetRobot(robotID)
if err != nil {
    return fmt.Errorf("failed to get robot: %v", err)
}
```

Uses `utils.ParseHarborErrorMsg` consistent with all other
API error handling in the same files.

## Checklist

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] DCO sign-off included (`git commit -s`)
- [x] Only 3 files changed
- [x] No unrelated edits
- [x] Fixes #927
- [x] Matches existing codebase error handling pattern
- [x] All 3 instances fixed in one PR