### PR TITLE
fix: Use WithSecretVariable in Sign() for consistent credential handling

### DIFF
--- a/.dagger/publishimage.go
+++ b/.dagger/publishimage.go
@@ -253,29 +253,29 @@ func (m *HarborCli) Sign(ctx context.Context,
 	registryPassword *dagger.Secret,
 	imageAddr string,
 ) (string, error) {
-	registryPasswordPlain, _ := registryPassword.Plaintext(ctx)
+	cosignCtr := dag.Container().
+		From("cgr.dev/chainguard/cosign").
+		WithSecretVariable("REGISTRY_PASSWORD", registryPassword)
 
-	cosing_ctr := dag.Container().From("cgr.dev/chainguard/cosign")
-
-	// If githubToken is provided, use it to sign the image
+	// If githubToken is provided, configure OIDC for keyless signing
 	if githubToken != nil {
 		if actionsIdTokenRequestUrl == nil || actionsIdTokenRequestToken == nil {
-			return "", fmt.Errorf("actionsIdTokenRequestUrl (exist=%s) and actionsIdTokenRequestToken (exist=%t) must be provided when githubToken is provided", actionsIdTokenRequestUrl, actionsIdTokenRequestToken != nil)
+			return "", fmt.Errorf("actionsIdTokenRequestUrl (exist=%v) and actionsIdTokenRequestToken (exist=%t) must be provided when githubToken is provided", actionsIdTokenRequestUrl != nil, actionsIdTokenRequestToken != nil)
 		}
-		fmt.Printf("Setting the ENV Vars GITHUB_TOKEN, ACTIONS_ID_TOKEN_REQUEST_URL, ACTIONS_ID_TOKEN_REQUEST_TOKEN to sign with GitHub Token")
-		cosing_ctr = cosing_ctr.WithSecretVariable("GITHUB_TOKEN", githubToken).
+		cosignCtr = cosignCtr.
+			WithSecretVariable("GITHUB_TOKEN", githubToken).
 			WithSecretVariable("ACTIONS_ID_TOKEN_REQUEST_URL", actionsIdTokenRequestUrl).
 			WithSecretVariable("ACTIONS_ID_TOKEN_REQUEST_TOKEN", actionsIdTokenRequestToken)
 	}
 
-	return cosing_ctr.WithSecretVariable("REGISTRY_PASSWORD", registryPassword).
+	return cosignCtr.
 		WithExec([]string{"cosign", "env"}).
 		WithExec([]string{
-			"cosign", "sign", "--yes", "--recursive",
-			"--registry-username", registryUsername,
-			"--registry-password", registryPasswordPlain,
-			imageAddr,
-			"--timeout", "1m",
+			"sh", "-c",
+			fmt.Sprintf(
+				"cosign sign --yes --recursive --registry-username %s --registry-password $REGISTRY_PASSWORD %s --timeout 1m",
+				registryUsername, imageAddr,
+			),
 		}).Stdout(ctx)
 }
 


### PR DESCRIPTION
## Description
Makes `Sign()` follow the same `WithSecretVariable` + shell expansion pattern already used by `AttestSBOM()`.

- Fixes #951 

### Before
In the Job push-latest-images -> Publish and Sign Snapshot Image
<img width="1164" height="144" alt="image" src="https://github.com/user-attachments/assets/8f3a07aa-0ed4-47e3-8b85-a75d21467b61" />


### After
<img width="1253" height="99" alt="image" src="https://github.com/user-attachments/assets/7251cb29-b953-45fc-b9a5-e8dbfc243c9d" />

same as the Attest:
<img width="1192" height="141" alt="image" src="https://github.com/user-attachments/assets/820fcb4f-95c5-4640-bb54-b83b5c447ba5" />



## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
- Replaced `Plaintext(ctx)` extraction with `WithSecretVariable("REGISTRY_PASSWORD", registryPassword)`
- Pass password via `$REGISTRY_PASSWORD` shell variable instead of direct CLI argument
- Fixed `fmt.Errorf` format verb (`%s` → `%v` for a pointer nil-check)
