### PR TITLE
fix(ci): preserve release dist during scoop update

### DIFF
--- a/.github/actions/scoop-update/action.yaml
+++ b/.github/actions/scoop-update/action.yaml
@@ -9,9 +9,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Checkout bucket repository
-      uses: actions/checkout@v4
-
     - name: Clone Scoop
       shell: bash
       run: |


### PR DESCRIPTION
## Summary
- Remove the redundant nested checkout from the local `scoop-update` action.
- Prevent the release job from deleting `dist/` before the later APT build and artifact/image publishing steps consume it.

## Root Cause
The `Scoop Update` step invoked `actions/checkout@v4` inside the same `publish-release` workspace. That checkout ran its clean phase and removed the generated, ignored `dist/` directory, causing the following `Apt Build` Dagger call to fail while resolving `--build-dir=./dist`.

## Testing
- `git diff --check`
- `actionlint .github/workflows/default.yaml`

Closes #961