### PR TITLE
fix: validate URL schemes and single-label hosts

### DIFF
--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -177,14 +177,21 @@ func ValidateRegistryName(rn string) bool {
 	return re.MatchString(rn)
 }
 
-// ValidateURL checks if the URL has valid format, non-empty host, and host is a valid IP or domain.
-// Domain regex: labels must start/end with alphanumeric, can contain hyphens, max 63 chars, TLD min 2 letters.
-func ValidateURL(rawURL string) error {
-	var domainNameRegex = regexp.MustCompile(`^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$`)
+var (
+	domainNameRegex = regexp.MustCompile(`^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$`)
+	hostLabelRegex  = regexp.MustCompile(`^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$`)
+)
 
+// ValidateURL checks if the URL has valid format, an HTTP(S) scheme, and a valid host.
+// Hostnames may be IP addresses, localhost, FQDNs, or single RFC 1123 labels for internal networks.
+func ValidateURL(rawURL string) error {
 	parsedURL, err := url.ParseRequestURI(rawURL)
 	if err != nil {
 		return fmt.Errorf("invalid URL format: %v", err)
+	}
+
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return fmt.Errorf("URL scheme must be http or https")
 	}
 
 	host := parsedURL.Hostname()
@@ -196,7 +203,7 @@ func ValidateURL(rawURL string) error {
 		return nil
 	}
 
-	if host == "localhost" {
+	if host == "localhost" || hostLabelRegex.MatchString(host) {
 		return nil
 	}
 

--- a/pkg/utils/helper_test.go
+++ b/pkg/utils/helper_test.go
@@ -147,13 +147,20 @@ func TestValidateURL(t *testing.T) {
 		{"valid localhost https", "https://localhost", false},
 		{"valid localhost http with port", "http://localhost:8080", false},
 		{"valid localhost https with port", "https://localhost:8443", false},
+		{"valid single-label host", "http://harbor", false},
+		{"valid single-label host with hyphen", "http://harbor-core", false},
+		{"valid single-label host with port", "https://registry:8443", false},
 
 		// invalid URLs
 		{"empty string", "", true},
 		{"no host", "https://", true},
 		{"bare path", "/just/a/path", true},
+		{"unsupported ftp scheme", "ftp://example.com/webhook", true},
+		{"unsupported file scheme", "file://example.com/webhook", true},
 		{"invalid domain double dot", "https://invalid..domain", true},
 		{"domain starting with hyphen", "https://-invalid.com", true},
+		{"single-label host starting with hyphen", "https://-harbor", true},
+		{"single-label host ending with hyphen", "https://harbor-", true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -165,6 +172,9 @@ func TestValidateURL(t *testing.T) {
 			}
 		})
 	}
+
+	err := utils.ValidateURL("ftp://example.com/webhook")
+	assert.EqualError(t, err, "URL scheme must be http or https")
 }
 
 func TestPrintFormat(t *testing.T) {


### PR DESCRIPTION
## Summary
- reject non-HTTP(S) URLs in the shared URL validator with `URL scheme must be http or https`
- allow RFC 1123-style single-label hosts such as `http://harbor` and `https://registry:8443`
- add regression coverage for unsupported schemes and single-label host edge cases

Fixes #937.
Fixes #879.

## Verification
- `go test ./pkg/utils`
- `go test ./...`
- `go build -o ./bin/harbor-cli cmd/harbor/main.go`
- `./bin/harbor-cli --help`
- `git diff --check`

## AI disclosure
This contribution was prepared with AI assistance and reviewed before submission. I verified the changed validator logic and tests locally.
