### PR TITLE
fix(webhook): reject unsupported endpoint URL schemes

### DIFF
--- a/cmd/harbor/root/webhook/create.go
+++ b/cmd/harbor/root/webhook/create.go
@@ -69,7 +69,7 @@ or leave them out and be guided through an interactive prompt to input each fiel
 				opts.NotifyType != "" &&
 				len(opts.EventType) != 0 &&
 				opts.EndpointURL != "" {
-				err = utils.ValidateURL(opts.EndpointURL)
+				err = utils.ValidateHTTPURL(opts.EndpointURL)
 				if err != nil {
 					return err
 				}

--- a/cmd/harbor/root/webhook/edit.go
+++ b/cmd/harbor/root/webhook/edit.go
@@ -85,7 +85,7 @@ or leave them out and use the interactive prompt to select and update a webhook.
 				opts.NotifyType != "" &&
 				len(opts.EventType) != 0 &&
 				opts.EndpointURL != "" {
-				if err := utils.ValidateURL(opts.EndpointURL); err != nil {
+				if err := utils.ValidateHTTPURL(opts.EndpointURL); err != nil {
 					return err
 				}
 				err = api.UpdateWebhook(&opts)

--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -207,6 +207,25 @@ func ValidateURL(rawURL string) error {
 	return nil
 }
 
+// ValidateHTTPURL checks if the URL is valid and uses the http or https scheme.
+func ValidateHTTPURL(rawURL string) error {
+	if err := ValidateURL(rawURL); err != nil {
+		return err
+	}
+
+	parsedURL, err := url.ParseRequestURI(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL format: %v", err)
+	}
+
+	scheme := strings.ToLower(parsedURL.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return fmt.Errorf("URL scheme must be http or https")
+	}
+
+	return nil
+}
+
 func PrintFormat[T any](resp T, format string) error {
 	if format == "json" {
 		PrintPayloadInJSONFormat(resp)

--- a/pkg/utils/helper_test.go
+++ b/pkg/utils/helper_test.go
@@ -167,6 +167,33 @@ func TestValidateURL(t *testing.T) {
 	}
 }
 
+func TestValidateHTTPURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"valid https domain", "https://demo.goharbor.io", false},
+		{"valid http domain", "http://registry.example.com", false},
+		{"valid localhost", "http://localhost:8080", false},
+		{"unsupported ftp scheme", "ftp://example.com/webhook", true},
+		{"unsupported file scheme", "file://example.com/webhook", true},
+		{"missing scheme", "example.com/webhook", true},
+		{"invalid host", "https://invalid..domain", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := utils.ValidateHTTPURL(tc.input)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestPrintFormat(t *testing.T) {
 	// capture stdout
 	var buf bytes.Buffer

--- a/pkg/views/webhook/create/view.go
+++ b/pkg/views/webhook/create/view.go
@@ -83,7 +83,7 @@ func WebhookCreateView(createView *CreateView) error {
 				Title("Endpoint URL").
 				Value(&createView.EndpointURL).
 				Validate(func(str string) error {
-					return utils.ValidateURL(str)
+					return utils.ValidateHTTPURL(str)
 				}),
 			huh.NewInput().
 				Title("Auth Header").

--- a/pkg/views/webhook/edit/view.go
+++ b/pkg/views/webhook/edit/view.go
@@ -109,7 +109,7 @@ func WebhookEditView(editView *EditView) {
 					if strings.TrimSpace(str) == "" {
 						return errors.New("endpoint URL cannot be empty")
 					}
-					if err := utils.ValidateURL(str); err != nil {
+					if err := utils.ValidateHTTPURL(str); err != nil {
 						return err
 					}
 					return nil


### PR DESCRIPTION
## Description
This pull request fixes webhook endpoint URL validation by rejecting unsupported URL schemes such as ftp:// and file://.

Previously, the CLI only validated URL parsing and host validity through utils.ValidateURL, but it did not restrict the URL scheme. As a result, unsupported schemes could pass client-side validation and proceed toward the Harbor API request.

This change ensures webhook endpoint URLs only allow http and https schemes during CLI-side validation.
- Fixes #937 

## Type of Change
Please select the relevant type.

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
- Added `utils.ValidateHTTPURL` to validate URLs and restrict schemes to `http` and `https`
- Updated webhook create/edit command validation to use HTTP(S)-only URL validation
- Updated webhook create/edit interactive views to use the same validation
- Added tests covering unsupported schemes such as `ftp://` and `file://`
- Regenerated CLI documentation with `dagger call run-doc export --path=./doc`; no documentation changes were produced
