### PR TITLE
fix(registry): return error when registry name not found

### DIFF
--- a/cmd/harbor/root/registry/delete.go
+++ b/cmd/harbor/root/registry/delete.go
@@ -33,7 +33,10 @@ func DeleteRegistryCommand() *cobra.Command {
 			errChan := make(chan error, len(args))
 			if len(args) > 0 {
 				for _, arg := range args {
-					registryID, _ := api.GetRegistryIdByName(arg)
+					registryID, err := api.GetRegistryIdByName(arg)
+					if err != nil {
+						return err
+					}
 					wg.Add(1)
 					go func(registryID int64) {
 						defer wg.Done()

--- a/pkg/api/registry_handler.go
+++ b/pkg/api/registry_handler.go
@@ -188,5 +188,8 @@ func GetRegistryIdByName(registryName string) (int64, error) {
 		}
 	}
 
-	return 0, err
+	return 0, fmt.Errorf(
+    "registry with name %q not found",
+    registryName,
+)
 }


### PR DESCRIPTION
## Description

Fixes an issue where `GetRegistryIdByName` returned `(0, nil)` when a registry name did not exist.

Previously, callers interpreted the result as success and continued operating on registry ID `0`, causing commands like:

```bash
harbor registry delete does-not-exist
```

to incorrectly call:

```text
DELETE /registries/0
```

This change now returns a proper error when the registry is not found and propagates the error correctly in the delete command.

* Fixes #933

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Refactor
* [ ] Documentation update
* [ ] Chore / maintenance

## Changes

* Return explicit error when registry name is not found in `GetRegistryIdByName`
* Handle and propagate errors correctly in `registry/delete.go`
* Prevent invalid operations on registry ID `0`
