### PR TITLE
fix: Missing windows binary

### DIFF
--- a/.dagger/archive.go
+++ b/.dagger/archive.go
@@ -59,7 +59,7 @@ func (m *HarborCli) Archive(ctx context.Context,
 					WithMountedDirectory("/input", archiveDir).
 					WithMountedDirectory("/out", archives).
 					WithWorkdir("/input").
-					WithExec([]string{"zip", "-j", "/out/" + archiveFile, "/input/harbor-cli", "/input/LICENSE", "/input/README.md"})
+					WithExec([]string{"zip", "-j", "/out/" + archiveFile, "/input/harbor-cli.exe", "/input/LICENSE", "/input/README.md"})
 			} else {
 				archiveFile = archiveName + ".tar.gz"
 				container = dag.Container().


### PR DESCRIPTION
## Description
The ZIP packaging step was referencing harbor-cli instead of harbor-cli.exe

Now zip has:
<img width="985" height="325" alt="image" src="https://github.com/user-attachments/assets/07daac47-19d2-4074-8ab8-de4d682c3e53" />


- Fixes #967


