### PR TITLE
fix: key checksums by filename to include windows_amd64

### DIFF
--- a/.dagger/checksum.go
+++ b/.dagger/checksum.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"dagger/harbor-cli/internal/dagger"
@@ -36,12 +37,19 @@ func (m *HarborCli) Checksum(ctx context.Context,
 		}
 
 		split := strings.Split(v, "/")
-		sums[out] = split[len(split)-1] // Taking only filename
+		filename := split[len(split)-1]
+		sums[filename] = strings.TrimSpace(out)
 	}
 
+	filenames := make([]string, 0, len(sums))
+	for filename := range sums {
+		filenames = append(filenames, filename)
+	}
+	sort.Strings(filenames)
+
 	content := ""
-	for k, v := range sums {
-		content += fmt.Sprintf("%s %s\n", strings.TrimSuffix(k, "\n"), v)
+	for _, filename := range filenames {
+		content += fmt.Sprintf("%s %s\n", sums[filename], filename)
 	}
 
 	buildDir = buildDir.WithFile("checksums.txt", dag.File("checksums.txt", content))


### PR DESCRIPTION
## Description

Scoop autoupdate reads hashes from `checksums.txt` by artifact filename. On v0.0.20, `harbor-cli_*_windows_amd64.zip` was missing from that file because duplicate SHA256 values overwrote each other when checksums were keyed by hash.

- Fixes #950 

## Type of Change
Please select the relevant type.

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
-  Key checksum entries by filename in `.dagger/checksum.go` instead of by hash
-  Emit `checksums.txt` with filenames sorted alphabetically
- Both `windows_amd64` and `windows_arm64` archives now appear in `checksums.txt` when their hashes collide

## Test plan
-  [x] `dagger call build` -> `archive` -> `nfpm-build` -> `apk` -> `checksum`
---
-  [x] `grep windows dist/checksums.txt` shows both `windows_amd64.zip` and `windows_arm64.zip`
<img width="892" height="164" alt="Screenshot From 2026-05-24 00-12-51" src="https://github.com/user-attachments/assets/66b03008-6afd-4d7e-b6aa-ec64ac80bc7f" />

---
-  [x] `sha256sum` on `dist/archive/*_windows_*.zip` matches `checksums.txt`
<img width="1070" height="218" alt="image" src="https://github.com/user-attachments/assets/9a36b813-ef7a-4f74-b286-d377a8fef89e" />






