### PR TITLE
fix(ci): retry cosign transparency log failures

### DIFF
--- a/.dagger/publishimage.go
+++ b/.dagger/publishimage.go
@@ -43,10 +43,10 @@ func (m *HarborCli) PublishImageAndSign(
 		// Generate SBOM (SPDX JSON) for the published image
 		sbom := m.GenerateSBOM(
 			ctx,
-			addr, 
-			registryUsername, 
+			addr,
+			registryUsername,
 			registryPassword,
-		);
+		)
 
 		// Attest SBOM to the image using Cosign in-toto attestation
 		if _, err := m.AttestSBOM(
@@ -272,10 +272,10 @@ func (m *HarborCli) Sign(ctx context.Context,
 		WithExec([]string{"cosign", "env"}).
 		WithExec([]string{
 			"sh", "-c",
-			fmt.Sprintf(
-				"cosign sign --yes --recursive --registry-username %s --registry-password $REGISTRY_PASSWORD %s --timeout 1m",
-				registryUsername, imageAddr,
-			),
+			cosignWithRetry(fmt.Sprintf(
+				"cosign sign --yes --recursive --registry-username %s --registry-password $REGISTRY_PASSWORD %s --timeout 2m",
+				shellQuote(registryUsername), shellQuote(imageAddr),
+			)),
 		}).Stdout(ctx)
 }
 
@@ -340,9 +340,52 @@ func (m *HarborCli) AttestSBOM(
 	// The registry password is already available as REGISTRY_PASSWORD env var
 	return cosignCtr.WithExec([]string{
 		"sh", "-c",
-		fmt.Sprintf(
-			"cosign attest --yes --type spdxjson --predicate /sbom.spdx.json --registry-username %s --registry-password $REGISTRY_PASSWORD %s --timeout 1m",
-			registryUsername, imageAddr,
-		),
+		cosignWithRetry(fmt.Sprintf(
+			"cosign attest --yes --type spdxjson --predicate /sbom.spdx.json --registry-username %s --registry-password $REGISTRY_PASSWORD %s --timeout 2m",
+			shellQuote(registryUsername), shellQuote(imageAddr),
+		)),
 	}).Stdout(ctx)
+}
+
+func cosignWithRetry(command string) string {
+	return fmt.Sprintf(`
+set +e
+attempt=1
+max_attempts=3
+
+while [ "$attempt" -le "$max_attempts" ]; do
+	output=$(%s 2>&1)
+	status=$?
+	printf '%%s\n' "$output"
+
+	if [ "$status" -eq 0 ]; then
+		exit 0
+	fi
+
+	case "$output" in
+		*createLogEntryConflict*|*"equivalent entry already exists"*)
+			printf 'cosign transparency log entry already exists; treating as success\n'
+			exit 0
+			;;
+	esac
+
+	if [ "$attempt" -eq "$max_attempts" ]; then
+		exit "$status"
+	fi
+
+	case "$output" in
+		*INTERNAL_ERROR*|*"stream error"*|*timeout*|*"connection reset"*|*"temporary failure"*)
+			sleep $((attempt * 10))
+			attempt=$((attempt + 1))
+			;;
+		*)
+			exit "$status"
+			;;
+	esac
+done
+`, command)
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }


### PR DESCRIPTION
## Summary
- Retry `cosign attest` and `cosign sign` when Sigstore/Rekor returns transient transport errors such as stream `INTERNAL_ERROR`.
- Treat Rekor duplicate transparency-log entries as success so reruns do not fail after an entry was already created.
- Increase the per-cosign timeout from 1 minute to 2 minutes for signing bundle creation.

## Root Cause
The image publish step succeeds before the workflow enters Sigstore/Rekor signing. The Dagger module ran each `cosign` command once, so transient transparency-log errors or duplicate entries from reruns failed the whole job even when the publish side had completed.

## Testing
- `git diff --check`
- `dagger call publish-image-and-sign --help`

`go test ./...` under `.dagger` is not runnable from a plain checkout because the generated `internal/dagger` package is gitignored and absent until Dagger loads the module.

Closes #964