### PR TITLE
fix(ci): Pin actions/checkout to SHA

### DIFF
--- a/.github/actions/scoop-update/action.yaml
+++ b/.github/actions/scoop-update/action.yaml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - name: Checkout bucket repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Clone Scoop
       shell: bash

--- a/.github/actions/scoop-update/action.yaml
+++ b/.github/actions/scoop-update/action.yaml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - name: Checkout bucket repository
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Clone Scoop
       shell: bash


### PR DESCRIPTION
## Description
Pin actions/checkout@v4 to SHA in `.github/actions/scoop-update/action.yaml`

- Fixes #958 
