### PR TITLE
fix(replication): propagate interactive prompt errors to prevent abrupt CLI crashes

### DIFF
--- a/cmd/harbor/root/replication/executions/list.go
+++ b/cmd/harbor/root/replication/executions/list.go
@@ -57,7 +57,11 @@ func ListCommand() *cobra.Command {
 					return fmt.Errorf("invalid replication policy ID: %s, %v", args[0], err)
 				}
 			} else {
-				rpolicyID = prompt.GetReplicationPolicyFromUser()
+				var err error
+				rpolicyID, err = prompt.GetReplicationPolicyFromUser()
+				if err != nil {
+					return fmt.Errorf("failed to get replication policy: %w", err)
+				}
 			}
 
 			log.Debug("Fetching executions...")

--- a/cmd/harbor/root/replication/executions/view.go
+++ b/cmd/harbor/root/replication/executions/view.go
@@ -65,8 +65,14 @@ func ViewCommand() *cobra.Command {
 					return fmt.Errorf("invalid replication execution ID: %s, %v", args[0], err)
 				}
 			} else {
-				rpolicyID := prompt.GetReplicationPolicyFromUser()
-				execID = prompt.GetReplicationExecutionIDFromUser(rpolicyID)
+				rpolicyID, err := prompt.GetReplicationPolicyFromUser()
+				if err != nil {
+					return fmt.Errorf("failed to get replication policy: %w", err)
+				}
+				execID, err = prompt.GetReplicationExecutionIDFromUser(rpolicyID)
+				if err != nil {
+					return fmt.Errorf("failed to get replication execution: %w", err)
+				}
 			}
 
 			execution, err := api.GetReplicationExecution(execID)

--- a/cmd/harbor/root/replication/logs.go
+++ b/cmd/harbor/root/replication/logs.go
@@ -38,11 +38,24 @@ func LogsCommand() *cobra.Command {
 		Args: cobra.MaximumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if execID != 0 && taskID == 0 {
-				taskID = prompt.GetReplicationTaskIDFromUser(execID)
+				var err error
+				taskID, err = prompt.GetReplicationTaskIDFromUser(execID)
+				if err != nil {
+					return fmt.Errorf("failed to get replication task: %w", err)
+				}
 			} else if execID == 0 && taskID == 0 {
-				rpolicyID := prompt.GetReplicationPolicyFromUser()
-				execID = prompt.GetReplicationExecutionIDFromUser(rpolicyID)
-				taskID = prompt.GetReplicationTaskIDFromUser(execID)
+				rpolicyID, err := prompt.GetReplicationPolicyFromUser()
+				if err != nil {
+					return fmt.Errorf("failed to get replication policy: %w", err)
+				}
+				execID, err = prompt.GetReplicationExecutionIDFromUser(rpolicyID)
+				if err != nil {
+					return fmt.Errorf("failed to get replication execution: %w", err)
+				}
+				taskID, err = prompt.GetReplicationTaskIDFromUser(execID)
+				if err != nil {
+					return fmt.Errorf("failed to get replication task: %w", err)
+				}
 			} else if execID == 0 && taskID != 0 {
 				return fmt.Errorf("execution ID must be provided if task ID is specified")
 			}

--- a/cmd/harbor/root/replication/policies/delete.go
+++ b/cmd/harbor/root/replication/policies/delete.go
@@ -39,7 +39,11 @@ func DeleteCommand() *cobra.Command {
 					return fmt.Errorf("invalid replication policy ID: %s, %v", args[0], err)
 				}
 			} else {
-				rpolicyID = prompt.GetReplicationPolicyFromUser()
+				var err error
+				rpolicyID, err = prompt.GetReplicationPolicyFromUser()
+				if err != nil {
+					return fmt.Errorf("failed to get replication policy: %w", err)
+				}
 			}
 
 			_, err := api.DeleteReplicationPolicy(rpolicyID)

--- a/cmd/harbor/root/replication/policies/update.go
+++ b/cmd/harbor/root/replication/policies/update.go
@@ -40,7 +40,11 @@ func UpdateCommand() *cobra.Command {
 					return fmt.Errorf("invalid replication policy ID: %s, %v", args[0], err)
 				}
 			} else {
-				policyID = prompt.GetReplicationPolicyFromUser()
+				var err error
+				policyID, err = prompt.GetReplicationPolicyFromUser()
+				if err != nil {
+					return fmt.Errorf("failed to get replication policy: %w", err)
+				}
 			}
 
 			existingPolicy, err := api.GetReplicationPolicy(policyID)

--- a/cmd/harbor/root/replication/policies/view.go
+++ b/cmd/harbor/root/replication/policies/view.go
@@ -41,7 +41,11 @@ func ViewCommand() *cobra.Command {
 					return fmt.Errorf("invalid replication policy ID: %s, %v", args[0], err)
 				}
 			} else {
-				rpolicyID = prompt.GetReplicationPolicyFromUser()
+				var err error
+				rpolicyID, err = prompt.GetReplicationPolicyFromUser()
+				if err != nil {
+					return fmt.Errorf("failed to get replication policy: %w", err)
+				}
 			}
 
 			response, err := api.GetReplicationPolicy(rpolicyID)

--- a/cmd/harbor/root/replication/start.go
+++ b/cmd/harbor/root/replication/start.go
@@ -41,7 +41,11 @@ func StartCommand() *cobra.Command {
 					return fmt.Errorf("invalid replication policy ID: %s, %v", args[0], err)
 				}
 			} else {
-				rpolicyID = prompt.GetReplicationPolicyFromUser()
+				var err error
+				rpolicyID, err = prompt.GetReplicationPolicyFromUser()
+				if err != nil {
+					return fmt.Errorf("failed to get replication policy: %w", err)
+				}
 			}
 			response, err := api.StartReplication(rpolicyID)
 			if err != nil {

--- a/cmd/harbor/root/replication/stop.go
+++ b/cmd/harbor/root/replication/stop.go
@@ -41,10 +41,20 @@ func StopCommand() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("invalid replication policy ID: %s, %v", args[0], err)
 				}
-				executionID = prompt.GetReplicationExecutionIDFromUser(rpolicyID)
+				executionID, err = prompt.GetReplicationExecutionIDFromUser(rpolicyID)
+				if err != nil {
+					return fmt.Errorf("failed to get replication execution: %w", err)
+				}
 			} else {
-				rpolicyID = prompt.GetReplicationPolicyFromUser()
-				executionID = prompt.GetReplicationExecutionIDFromUser(rpolicyID)
+				var err error
+				rpolicyID, err = prompt.GetReplicationPolicyFromUser()
+				if err != nil {
+					return fmt.Errorf("failed to get replication policy: %w", err)
+				}
+				executionID, err = prompt.GetReplicationExecutionIDFromUser(rpolicyID)
+				if err != nil {
+					return fmt.Errorf("failed to get replication execution: %w", err)
+				}
 			}
 
 			execution, err := api.GetReplicationExecution(executionID)

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -41,7 +41,6 @@ import (
 	phpolicies "github.com/goharbor/harbor-cli/pkg/views/preheat/policy/select"
 
 	repoView "github.com/goharbor/harbor-cli/pkg/views/repository/select"
-	retview "github.com/goharbor/harbor-cli/pkg/views/retention/select"
 	robotView "github.com/goharbor/harbor-cli/pkg/views/robot/select"
 	sview "github.com/goharbor/harbor-cli/pkg/views/scanner/select"
 	uview "github.com/goharbor/harbor-cli/pkg/views/user/select"
@@ -309,7 +308,7 @@ func GetQuotaIDFromUser() int64 {
 	QuotaID := make(chan int64)
 
 	go func() {
-		response, err := api.ListQuota(*&api.ListQuotaFlags{})
+		response, err := api.ListQuota(api.ListQuotaFlags{})
 		if err != nil {
 			log.Errorf("failed to list quota: %v", err)
 		}
@@ -385,78 +384,36 @@ func GetRobotIDFromUser(projectID int64) (int64, error) {
 }
 
 func GetReplicationPolicyFromUser() (int64, error) {
-	replicationPolicyID := make(chan int64)
-	errChan := make(chan error, 1)
-
-	go func() {
-		response, err := api.ListReplicationPolicies()
-		if err != nil {
-			errChan <- err
-			return
-		}
-		if len(response.Payload) == 0 {
-			errChan <- fmt.Errorf("no replication policies found")
-			return
-		}
-		rpolicies.ReplicationPoliciesList(response.Payload, replicationPolicyID)
-	}()
-
-	select {
-	case id := <-replicationPolicyID:
-		return id, nil
-	case err := <-errChan:
+	response, err := api.ListReplicationPolicies()
+	if err != nil {
 		return 0, err
 	}
+	if len(response.Payload) == 0 {
+		return 0, fmt.Errorf("no replication policies found")
+	}
+	return rpolicies.ReplicationPoliciesList(response.Payload)
 }
 
 func GetReplicationExecutionIDFromUser(rpolicyID int64) (int64, error) {
-	executionID := make(chan int64)
-	errChan := make(chan error, 1)
-
-	go func() {
-		response, err := api.ListReplicationExecutions(rpolicyID)
-		if err != nil {
-			errChan <- err
-			return
-		}
-		if len(response.Payload) == 0 {
-			errChan <- fmt.Errorf("no replication executions found")
-			return
-		}
-		rexecutions.ReplicationExecutionList(response.Payload, executionID)
-	}()
-
-	select {
-	case id := <-executionID:
-		return id, nil
-	case err := <-errChan:
+	response, err := api.ListReplicationExecutions(rpolicyID)
+	if err != nil {
 		return 0, err
 	}
+	if len(response.Payload) == 0 {
+		return 0, fmt.Errorf("no replication executions found")
+	}
+	return rexecutions.ReplicationExecutionList(response.Payload)
 }
 
 func GetReplicationTaskIDFromUser(execID int64) (int64, error) {
-	executionID := make(chan int64)
-	errChan := make(chan error, 1)
-
-	go func() {
-		response, err := api.ListReplicationTasks(execID)
-		if err != nil {
-			errChan <- err
-			return
-		}
-		if len(response.Payload) == 0 {
-			errChan <- fmt.Errorf("no replication tasks found")
-			return
-		}
-		rtasks.ReplicationTasksList(response.Payload, executionID)
-	}()
-
-	select {
-	case id := <-executionID:
-		return id, nil
-	case err := <-errChan:
+	response, err := api.ListReplicationTasks(execID)
+	if err != nil {
 		return 0, err
 	}
+	if len(response.Payload) == 0 {
+		return 0, fmt.Errorf("no replication tasks found")
+	}
+	return rtasks.ReplicationTasksList(response.Payload)
 }
 
 // Get GetMemberIDFromUser choosing from list of members

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -41,6 +41,7 @@ import (
 	phpolicies "github.com/goharbor/harbor-cli/pkg/views/preheat/policy/select"
 
 	repoView "github.com/goharbor/harbor-cli/pkg/views/repository/select"
+	retview "github.com/goharbor/harbor-cli/pkg/views/retention/select"
 	robotView "github.com/goharbor/harbor-cli/pkg/views/robot/select"
 	sview "github.com/goharbor/harbor-cli/pkg/views/scanner/select"
 	uview "github.com/goharbor/harbor-cli/pkg/views/user/select"

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -384,52 +384,79 @@ func GetRobotIDFromUser(projectID int64) (int64, error) {
 	return id, nil
 }
 
-func GetReplicationPolicyFromUser() int64 {
+func GetReplicationPolicyFromUser() (int64, error) {
 	replicationPolicyID := make(chan int64)
+	errChan := make(chan error, 1)
 
 	go func() {
 		response, err := api.ListReplicationPolicies()
 		if err != nil {
-			log.Fatal(err)
+			errChan <- err
+			return
+		}
+		if len(response.Payload) == 0 {
+			errChan <- fmt.Errorf("no replication policies found")
+			return
 		}
 		rpolicies.ReplicationPoliciesList(response.Payload, replicationPolicyID)
 	}()
 
-	return <-replicationPolicyID
+	select {
+	case id := <-replicationPolicyID:
+		return id, nil
+	case err := <-errChan:
+		return 0, err
+	}
 }
 
-func GetReplicationExecutionIDFromUser(rpolicyID int64) int64 {
+func GetReplicationExecutionIDFromUser(rpolicyID int64) (int64, error) {
 	executionID := make(chan int64)
+	errChan := make(chan error, 1)
 
 	go func() {
 		response, err := api.ListReplicationExecutions(rpolicyID)
 		if err != nil {
-			log.Fatal(err)
+			errChan <- err
+			return
 		}
 		if len(response.Payload) == 0 {
-			log.Fatal("no replication executions found")
+			errChan <- fmt.Errorf("no replication executions found")
+			return
 		}
 		rexecutions.ReplicationExecutionList(response.Payload, executionID)
 	}()
 
-	return <-executionID
+	select {
+	case id := <-executionID:
+		return id, nil
+	case err := <-errChan:
+		return 0, err
+	}
 }
 
-func GetReplicationTaskIDFromUser(execID int64) int64 {
+func GetReplicationTaskIDFromUser(execID int64) (int64, error) {
 	executionID := make(chan int64)
+	errChan := make(chan error, 1)
 
 	go func() {
 		response, err := api.ListReplicationTasks(execID)
 		if err != nil {
-			log.Fatal(err)
+			errChan <- err
+			return
 		}
 		if len(response.Payload) == 0 {
-			log.Fatal("no replication tasks found")
+			errChan <- fmt.Errorf("no replication tasks found")
+			return
 		}
 		rtasks.ReplicationTasksList(response.Payload, executionID)
 	}()
 
-	return <-executionID
+	select {
+	case id := <-executionID:
+		return id, nil
+	case err := <-errChan:
+		return 0, err
+	}
 }
 
 // Get GetMemberIDFromUser choosing from list of members

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -384,36 +384,78 @@ func GetRobotIDFromUser(projectID int64) (int64, error) {
 }
 
 func GetReplicationPolicyFromUser() (int64, error) {
-	response, err := api.ListReplicationPolicies()
-	if err != nil {
+	replicationPolicyID := make(chan int64, 1)
+	errChan := make(chan error, 1)
+
+	go func() {
+		response, err := api.ListReplicationPolicies()
+		if err != nil {
+			errChan <- err
+			return
+		}
+		if len(response.Payload) == 0 {
+			errChan <- fmt.Errorf("no replication policies found")
+			return
+		}
+		rpolicies.ReplicationPoliciesList(response.Payload, replicationPolicyID, errChan)
+	}()
+
+	select {
+	case id := <-replicationPolicyID:
+		return id, nil
+	case err := <-errChan:
 		return 0, err
 	}
-	if len(response.Payload) == 0 {
-		return 0, fmt.Errorf("no replication policies found")
-	}
-	return rpolicies.ReplicationPoliciesList(response.Payload)
 }
 
 func GetReplicationExecutionIDFromUser(rpolicyID int64) (int64, error) {
-	response, err := api.ListReplicationExecutions(rpolicyID)
-	if err != nil {
+	executionID := make(chan int64, 1)
+	errChan := make(chan error, 1)
+
+	go func() {
+		response, err := api.ListReplicationExecutions(rpolicyID)
+		if err != nil {
+			errChan <- err
+			return
+		}
+		if len(response.Payload) == 0 {
+			errChan <- fmt.Errorf("no replication executions found")
+			return
+		}
+		rexecutions.ReplicationExecutionList(response.Payload, executionID, errChan)
+	}()
+
+	select {
+	case id := <-executionID:
+		return id, nil
+	case err := <-errChan:
 		return 0, err
 	}
-	if len(response.Payload) == 0 {
-		return 0, fmt.Errorf("no replication executions found")
-	}
-	return rexecutions.ReplicationExecutionList(response.Payload)
 }
 
 func GetReplicationTaskIDFromUser(execID int64) (int64, error) {
-	response, err := api.ListReplicationTasks(execID)
-	if err != nil {
+	taskID := make(chan int64, 1)
+	errChan := make(chan error, 1)
+
+	go func() {
+		response, err := api.ListReplicationTasks(execID)
+		if err != nil {
+			errChan <- err
+			return
+		}
+		if len(response.Payload) == 0 {
+			errChan <- fmt.Errorf("no replication tasks found")
+			return
+		}
+		rtasks.ReplicationTasksList(response.Payload, taskID, errChan)
+	}()
+
+	select {
+	case id := <-taskID:
+		return id, nil
+	case err := <-errChan:
 		return 0, err
 	}
-	if len(response.Payload) == 0 {
-		return 0, fmt.Errorf("no replication tasks found")
-	}
-	return rtasks.ReplicationTasksList(response.Payload)
 }
 
 // Get GetMemberIDFromUser choosing from list of members

--- a/pkg/views/base/selection/errors.go
+++ b/pkg/views/base/selection/errors.go
@@ -1,0 +1,18 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package selection
+
+import "errors"
+
+var ErrUserAborted = errors.New("user aborted selection")

--- a/pkg/views/base/selection/model.go
+++ b/pkg/views/base/selection/model.go
@@ -83,14 +83,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyMsg:
 		switch keypress := msg.String(); keypress {
-		case "ctrl+c":
-			m.Aborted = true
-			return m, tea.Quit
-		case "esc":
-			if m.List.FilterState() != list.Filtering {
-				m.Aborted = true
-				return m, tea.Quit
-			}
 		case "enter":
 			if m.List.FilterState() != list.Filtering {
 				i, ok := m.List.SelectedItem().(Item)

--- a/pkg/views/base/selection/model.go
+++ b/pkg/views/base/selection/model.go
@@ -83,6 +83,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyMsg:
 		switch keypress := msg.String(); keypress {
+		case "ctrl+c":
+			m.Aborted = true
+			return m, tea.Quit
+		case "esc":
+			if m.List.FilterState() != list.Filtering {
+				m.Aborted = true
+				return m, tea.Quit
+			}
 		case "enter":
 			if m.List.FilterState() != list.Filtering {
 				i, ok := m.List.SelectedItem().(Item)

--- a/pkg/views/replication/execution/select/view.go
+++ b/pkg/views/replication/execution/select/view.go
@@ -25,7 +25,7 @@ import (
 
 var ErrUserAborted = errors.New("user aborted selection")
 
-func ReplicationExecutionList(executions []*models.ReplicationExecution) (int64, error) {
+func ReplicationExecutionList(executions []*models.ReplicationExecution, choice chan<- int64, errChan chan<- error) {
 	itemsList := make([]list.Item, len(executions))
 	for i, p := range executions {
 		displayName := fmt.Sprintf("ID: %d, Status: %s, Trigger: %s, Start Time: %s, Succeed: %d, Total: %d",
@@ -37,24 +37,25 @@ func ReplicationExecutionList(executions []*models.ReplicationExecution) (int64,
 
 	p, err := tea.NewProgram(m, tea.WithAltScreen()).Run()
 	if err != nil {
-		return 0, fmt.Errorf("error running selection program: %w", err)
+		errChan <- fmt.Errorf("error running selection program: %w", err)
+		return
 	}
 
 	if model, ok := p.(selection.Model); ok {
-		if model.Aborted {
-			return 0, ErrUserAborted
-		}
 		if model.Choice == "" {
-			return 0, errors.New("no replication execution selected")
+			errChan <- errors.New("user aborted selection")
+			return
 		}
 		// Extract the ID from model.Choice
 		var execID int64
 		_, err = fmt.Sscanf(model.Choice, "ID: %d", &execID)
 		if err != nil {
-			return 0, fmt.Errorf("error parsing execution ID: %w", err)
+			errChan <- fmt.Errorf("error parsing execution ID: %w", err)
+			return
 		}
-		return execID, nil
+		choice <- execID
+		return
 	}
 
-	return 0, errors.New("unexpected program result")
+	errChan <- errors.New("unexpected program result")
 }

--- a/pkg/views/replication/execution/select/view.go
+++ b/pkg/views/replication/execution/select/view.go
@@ -14,8 +14,8 @@
 package execution
 
 import (
+	"errors"
 	"fmt"
-	"os"
 
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
@@ -23,7 +23,9 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/views/base/selection"
 )
 
-func ReplicationExecutionList(executions []*models.ReplicationExecution, choice chan<- int64) {
+var ErrUserAborted = errors.New("user aborted selection")
+
+func ReplicationExecutionList(executions []*models.ReplicationExecution) (int64, error) {
 	itemsList := make([]list.Item, len(executions))
 	for i, p := range executions {
 		displayName := fmt.Sprintf("ID: %d, Status: %s, Trigger: %s, Start Time: %s, Succeed: %d, Total: %d",
@@ -35,18 +37,24 @@ func ReplicationExecutionList(executions []*models.ReplicationExecution, choice 
 
 	p, err := tea.NewProgram(m, tea.WithAltScreen()).Run()
 	if err != nil {
-		fmt.Println("Error running program:", err)
-		os.Exit(1)
+		return 0, fmt.Errorf("error running selection program: %w", err)
 	}
 
-	if p, ok := p.(selection.Model); ok {
-		// Extract the ID from p.Choice
-		var execID int64
-		_, err = fmt.Sscanf(p.Choice, "ID: %d", &execID)
-		if err != nil {
-			fmt.Println("error parsing execution ID:", err)
-			os.Exit(1)
+	if model, ok := p.(selection.Model); ok {
+		if model.Aborted {
+			return 0, ErrUserAborted
 		}
-		choice <- execID
+		if model.Choice == "" {
+			return 0, errors.New("no replication execution selected")
+		}
+		// Extract the ID from model.Choice
+		var execID int64
+		_, err = fmt.Sscanf(model.Choice, "ID: %d", &execID)
+		if err != nil {
+			return 0, fmt.Errorf("error parsing execution ID: %w", err)
+		}
+		return execID, nil
 	}
+
+	return 0, errors.New("unexpected program result")
 }

--- a/pkg/views/replication/execution/select/view.go
+++ b/pkg/views/replication/execution/select/view.go
@@ -43,7 +43,7 @@ func ReplicationExecutionList(executions []*models.ReplicationExecution, choice 
 
 	if model, ok := p.(selection.Model); ok {
 		if model.Choice == "" {
-			errChan <- errors.New("user aborted selection")
+			errChan <- ErrUserAborted
 			return
 		}
 		// Extract the ID from model.Choice

--- a/pkg/views/replication/execution/select/view.go
+++ b/pkg/views/replication/execution/select/view.go
@@ -23,14 +23,14 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/views/base/selection"
 )
 
-var ErrUserAborted = errors.New("user aborted selection")
-
 func ReplicationExecutionList(executions []*models.ReplicationExecution, choice chan<- int64, errChan chan<- error) {
 	itemsList := make([]list.Item, len(executions))
+	executionIDs := make(map[string]int64, len(executions))
 	for i, p := range executions {
 		displayName := fmt.Sprintf("ID: %d, Status: %s, Trigger: %s, Start Time: %s, Succeed: %d, Total: %d",
 			p.ID, p.Status, p.Trigger, p.StartTime.String(), p.Succeed, p.Total)
 		itemsList[i] = selection.Item(displayName)
+		executionIDs[displayName] = p.ID
 	}
 
 	m := selection.NewModel(itemsList, "Select a Replication Execution")
@@ -43,14 +43,12 @@ func ReplicationExecutionList(executions []*models.ReplicationExecution, choice 
 
 	if model, ok := p.(selection.Model); ok {
 		if model.Choice == "" {
-			errChan <- ErrUserAborted
+			errChan <- selection.ErrUserAborted
 			return
 		}
-		// Extract the ID from model.Choice
-		var execID int64
-		_, err = fmt.Sscanf(model.Choice, "ID: %d", &execID)
-		if err != nil {
-			errChan <- fmt.Errorf("error parsing execution ID: %w", err)
+		execID, ok := executionIDs[model.Choice]
+		if !ok {
+			errChan <- fmt.Errorf("selected execution %q not found in execution list", model.Choice)
 			return
 		}
 		choice <- execID

--- a/pkg/views/replication/policies/select/view.go
+++ b/pkg/views/replication/policies/select/view.go
@@ -14,8 +14,8 @@
 package replication
 
 import (
+	"errors"
 	"fmt"
-	"os"
 
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
@@ -23,7 +23,9 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/views/base/selection"
 )
 
-func ReplicationPoliciesList(policies []*models.ReplicationPolicy, choice chan<- int64) {
+var ErrUserAborted = errors.New("user aborted selection")
+
+func ReplicationPoliciesList(policies []*models.ReplicationPolicy) (int64, error) {
 	policyNameIDsMap := make(map[string]int64, len(policies))
 	for _, p := range policies {
 		policyNameIDsMap[p.Name] = p.ID
@@ -38,11 +40,18 @@ func ReplicationPoliciesList(policies []*models.ReplicationPolicy, choice chan<-
 
 	p, err := tea.NewProgram(m, tea.WithAltScreen()).Run()
 	if err != nil {
-		fmt.Println("Error running program:", err)
-		os.Exit(1)
+		return 0, fmt.Errorf("error running selection program: %w", err)
 	}
 
-	if p, ok := p.(selection.Model); ok {
-		choice <- policyNameIDsMap[p.Choice]
+	if model, ok := p.(selection.Model); ok {
+		if model.Aborted {
+			return 0, ErrUserAborted
+		}
+		if model.Choice == "" {
+			return 0, errors.New("no replication policy selected")
+		}
+		return policyNameIDsMap[model.Choice], nil
 	}
+
+	return 0, errors.New("unexpected program result")
 }

--- a/pkg/views/replication/policies/select/view.go
+++ b/pkg/views/replication/policies/select/view.go
@@ -25,7 +25,7 @@ import (
 
 var ErrUserAborted = errors.New("user aborted selection")
 
-func ReplicationPoliciesList(policies []*models.ReplicationPolicy) (int64, error) {
+func ReplicationPoliciesList(policies []*models.ReplicationPolicy, choice chan<- int64, errChan chan<- error) {
 	policyNameIDsMap := make(map[string]int64, len(policies))
 	for _, p := range policies {
 		policyNameIDsMap[p.Name] = p.ID
@@ -40,18 +40,18 @@ func ReplicationPoliciesList(policies []*models.ReplicationPolicy) (int64, error
 
 	p, err := tea.NewProgram(m, tea.WithAltScreen()).Run()
 	if err != nil {
-		return 0, fmt.Errorf("error running selection program: %w", err)
+		errChan <- fmt.Errorf("error running selection program: %w", err)
+		return
 	}
 
 	if model, ok := p.(selection.Model); ok {
-		if model.Aborted {
-			return 0, ErrUserAborted
-		}
 		if model.Choice == "" {
-			return 0, errors.New("no replication policy selected")
+			errChan <- errors.New("user aborted selection")
+			return
 		}
-		return policyNameIDsMap[model.Choice], nil
+		choice <- policyNameIDsMap[model.Choice]
+		return
 	}
 
-	return 0, errors.New("unexpected program result")
+	errChan <- errors.New("unexpected program result")
 }

--- a/pkg/views/replication/policies/select/view.go
+++ b/pkg/views/replication/policies/select/view.go
@@ -46,10 +46,15 @@ func ReplicationPoliciesList(policies []*models.ReplicationPolicy, choice chan<-
 
 	if model, ok := p.(selection.Model); ok {
 		if model.Choice == "" {
-			errChan <- errors.New("user aborted selection")
+			errChan <- ErrUserAborted
 			return
 		}
-		choice <- policyNameIDsMap[model.Choice]
+		id, found := policyNameIDsMap[model.Choice]
+		if !found {
+			errChan <- fmt.Errorf("selected policy %q not found in policy list", model.Choice)
+			return
+		}
+		choice <- id
 		return
 	}
 

--- a/pkg/views/replication/policies/select/view.go
+++ b/pkg/views/replication/policies/select/view.go
@@ -23,8 +23,6 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/views/base/selection"
 )
 
-var ErrUserAborted = errors.New("user aborted selection")
-
 func ReplicationPoliciesList(policies []*models.ReplicationPolicy, choice chan<- int64, errChan chan<- error) {
 	policyNameIDsMap := make(map[string]int64, len(policies))
 	for _, p := range policies {
@@ -46,7 +44,7 @@ func ReplicationPoliciesList(policies []*models.ReplicationPolicy, choice chan<-
 
 	if model, ok := p.(selection.Model); ok {
 		if model.Choice == "" {
-			errChan <- ErrUserAborted
+			errChan <- selection.ErrUserAborted
 			return
 		}
 		id, found := policyNameIDsMap[model.Choice]

--- a/pkg/views/replication/task/select/view.go
+++ b/pkg/views/replication/task/select/view.go
@@ -14,8 +14,8 @@
 package task
 
 import (
+	"errors"
 	"fmt"
-	"os"
 
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
@@ -23,7 +23,9 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/views/base/selection"
 )
 
-func ReplicationTasksList(tasks []*models.ReplicationTask, choice chan<- int64) {
+var ErrUserAborted = errors.New("user aborted selection")
+
+func ReplicationTasksList(tasks []*models.ReplicationTask) (int64, error) {
 	itemsList := make([]list.Item, len(tasks))
 	for i, p := range tasks {
 		displayName := fmt.Sprintf("ID: %d, Status: %s, Operation: %s, Src: %s, Dst: %s, Start Time: %s",
@@ -35,18 +37,24 @@ func ReplicationTasksList(tasks []*models.ReplicationTask, choice chan<- int64) 
 
 	p, err := tea.NewProgram(m, tea.WithAltScreen()).Run()
 	if err != nil {
-		fmt.Println("Error running program:", err)
-		os.Exit(1)
+		return 0, fmt.Errorf("error running selection program: %w", err)
 	}
 
-	if p, ok := p.(selection.Model); ok {
-		// Extract the ID from p.Choice
-		var taskID int64
-		_, err = fmt.Sscanf(p.Choice, "ID: %d", &taskID)
-		if err != nil {
-			fmt.Println("error parsing task ID:", err)
-			os.Exit(1)
+	if model, ok := p.(selection.Model); ok {
+		if model.Aborted {
+			return 0, ErrUserAborted
 		}
-		choice <- taskID
+		if model.Choice == "" {
+			return 0, errors.New("no replication task selected")
+		}
+		// Extract the ID from model.Choice
+		var taskID int64
+		_, err = fmt.Sscanf(model.Choice, "ID: %d", &taskID)
+		if err != nil {
+			return 0, fmt.Errorf("error parsing task ID: %w", err)
+		}
+		return taskID, nil
 	}
+
+	return 0, errors.New("unexpected program result")
 }

--- a/pkg/views/replication/task/select/view.go
+++ b/pkg/views/replication/task/select/view.go
@@ -25,7 +25,7 @@ import (
 
 var ErrUserAborted = errors.New("user aborted selection")
 
-func ReplicationTasksList(tasks []*models.ReplicationTask) (int64, error) {
+func ReplicationTasksList(tasks []*models.ReplicationTask, choice chan<- int64, errChan chan<- error) {
 	itemsList := make([]list.Item, len(tasks))
 	for i, p := range tasks {
 		displayName := fmt.Sprintf("ID: %d, Status: %s, Operation: %s, Src: %s, Dst: %s, Start Time: %s",
@@ -37,24 +37,25 @@ func ReplicationTasksList(tasks []*models.ReplicationTask) (int64, error) {
 
 	p, err := tea.NewProgram(m, tea.WithAltScreen()).Run()
 	if err != nil {
-		return 0, fmt.Errorf("error running selection program: %w", err)
+		errChan <- fmt.Errorf("error running selection program: %w", err)
+		return
 	}
 
 	if model, ok := p.(selection.Model); ok {
-		if model.Aborted {
-			return 0, ErrUserAborted
-		}
 		if model.Choice == "" {
-			return 0, errors.New("no replication task selected")
+			errChan <- errors.New("user aborted selection")
+			return
 		}
 		// Extract the ID from model.Choice
 		var taskID int64
 		_, err = fmt.Sscanf(model.Choice, "ID: %d", &taskID)
 		if err != nil {
-			return 0, fmt.Errorf("error parsing task ID: %w", err)
+			errChan <- fmt.Errorf("error parsing task ID: %w", err)
+			return
 		}
-		return taskID, nil
+		choice <- taskID
+		return
 	}
 
-	return 0, errors.New("unexpected program result")
+	errChan <- errors.New("unexpected program result")
 }

--- a/pkg/views/replication/task/select/view.go
+++ b/pkg/views/replication/task/select/view.go
@@ -23,8 +23,6 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/views/base/selection"
 )
 
-var ErrUserAborted = errors.New("user aborted selection")
-
 func ReplicationTasksList(tasks []*models.ReplicationTask, choice chan<- int64, errChan chan<- error) {
 	itemsList := make([]list.Item, len(tasks))
 	for i, p := range tasks {
@@ -43,7 +41,7 @@ func ReplicationTasksList(tasks []*models.ReplicationTask, choice chan<- int64, 
 
 	if model, ok := p.(selection.Model); ok {
 		if model.Choice == "" {
-			errChan <- ErrUserAborted
+			errChan <- selection.ErrUserAborted
 			return
 		}
 		// Extract the ID from model.Choice

--- a/pkg/views/replication/task/select/view.go
+++ b/pkg/views/replication/task/select/view.go
@@ -43,7 +43,7 @@ func ReplicationTasksList(tasks []*models.ReplicationTask, choice chan<- int64, 
 
 	if model, ok := p.(selection.Model); ok {
 		if model.Choice == "" {
-			errChan <- errors.New("user aborted selection")
+			errChan <- ErrUserAborted
 			return
 		}
 		// Extract the ID from model.Choice


### PR DESCRIPTION
# Description

This PR fixes replication interactive prompt helpers and views that terminate the CLI abruptly via `log.Fatal()` or `os.Exit(1)` during API failures or invalid selections.

Errors are now propagated through Cobra's command lifecycle (`RunE`) instead of terminating the process directly, resulting in more consistent and automation-friendly CLI behavior.

Fixes #931

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which improves code structure)
- [ ] Documentation update
- [ ] Chore / maintenance

## Key Changes in PR #932

### 1. Removal of Abrupt CLI Crashes (`log.Fatal()`, `os.Exit()`)
* **Prompt Helpers:** Removed all instances of `log.Fatal()` in prompt helper functions in `pkg/prompt/prompt.go` when replication APIs fail or return empty lists.
* **View Tier:** Replaced direct `os.Exit(1)` calls inside selection views (such as `ReplicationExecutionList` and `ReplicationTasksList`) with clean error propagation via channels.
* **Cobra Integration:** Errors are returned up to Cobra's command layer, allowing it to format error messages and return appropriate exit codes.

### 2. Error & Cancel/Abort Propagation
* Added an `errChan chan<- error` channel to the asynchronous view functions to propagate errors back to the caller prompts.
* If a selection is cancelled/aborted (yielding empty selection choice), an error is sent to the channel instead of calling `os.Exit(1)`.

## How to Test

1. **Verify Cancel/Abort Graceful Exit:**
   Run an interactive command like `harbor replication start` without arguments, cancel the prompt selection, and verify the command exits gracefully with `user aborted selection` instead of calling `log.Fatal()`, calling `os.Exit(1)`, or silently executing on default values.

2. **Replication Commands:**
   Verify `harbor replication start`, `harbor replication stop`, and `harbor replication log` function as expected and terminate cleanly if aborted.
