### PR TITLE
feat: add non-interactive replication policy updates

### DIFF
--- a/cmd/harbor/root/replication/policies/update.go
+++ b/cmd/harbor/root/replication/policies/update.go
@@ -54,10 +54,12 @@ func UpdateCommand() *cobra.Command {
 		Short: "Update an existing replication policy",
 		Long: `Update an existing replication policy.
 
-When update flags are provided, the command runs non-interactively and updates only the specified fields while preserving all other values.`,
+When update flags are provided, the command runs non-interactively and updates only the specified fields while preserving all other values. Policy ID is required when update flags are used.
+For interactive mode, omit all flags and the command will guide you through the update process.`,
 		Example: `harbor replication policies update 1 --name production-sync --enabled=true`,
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			isNonInteractiveMode := hasReplicationUpdateFlagChanges(cmd)
 			var policyID int64
 			if len(args) > 0 {
 				var err error
@@ -65,7 +67,11 @@ When update flags are provided, the command runs non-interactively and updates o
 				if err != nil {
 					return fmt.Errorf("invalid replication policy ID: %s, %v", args[0], err)
 				}
+			} else if isNonInteractiveMode {
+				// In non-interactive mode, policy-id is required
+				return fmt.Errorf("policy-id is required when update flags are provided. Usage: harbor replication policies update <policy-id> --flag=value")
 			} else {
+				// In interactive mode, prompt for policy ID
 				policyID = prompt.GetReplicationPolicyFromUser()
 			}
 

--- a/cmd/harbor/root/replication/policies/update.go
+++ b/cmd/harbor/root/replication/policies/update.go
@@ -16,6 +16,7 @@ package policies
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/api"
@@ -25,12 +26,37 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// updateOpts holds all non-interactive flag values for the update command.
+type updateOpts struct {
+	Name              string
+	Description       string
+	ResourceFilter    string
+	NameFilter        string
+	TagFilter         string
+	TagPattern        string
+	LabelFilter       string
+	LabelPattern      string
+	TriggerType       string
+	CronString        string
+	Speed             string
+	Enabled           bool
+	Override          bool
+	ReplicateDeletion bool
+	CopyByChunk       bool
+}
+
 // UpdateCommand returns a command to update existing replication policies
 func UpdateCommand() *cobra.Command {
+	var opts updateOpts
+
 	cmd := &cobra.Command{
 		Use:   "update [policy-id]",
 		Short: "Update an existing replication policy",
-		Args:  cobra.MaximumNArgs(1),
+		Long: `Update an existing replication policy.
+
+When update flags are provided, the command runs non-interactively and updates only the specified fields while preserving all other values.`,
+		Example: `harbor replication policies update 1 --name production-sync --enabled=true`,
+		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var policyID int64
 			if len(args) > 0 {
@@ -49,14 +75,17 @@ func UpdateCommand() *cobra.Command {
 			}
 
 			var existingReplicationMode string
-			if existingPolicy.Payload.SrcRegistry.ID != 0 && existingPolicy.Payload.DestRegistry.ID == 0 {
+			if existingPolicy.Payload.SrcRegistry != nil && existingPolicy.Payload.SrcRegistry.ID != 0 &&
+				(existingPolicy.Payload.DestRegistry == nil || existingPolicy.Payload.DestRegistry.ID == 0) {
 				existingReplicationMode = "Pull"
-			} else if existingPolicy.Payload.SrcRegistry.ID == 0 && existingPolicy.Payload.DestRegistry.ID != 0 {
+			} else if (existingPolicy.Payload.SrcRegistry == nil || existingPolicy.Payload.SrcRegistry.ID == 0) &&
+				existingPolicy.Payload.DestRegistry != nil && existingPolicy.Payload.DestRegistry.ID != 0 {
 				existingReplicationMode = "Push"
 			} else {
 				return fmt.Errorf("replication policy with ID %d is neither Pull nor Push", policyID)
 			}
 
+			// Build the baseline CreateView from the existing policy.
 			createView := &create.CreateView{
 				Name:              existingPolicy.Payload.Name,
 				Description:       existingPolicy.Payload.Description,
@@ -78,15 +107,8 @@ func UpdateCommand() *cobra.Command {
 				createView.Speed = strconv.FormatInt(int64(*existingPolicy.Payload.Speed), 10)
 			}
 
-			if existingPolicy.Payload.SrcRegistry != nil && existingPolicy.Payload.DestRegistry == nil {
-				createView.ReplicationMode = "Pull"
-			} else if existingPolicy.Payload.SrcRegistry == nil && existingPolicy.Payload.DestRegistry != nil {
-				createView.ReplicationMode = "Push"
-			}
-
 			if existingPolicy.Payload.Trigger != nil {
 				createView.TriggerType = existingPolicy.Payload.Trigger.Type
-
 				if existingPolicy.Payload.Trigger.TriggerSettings != nil {
 					if existingPolicy.Payload.Trigger.Type == "scheduled" {
 						createView.CronString = existingPolicy.Payload.Trigger.TriggerSettings.Cron
@@ -96,17 +118,63 @@ func UpdateCommand() *cobra.Command {
 				}
 			}
 
+			// Populate filter fields from the existing policy filters.
+			for _, f := range existingPolicy.Payload.Filters {
+				if f == nil {
+					continue
+				}
+				switch f.Type {
+				case "resource":
+					if s, ok := f.Value.(string); ok {
+						createView.ResourceFilter = s
+					}
+				case "name":
+					if s, ok := f.Value.(string); ok {
+						createView.NameFilter = s
+					}
+				case "tag":
+					if s, ok := f.Value.(string); ok {
+						createView.TagPattern = s
+					}
+					createView.TagFilter = f.Decoration
+				case "label":
+					createView.LabelFilter = f.Decoration
+					switch v := f.Value.(type) {
+					case string:
+						createView.LabelPattern = v
+					case []string:
+						createView.LabelPattern = strings.Join(v, ",")
+					case []interface{}:
+						var parts []string
+						for _, item := range v {
+							if s, ok := item.(string); ok {
+								parts = append(parts, s)
+							}
+						}
+						createView.LabelPattern = strings.Join(parts, ",")
+					}
+				}
+			}
+
 			log.Debugf("Updating replication policy: %s (ID: %d)", existingPolicy.Payload.Name, policyID)
-			create.CreateRPolicyView(createView, true)
+
+			// Branch: non-interactive if any update flag was explicitly provided.
+			if hasReplicationUpdateFlagChanges(cmd) {
+				if err := applyReplicationUpdateFlags(cmd, createView, opts); err != nil {
+					return err
+				}
+			} else {
+				// Preserve the existing interactive TUI workflow.
+				create.CreateRPolicyView(createView, true)
+			}
 
 			var updatedPolicy *models.ReplicationPolicy
-
-			fmt.Println("Updated policy replicate deletion:", createView.ReplicateDeletion)
 			if createView.ReplicationMode == "Pull" {
 				updatedPolicy = ConvertToPolicy(createView, existingPolicy.Payload.SrcRegistry)
 				updatedPolicy.ID = policyID
 			} else {
 				updatedPolicy = ConvertToPolicy(createView, existingPolicy.Payload.DestRegistry)
+				updatedPolicy.ID = policyID
 			}
 
 			_, err = api.UpdateReplicationPolicy(policyID, updatedPolicy)
@@ -119,5 +187,133 @@ func UpdateCommand() *cobra.Command {
 		},
 	}
 
+	flags := cmd.Flags()
+	flags.StringVar(&opts.Name, "name", "", "New name for the replication policy")
+	flags.StringVar(&opts.Description, "description", "", "New description for the replication policy")
+	flags.StringVar(&opts.ResourceFilter, "resource-filter", "", "Resource type filter: image, artifact, or empty for all")
+	flags.StringVar(&opts.NameFilter, "name-filter", "", "Repository name filter pattern (supports wildcards, e.g. library/*)")
+	flags.StringVar(&opts.TagFilter, "tag-filter", "", "Tag filter type: matches or excludes")
+	flags.StringVar(&opts.TagPattern, "tag-pattern", "", "Tag filter pattern (e.g. v*, latest, *-prod)")
+	flags.StringVar(&opts.LabelFilter, "label-filter", "", "Label filter type: matches or excludes")
+	flags.StringVar(&opts.LabelPattern, "label-pattern", "", "Label filter pattern (e.g. env=prod or env=prod,ver=1.0)")
+	flags.StringVar(&opts.TriggerType, "trigger-type", "", "Trigger type: manual, scheduled, or event_based")
+	flags.StringVar(&opts.CronString, "cron", "", "Cron schedule (6-field format, required when --trigger-type=scheduled, e.g. \"0 0 */6 * * *\")")
+	flags.StringVar(&opts.Speed, "speed", "", "Maximum replication speed in KB/s (-1 for unlimited)")
+	flags.BoolVar(&opts.Enabled, "enabled", false, "Enable the replication policy")
+	flags.BoolVar(&opts.Override, "override", false, "Override artifacts on destination if they already exist")
+	flags.BoolVar(&opts.ReplicateDeletion, "replicate-deletion", false, "Replicate deletion operations to the destination")
+	flags.BoolVar(&opts.CopyByChunk, "copy-by-chunk", false, "Transfer artifacts in chunks for better reliability")
+
 	return cmd
+}
+
+// hasReplicationUpdateFlagChanges reports whether the user explicitly set any update flag.
+func hasReplicationUpdateFlagChanges(cmd *cobra.Command) bool {
+	flags := cmd.Flags()
+	return flags.Changed("name") ||
+		flags.Changed("description") ||
+		flags.Changed("resource-filter") ||
+		flags.Changed("name-filter") ||
+		flags.Changed("tag-filter") ||
+		flags.Changed("tag-pattern") ||
+		flags.Changed("label-filter") ||
+		flags.Changed("label-pattern") ||
+		flags.Changed("trigger-type") ||
+		flags.Changed("cron") ||
+		flags.Changed("speed") ||
+		flags.Changed("enabled") ||
+		flags.Changed("override") ||
+		flags.Changed("replicate-deletion") ||
+		flags.Changed("copy-by-chunk")
+}
+
+// applyReplicationUpdateFlags overlays only the explicitly provided flags onto createView.
+func applyReplicationUpdateFlags(cmd *cobra.Command, createView *create.CreateView, opts updateOpts) error {
+	flags := cmd.Flags()
+
+	if flags.Changed("name") {
+		if strings.TrimSpace(opts.Name) == "" {
+			return fmt.Errorf("--name cannot be empty")
+		}
+		createView.Name = strings.TrimSpace(opts.Name)
+	}
+
+	if flags.Changed("description") {
+		createView.Description = opts.Description
+	}
+
+	if flags.Changed("resource-filter") {
+		createView.ResourceFilter = opts.ResourceFilter
+	}
+
+	if flags.Changed("name-filter") {
+		createView.NameFilter = opts.NameFilter
+	}
+
+	if flags.Changed("tag-filter") {
+		v := strings.ToLower(strings.TrimSpace(opts.TagFilter))
+		if v != "matches" && v != "excludes" {
+			return fmt.Errorf("--tag-filter must be 'matches' or 'excludes', got %q", opts.TagFilter)
+		}
+		createView.TagFilter = v
+	}
+
+	if flags.Changed("tag-pattern") {
+		createView.TagPattern = opts.TagPattern
+	}
+
+	if flags.Changed("label-filter") {
+		v := strings.ToLower(strings.TrimSpace(opts.LabelFilter))
+		if v != "matches" && v != "excludes" {
+			return fmt.Errorf("--label-filter must be 'matches' or 'excludes', got %q", opts.LabelFilter)
+		}
+		createView.LabelFilter = v
+	}
+
+	if flags.Changed("label-pattern") {
+		createView.LabelPattern = opts.LabelPattern
+	}
+
+	if flags.Changed("trigger-type") {
+		v := strings.ToLower(strings.TrimSpace(opts.TriggerType))
+		if v != "manual" && v != "scheduled" && v != "event_based" {
+			return fmt.Errorf("--trigger-type must be 'manual', 'scheduled', or 'event_based', got %q", opts.TriggerType)
+		}
+		createView.TriggerType = v
+	}
+
+	if flags.Changed("cron") {
+		createView.CronString = opts.CronString
+	}
+
+	// Validate cron dependency: required when trigger-type is scheduled.
+	if createView.TriggerType == "scheduled" && createView.CronString == "" {
+		return fmt.Errorf("--cron is required when --trigger-type=scheduled")
+	}
+
+	if flags.Changed("speed") {
+		speedVal, err := strconv.ParseInt(opts.Speed, 10, 32)
+		if err != nil || speedVal < -1 {
+			return fmt.Errorf("--speed must be a valid integer >= -1 (use -1 for unlimited), got %q", opts.Speed)
+		}
+		createView.Speed = opts.Speed
+	}
+
+	if flags.Changed("enabled") {
+		createView.Enabled = opts.Enabled
+	}
+
+	if flags.Changed("override") {
+		createView.Override = opts.Override
+	}
+
+	if flags.Changed("replicate-deletion") {
+		createView.ReplicateDeletion = opts.ReplicateDeletion
+	}
+
+	if flags.Changed("copy-by-chunk") {
+		createView.CopyByChunk = opts.CopyByChunk
+	}
+
+	return nil
 }

--- a/cmd/harbor/root/replication/policies/update.go
+++ b/cmd/harbor/root/replication/policies/update.go
@@ -199,7 +199,7 @@ When update flags are provided, the command runs non-interactively and updates o
 	flags.StringVar(&opts.TriggerType, "trigger-type", "", "Trigger type: manual, scheduled, or event_based")
 	flags.StringVar(&opts.CronString, "cron", "", "Cron schedule (6-field format, required when --trigger-type=scheduled, e.g. \"0 0 */6 * * *\")")
 	flags.StringVar(&opts.Speed, "speed", "", "Maximum replication speed in KB/s (-1 for unlimited)")
-	flags.BoolVar(&opts.Enabled, "enabled", false, "Enable the replication policy")
+	flags.BoolVar(&opts.Enabled, "enabled", false, "Whether the replication policy is enabled or not")
 	flags.BoolVar(&opts.Override, "override", false, "Override artifacts on destination if they already exist")
 	flags.BoolVar(&opts.ReplicateDeletion, "replicate-deletion", false, "Replicate deletion operations to the destination")
 	flags.BoolVar(&opts.CopyByChunk, "copy-by-chunk", false, "Transfer artifacts in chunks for better reliability")
@@ -243,7 +243,20 @@ func applyReplicationUpdateFlags(cmd *cobra.Command, createView *create.CreateVi
 	}
 
 	if flags.Changed("resource-filter") {
-		createView.ResourceFilter = opts.ResourceFilter
+		v := strings.ToLower(strings.TrimSpace(opts.ResourceFilter))
+		switch createView.ReplicationMode {
+		case "Pull":
+			if v != "image" {
+				return fmt.Errorf("--resource-filter must be 'image' for Pull mode, got %q", opts.ResourceFilter)
+			}
+		case "Push":
+			if v != "" && v != "image" && v != "artifact" {
+				return fmt.Errorf("--resource-filter must be '', 'image', or 'artifact' for Push mode, got %q", opts.ResourceFilter)
+			}
+		default:
+			return fmt.Errorf("unknown replication mode %q", createView.ReplicationMode)
+		}
+		createView.ResourceFilter = v
 	}
 
 	if flags.Changed("name-filter") {
@@ -283,12 +296,23 @@ func applyReplicationUpdateFlags(cmd *cobra.Command, createView *create.CreateVi
 	}
 
 	if flags.Changed("cron") {
-		createView.CronString = opts.CronString
+		createView.CronString = strings.TrimSpace(opts.CronString)
+		if createView.TriggerType != "scheduled" {
+			return fmt.Errorf("--cron can only be used when --trigger-type=scheduled (current trigger-type: %s)", createView.TriggerType)
+		}
 	}
 
-	// Validate cron dependency: required when trigger-type is scheduled.
-	if createView.TriggerType == "scheduled" && createView.CronString == "" {
-		return fmt.Errorf("--cron is required when --trigger-type=scheduled")
+	// Validate cron dependency/format for scheduled triggers.
+	if createView.TriggerType == "scheduled" {
+		if createView.CronString == "" {
+			return fmt.Errorf("--cron is required when --trigger-type=scheduled")
+		}
+		if flags.Changed("cron") || flags.Changed("trigger-type") {
+			fields := strings.Fields(createView.CronString)
+			if len(fields) != 6 {
+				return fmt.Errorf("--cron must have exactly 6 fields (found %d): seconds minutes hours day-month month day-week", len(fields))
+			}
+		}
 	}
 
 	if flags.Changed("speed") {

--- a/cmd/harbor/root/replication/policies/update.go
+++ b/cmd/harbor/root/replication/policies/update.go
@@ -165,7 +165,7 @@ For interactive mode, omit all flags and the command will guide you through the 
 			log.Debugf("Updating replication policy: %s (ID: %d)", existingPolicy.Payload.Name, policyID)
 
 			// Branch: non-interactive if any update flag was explicitly provided.
-			if hasReplicationUpdateFlagChanges(cmd) {
+			if isNonInteractiveMode {
 				if err := applyReplicationUpdateFlags(cmd, createView, opts); err != nil {
 					return err
 				}
@@ -196,13 +196,13 @@ For interactive mode, omit all flags and the command will guide you through the 
 	flags := cmd.Flags()
 	flags.StringVar(&opts.Name, "name", "", "New name for the replication policy")
 	flags.StringVar(&opts.Description, "description", "", "New description for the replication policy")
-	flags.StringVar(&opts.ResourceFilter, "resource-filter", "", "Resource type filter: image, artifact, or empty for all")
+	flags.StringVar(&opts.ResourceFilter, "resource-filter", "", "Resource type filter: Pull supports 'image' only; Push supports '', 'image', or 'artifact'")
 	flags.StringVar(&opts.NameFilter, "name-filter", "", "Repository name filter pattern (supports wildcards, e.g. library/*)")
 	flags.StringVar(&opts.TagFilter, "tag-filter", "", "Tag filter type: matches or excludes")
 	flags.StringVar(&opts.TagPattern, "tag-pattern", "", "Tag filter pattern (e.g. v*, latest, *-prod)")
 	flags.StringVar(&opts.LabelFilter, "label-filter", "", "Label filter type: matches or excludes")
 	flags.StringVar(&opts.LabelPattern, "label-pattern", "", "Label filter pattern (e.g. env=prod or env=prod,ver=1.0)")
-	flags.StringVar(&opts.TriggerType, "trigger-type", "", "Trigger type: manual, scheduled, or event_based")
+	flags.StringVar(&opts.TriggerType, "trigger-type", "", "Trigger type: manual, scheduled, or event_based (event_based is Push-only)")
 	flags.StringVar(&opts.CronString, "cron", "", "Cron schedule (6-field format, required when --trigger-type=scheduled, e.g. \"0 0 */6 * * *\")")
 	flags.StringVar(&opts.Speed, "speed", "", "Maximum replication speed in KB/s (-1 for unlimited)")
 	flags.BoolVar(&opts.Enabled, "enabled", false, "Whether the replication policy is enabled or not")
@@ -297,6 +297,9 @@ func applyReplicationUpdateFlags(cmd *cobra.Command, createView *create.CreateVi
 		v := strings.ToLower(strings.TrimSpace(opts.TriggerType))
 		if v != "manual" && v != "scheduled" && v != "event_based" {
 			return fmt.Errorf("--trigger-type must be 'manual', 'scheduled', or 'event_based', got %q", opts.TriggerType)
+		}
+		if v == "event_based" && createView.ReplicationMode == "Pull" {
+			return fmt.Errorf("--trigger-type=event_based is only supported for Push replication policies")
 		}
 		createView.TriggerType = v
 	}

--- a/cmd/harbor/root/replication/policies/update.go
+++ b/cmd/harbor/root/replication/policies/update.go
@@ -84,7 +84,7 @@ explicitly provided flags (partial update).`,
   harbor replication policies update 1 \
     --trigger-type scheduled \
     --cron "0 0 */6 * * *"`,
-		Args:    cobra.MaximumNArgs(1),
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			isNonInteractiveMode := hasReplicationUpdateFlagChanges(cmd)
 			var policyID int64

--- a/cmd/harbor/root/replication/policies/update.go
+++ b/cmd/harbor/root/replication/policies/update.go
@@ -54,9 +54,36 @@ func UpdateCommand() *cobra.Command {
 		Short: "Update an existing replication policy",
 		Long: `Update an existing replication policy.
 
-When update flags are provided, the command runs non-interactively and updates only the specified fields while preserving all other values. Policy ID is required when update flags are used.
-For interactive mode, omit all flags and the command will guide you through the update process.`,
-		Example: `harbor replication policies update 1 --name production-sync --enabled=true`,
+When called without any update flags, the command opens the interactive TUI wizard
+(existing behavior preserved). When any update flag is provided, the command runs
+non-interactively — loading the existing policy as the baseline and applying only the
+explicitly provided flags (partial update).`,
+		Example: `  # Interactive (existing behavior — opens TUI wizard)
+  harbor replication policies update 1
+
+  # Change only the name
+  harbor replication policies update 1 --name production-sync
+
+  # Enable the policy
+  harbor replication policies update 1 --enabled=true
+
+  # Update multiple fields at once
+  harbor replication policies update 1 \
+    --name production-sync \
+    --description "Production replication" \
+    --enabled=true \
+    --override=true
+
+  # Update resource/name/tag filters
+  harbor replication policies update 1 \
+    --name-filter "library/*" \
+    --tag-filter matches \
+    --tag-pattern "v*"
+
+  # Switch to a scheduled trigger
+  harbor replication policies update 1 \
+    --trigger-type scheduled \
+    --cron "0 0 */6 * * *"`,
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			isNonInteractiveMode := hasReplicationUpdateFlagChanges(cmd)

--- a/doc/cli-docs/harbor-replication-policies-update.md
+++ b/doc/cli-docs/harbor-replication-policies-update.md
@@ -8,14 +8,65 @@ weight: 5
 
 ##### Update an existing replication policy
 
+When called without any update flags, the command opens the interactive TUI wizard
+(existing behavior preserved). When any update flag is provided, the command runs
+non-interactively — loading the existing policy as the baseline and applying only the
+explicitly provided flags (partial update).
+
 ```sh
 harbor replication policies update [policy-id] [flags]
+```
+
+### Examples
+
+```sh
+  # Interactive (existing behavior — opens TUI wizard)
+  harbor replication policies update 1
+
+  # Change only the name
+  harbor replication policies update 1 --name production-sync
+
+  # Enable the policy
+  harbor replication policies update 1 --enabled=true
+
+  # Update multiple fields at once
+  harbor replication policies update 1 \
+    --name production-sync \
+    --description "Production replication" \
+    --enabled=true \
+    --override=true
+
+  # Update resource/name/tag filters
+  harbor replication policies update 1 \
+    --name-filter "library/" \
+    --tag-filter matches \
+    --tag-pattern "v*"
+
+  # Switch to a scheduled trigger
+  harbor replication policies update 1 \
+    --trigger-type scheduled \
+    --cron "0 0 */6 * * *"
 ```
 
 ### Options
 
 ```sh
-  -h, --help   help for update
+      --copy-by-chunk            Transfer artifacts in chunks for better reliability
+      --cron string              Cron schedule (6-field format, required when --trigger-type=scheduled, e.g. "0 0 */6 * * *")
+      --description string       New description for the replication policy
+      --enabled                  Enable the replication policy
+  -h, --help                     help for update
+      --label-filter string      Label filter type: matches or excludes
+      --label-pattern string     Label filter pattern (e.g. env=prod or env=prod,ver=1.0)
+      --name string              New name for the replication policy
+      --name-filter string       Repository name filter pattern (supports wildcards, e.g. library/*)
+      --override                 Override artifacts on destination if they already exist
+      --replicate-deletion       Replicate deletion operations to the destination
+      --resource-filter string   Resource type filter: image, artifact, or empty for all
+      --speed string             Maximum replication speed in KB/s (-1 for unlimited)
+      --tag-filter string        Tag filter type: matches or excludes
+      --tag-pattern string       Tag filter pattern (e.g. v*, latest, *-prod)
+      --trigger-type string      Trigger type: manual, scheduled, or event_based
 ```
 
 ### Options inherited from parent commands

--- a/doc/cli-docs/harbor-replication-policies-update.md
+++ b/doc/cli-docs/harbor-replication-policies-update.md
@@ -54,7 +54,7 @@ harbor replication policies update [policy-id] [flags]
       --copy-by-chunk            Transfer artifacts in chunks for better reliability
       --cron string              Cron schedule (6-field format, required when --trigger-type=scheduled, e.g. "0 0 */6 * * *")
       --description string       New description for the replication policy
-      --enabled                  Enable the replication policy
+      --enabled                  Whether the replication policy is enabled or not
   -h, --help                     help for update
       --label-filter string      Label filter type: matches or excludes
       --label-pattern string     Label filter pattern (e.g. env=prod or env=prod,ver=1.0)

--- a/doc/cli-docs/harbor-replication-policies-update.md
+++ b/doc/cli-docs/harbor-replication-policies-update.md
@@ -8,6 +8,10 @@ weight: 5
 
 ##### Update an existing replication policy
 
+### Synopsis
+
+Update an existing replication policy.
+
 When called without any update flags, the command opens the interactive TUI wizard
 (existing behavior preserved). When any update flag is provided, the command runs
 non-interactively — loading the existing policy as the baseline and applying only the

--- a/doc/cli-docs/harbor-replication-policies-update.md
+++ b/doc/cli-docs/harbor-replication-policies-update.md
@@ -38,7 +38,7 @@ harbor replication policies update [policy-id] [flags]
 
   # Update resource/name/tag filters
   harbor replication policies update 1 \
-    --name-filter "library/" \
+    --name-filter "library/*" \
     --tag-filter matches \
     --tag-pattern "v*"
 
@@ -62,11 +62,11 @@ harbor replication policies update [policy-id] [flags]
       --name-filter string       Repository name filter pattern (supports wildcards, e.g. library/*)
       --override                 Override artifacts on destination if they already exist
       --replicate-deletion       Replicate deletion operations to the destination
-      --resource-filter string   Resource type filter: image, artifact, or empty for all
+      --resource-filter string   Resource type filter: Pull supports 'image' only; Push supports '', 'image', or 'artifact'
       --speed string             Maximum replication speed in KB/s (-1 for unlimited)
       --tag-filter string        Tag filter type: matches or excludes
       --tag-pattern string       Tag filter pattern (e.g. v*, latest, *-prod)
-      --trigger-type string      Trigger type: manual, scheduled, or event_based
+      --trigger-type string      Trigger type: manual, scheduled, or event_based (event_based is Push-only)
 ```
 
 ### Options inherited from parent commands

--- a/doc/man-docs/man1/harbor-replication-policies-update.1
+++ b/doc/man-docs/man1/harbor-replication-policies-update.1
@@ -32,7 +32,7 @@ explicitly provided flags (partial update).
 
 .PP
 \fB--enabled\fP[=false]
-	Enable the replication policy
+	Whether the replication policy is enabled or not
 
 .PP
 \fB-h\fP, \fB--help\fP[=false]

--- a/doc/man-docs/man1/harbor-replication-policies-update.1
+++ b/doc/man-docs/man1/harbor-replication-policies-update.1
@@ -10,12 +10,77 @@ harbor-replication-policies-update - Update an existing replication policy
 
 
 .SH DESCRIPTION
-Update an existing replication policy
+Update an existing replication policy.
+
+When called without any update flags, the command opens the interactive TUI wizard
+(existing behavior preserved). When any update flag is provided, the command runs
+non-interactively: it loads the existing policy as the baseline and applies only the
+explicitly provided flags (partial update).
 
 
 .SH OPTIONS
+\fB--copy-by-chunk\fP[=false]
+	Transfer artifacts in chunks for better reliability
+
+.PP
+\fB--cron\fP=""
+	Cron schedule (6-field format, required when --trigger-type=scheduled, e.g. "0 0 */6 * * *")
+
+.PP
+\fB--description\fP=""
+	New description for the replication policy
+
+.PP
+\fB--enabled\fP[=false]
+	Enable the replication policy
+
+.PP
 \fB-h\fP, \fB--help\fP[=false]
 	help for update
+
+.PP
+\fB--label-filter\fP=""
+	Label filter type: matches or excludes
+
+.PP
+\fB--label-pattern\fP=""
+	Label filter pattern (e.g. env=prod or env=prod,ver=1.0)
+
+.PP
+\fB--name\fP=""
+	New name for the replication policy
+
+.PP
+\fB--name-filter\fP=""
+	Repository name filter pattern (supports wildcards, e.g. library/*)
+
+.PP
+\fB--override\fP[=false]
+	Override artifacts on destination if they already exist
+
+.PP
+\fB--replicate-deletion\fP[=false]
+	Replicate deletion operations to the destination
+
+.PP
+\fB--resource-filter\fP=""
+	Resource type filter: image, artifact, or empty for all
+
+.PP
+\fB--speed\fP=""
+	Maximum replication speed in KB/s (-1 for unlimited)
+
+.PP
+\fB--tag-filter\fP=""
+	Tag filter type: matches or excludes
+
+.PP
+\fB--tag-pattern\fP=""
+	Tag filter pattern (e.g. v*, latest, *-prod)
+
+.PP
+\fB--trigger-type\fP=""
+	Trigger type: manual, scheduled, or event_based
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS

--- a/doc/man-docs/man1/harbor-replication-policies-update.1
+++ b/doc/man-docs/man1/harbor-replication-policies-update.1
@@ -64,7 +64,7 @@ explicitly provided flags (partial update).
 
 .PP
 \fB--resource-filter\fP=""
-	Resource type filter: image, artifact, or empty for all
+	Resource type filter: Pull supports 'image' only; Push supports '', 'image', or 'artifact'
 
 .PP
 \fB--speed\fP=""
@@ -80,7 +80,7 @@ explicitly provided flags (partial update).
 
 .PP
 \fB--trigger-type\fP=""
-	Trigger type: manual, scheduled, or event_based
+	Trigger type: manual, scheduled, or event_based (event_based is Push-only)
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS

--- a/doc/man-docs/man1/harbor-replication-policies-update.1
+++ b/doc/man-docs/man1/harbor-replication-policies-update.1
@@ -12,9 +12,10 @@ harbor-replication-policies-update - Update an existing replication policy
 .SH DESCRIPTION
 Update an existing replication policy.
 
+.PP
 When called without any update flags, the command opens the interactive TUI wizard
 (existing behavior preserved). When any update flag is provided, the command runs
-non-interactively: it loads the existing policy as the baseline and applies only the
+non-interactively — loading the existing policy as the baseline and applying only the
 explicitly provided flags (partial update).
 
 
@@ -94,6 +95,37 @@ explicitly provided flags (partial update).
 .PP
 \fB-v\fP, \fB--verbose\fP[=false]
 	verbose output
+
+
+.SH EXAMPLE
+.EX
+  # Interactive (existing behavior — opens TUI wizard)
+  harbor replication policies update 1
+
+  # Change only the name
+  harbor replication policies update 1 --name production-sync
+
+  # Enable the policy
+  harbor replication policies update 1 --enabled=true
+
+  # Update multiple fields at once
+  harbor replication policies update 1 \\
+    --name production-sync \\
+    --description "Production replication" \\
+    --enabled=true \\
+    --override=true
+
+  # Update resource/name/tag filters
+  harbor replication policies update 1 \\
+    --name-filter "library/*" \\
+    --tag-filter matches \\
+    --tag-pattern "v*"
+
+  # Switch to a scheduled trigger
+  harbor replication policies update 1 \\
+    --trigger-type scheduled \\
+    --cron "0 0 */6 * * *"
+.EE
 
 
 .SH SEE ALSO


### PR DESCRIPTION
## Description
Adds support for non-interactive replication policy updates through CLI flags.

- Fixes #971 
- [x] New feature

Changes

* Added update flags for replication policy fields.
* Added non-interactive update support with partial-update behavior.
* Preserved existing interactive TUI workflow when no flags are provided.
* Populated existing filter values before applying updates.
* Added validation for update-specific flag combinations (for example scheduled triggers requiring a cron expression).
* Updated CLI and man-page documentation.

Testing

Verified the following scenarios:

* Interactive update flow remains unchanged.
* Update policy name using --name.
* Update description using --description.
* Update boolean fields such as --enabled, --override, and --copy-by-chunk.
* Update trigger configuration using --trigger-type and --cron.
* Confirmed unspecified fields remain unchanged after partial updates.
<img width="1022" height="465" alt="Screenshot 2026-06-01 at 2 30 46 AM" src="https://github.com/user-attachments/assets/d29df03e-017e-44ef-b83a-fd3de6f12410" />
