### PR TITLE
fix(docs): Update maintainer from Nucleo Fusion to Lakshit Singh

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,4 +7,4 @@ This file lists the current sub-project maintainers for `harbor-cli`.
 - Vadim Bauer (`@Vad1mo`)
 - Prasanth Baskar (`@bupd`)
 - Patrick Eschenbach (`@qcserestipy`)
-- Nucleo Fusion (`@NucleoFusion`)
+- Lakshit Singh (`@NucleoFusion`)


### PR DESCRIPTION
## Description
- Update name from Nucleo Fusion to Lakshit Singh
