### PR TITLE
fix(login): avoid false login failures for robot accounts

### DIFF
--- a/cmd/harbor/root/login.go
+++ b/cmd/harbor/root/login.go
@@ -218,12 +218,12 @@ func validateClientConnection(client *client.HarborAPI) error {
 	}
 
 	errorCode := utils.ParseHarborErrorCode(err)
-	// 401/403 = definite auth failure
-	if errorCode == "401" || errorCode == "403" {
+	// 401 = definite auth failure
+	if errorCode == "401" {
 		return fmt.Errorf("authentication failed, check your credentials: %v", utils.ParseHarborErrorMsg(err))
 	}
 
-	// For other errors (e.g. 412 for robot/OIDC accounts, 5xx),
+	// For other errors (e.g. 403 for robot accounts, 412 for OIDC accounts, 5xx, or deserialization errors),
 	// fall back to secondary endpoints to verify creds and reachability.
 	_, projectErr := client.Project.ListProjects(ctx, &project.ListProjectsParams{
 		Page:     new(int64(1)),
@@ -231,16 +231,18 @@ func validateClientConnection(client *client.HarborAPI) error {
 	})
 	_, pingErr := client.Ping.GetPing(ctx, &ping.GetPingParams{})
 
-	// If either secondary check returns 401/403, creds are bad.
+	// If either secondary check returns 401, creds are bad.
 	if projectErr != nil {
 		projCode := utils.ParseHarborErrorCode(projectErr)
-		if projCode == "401" || projCode == "403" {
+		if projCode == "401" {
 			return fmt.Errorf("authentication failed, check your credentials: %v", utils.ParseHarborErrorMsg(projectErr))
 		}
 	}
 
-	// Both passed → creds valid, server reachable
-	if projectErr == nil && pingErr == nil {
+	// If Ping succeeds, the server is reachable.
+	// If ListProjects succeeded (nil) or returned 403 (valid but restricted robot account),
+	// we consider the client connection validated.
+	if pingErr == nil && (projectErr == nil || utils.ParseHarborErrorCode(projectErr) == "403") {
 		return nil
 	}
 

--- a/cmd/harbor/root/login_test.go
+++ b/cmd/harbor/root/login_test.go
@@ -14,6 +14,8 @@
 package root_test
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/goharbor/harbor-cli/cmd/harbor/root"
@@ -121,4 +123,116 @@ func Test_Login_Failure_MutuallyExclusiveFlags(t *testing.T) {
 
 	err := cmd.Execute()
 	assert.Error(t, err, "Expected error when both --password and --password-stdin are set")
+}
+
+func Test_Login_Validation_MockServer(t *testing.T) {
+	tests := []struct {
+		name                   string
+		currentUserStatus      int
+		currentUserResponse    string
+		projectsStatus         int
+		projectsResponse       string
+		pingStatus             int
+		pingResponse           string
+		expectError            bool
+		expectedErrSubstr      string
+	}{
+		{
+			name:                "Human Login Success",
+			currentUserStatus:   http.StatusOK,
+			currentUserResponse: `{"username": "human-user", "sysadmin_flag": false}`,
+			expectError:         false,
+		},
+		{
+			name:                "Invalid Credentials (401)",
+			currentUserStatus:   http.StatusUnauthorized,
+			currentUserResponse: `{"errors": [{"code": "UNAUTHORIZED", "message": "unauthorized"}]}`,
+			expectError:         true,
+			expectedErrSubstr:   "authentication failed, check your credentials",
+		},
+		{
+			name:                "Robot Login Success (Standard fallback)",
+			currentUserStatus:   http.StatusForbidden,
+			currentUserResponse: `{"errors": [{"code": "FORBIDDEN", "message": "forbidden"}]}`,
+			projectsStatus:      http.StatusOK,
+			projectsResponse:    `[]`,
+			pingStatus:          http.StatusOK,
+			pingResponse:        `"pong"`,
+			expectError:         false,
+		},
+		{
+			name:                "Robot Login Success (Restricted project access 403 fallback)",
+			currentUserStatus:   http.StatusForbidden,
+			currentUserResponse: `{"errors": [{"code": "FORBIDDEN", "message": "forbidden"}]}`,
+			projectsStatus:      http.StatusForbidden,
+			projectsResponse:    `{"errors": [{"code": "FORBIDDEN", "message": "forbidden"}]}`,
+			pingStatus:          http.StatusOK,
+			pingResponse:        `"pong"`,
+			expectError:         false,
+		},
+		{
+			name:                "Robot Login Failure (Bad credentials 401 on fallback)",
+			currentUserStatus:   http.StatusForbidden,
+			currentUserResponse: `{"errors": [{"code": "FORBIDDEN", "message": "forbidden"}]}`,
+			projectsStatus:      http.StatusUnauthorized,
+			projectsResponse:    `{"errors": [{"code": "UNAUTHORIZED", "message": "unauthorized"}]}`,
+			pingStatus:          http.StatusOK,
+			pingResponse:        `"pong"`,
+			expectError:         true,
+			expectedErrSubstr:   "authentication failed, check your credentials",
+		},
+		{
+			name:                "Server Error (500)",
+			currentUserStatus:   http.StatusInternalServerError,
+			currentUserResponse: `Internal Server Error`,
+			projectsStatus:      http.StatusInternalServerError,
+			projectsResponse:    `Internal Server Error`,
+			pingStatus:          http.StatusInternalServerError,
+			pingResponse:        `Internal Server Error`,
+			expectError:         true,
+			expectedErrSubstr:   "server error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			data := helpers.Initialize(t, tempDir)
+			defer helpers.ConfigCleanup(t, data)
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/api/v2.0/users/current":
+					w.WriteHeader(tt.currentUserStatus)
+					w.Write([]byte(tt.currentUserResponse))
+				case "/api/v2.0/projects":
+					w.WriteHeader(tt.projectsStatus)
+					w.Write([]byte(tt.projectsResponse))
+				case "/api/v2.0/ping":
+					w.WriteHeader(tt.pingStatus)
+					w.Write([]byte(tt.pingResponse))
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+
+			cmd := root.LoginCommand()
+			cmd.SetArgs([]string{server.URL})
+
+			assert.NoError(t, cmd.Flags().Set("username", "test-user"))
+			assert.NoError(t, cmd.Flags().Set("password", "test-password"))
+
+			err := cmd.Execute()
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.expectedErrSubstr != "" {
+					assert.Contains(t, err.Error(), tt.expectedErrSubstr)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

* Running `harbor login` with valid robot account credentials can incorrectly trigger an authentication failure during connection validation.
* This behavior impacts non-interactive workflows and CI/CD pipelines that rely on automated robot account authentication.
* The issue occurs even when the supplied credentials themselves are valid.

## Root Cause Analysis

* The login flow actively validates credentials by calling the `/users/current` API endpoint through `GetCurrentUserInfo`.
* Robot accounts are system-level authentication tokens and are not treated as standard Harbor user principals.
* When robot accounts access the `/users/current` endpoint, Harbor returns a `403 Forbidden` response instead of a standard user profile response.
* `validateClientConnection` previously handled `403 Forbidden` identically to `401 Unauthorized`, causing robot account authentication to fail during validation even though authentication itself succeeded successfully.

## Validation Behavior Matrix

| Scenario                 | Previous Behavior | New Behavior |
| ------------------------ | ----------------- | ------------ |
| Human user login         | Success           | Success      |
| Invalid credentials      | Failure           | Failure      |
| Standard robot account   | False failure     | Success      |
| Restricted robot account | False failure     | Success      |

## What Changed

* `401 Unauthorized` is now treated as the only definitive authentication failure during the primary validation step.
* `403 Forbidden` responses now gracefully fall back to secondary `/projects` and `/ping` reachability validation checks instead of immediately failing the login flow.
* Restricted robot accounts without global project-listing permissions are now handled correctly by treating a `403 Forbidden` response from the `/projects` fallback as successful validation when `/ping` succeeds.
* Existing authentication behavior for invalid credentials remains unchanged, and invalid credentials continue to fail immediately and securely.

## Test Coverage

* Added a new table-driven mock server validation suite using `httptest.NewServer`.
* The test suite verifies standard human login flows returning `200 OK`.
* The test suite verifies invalid credential handling returning `401 Unauthorized`.
* The test suite verifies robot account validation flows returning `403 Forbidden` on `/users/current` while successfully passing fallback validation endpoints.
* The test suite also verifies restricted robot account scenarios where `/projects` returns `403 Forbidden` but `/ping` succeeds successfully.
* All scenarios pass reliably without requiring external Harbor instances or live network calls.

Fixes #941
