### PR TITLE
build: address Go security findings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/goharbor/harbor-cli
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/atotto/clipboard v0.1.4


### PR DESCRIPTION
## Description
- Address Go standard library vulnerability findings by moving the module to the fixed Go patch version.


## Type of Change
Please select the relevant type.

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [x] Chore / maintenance

## Changes
- Update the root module Go version from 1.26.2 to 1.26.3 to pick up fixes for GO-2026-4971 and GO-2026-4918.

## Testing
- `go test ./...`
- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...`