### PR TITLE
fix(webhook): handle empty targets in webhook list view

### DIFF
--- a/pkg/views/webhook/list/view.go
+++ b/pkg/views/webhook/list/view.go
@@ -44,17 +44,14 @@ func ListWebhooks(webhooks []*models.WebhookPolicy) {
 		} else {
 			webhookEnabled = "False"
 		}
-		payloadFormat := "--"
-		if len(webhook.Targets[0].PayloadFormat) != 0 {
-			payloadFormat = string(webhook.Targets[0].PayloadFormat)
-		}
+		endpointURL, notifyType, payloadFormat := webhookTargetDetails(webhook)
 		creationTime, _ := utils.FormatCreatedTime(webhook.CreationTime.String())
 		rows = append(rows, table.Row{
 			strconv.FormatInt(webhook.ID, 10),
 			webhook.Name,
 			webhookEnabled,
-			webhook.Targets[0].Address,
-			webhook.Targets[0].Type,
+			endpointURL,
+			notifyType,
 			payloadFormat,
 			creationTime,
 		})
@@ -65,4 +62,28 @@ func ListWebhooks(webhooks []*models.WebhookPolicy) {
 		fmt.Println("Error running program:", err)
 		os.Exit(1)
 	}
+}
+
+func webhookTargetDetails(webhook *models.WebhookPolicy) (string, string, string) {
+	if len(webhook.Targets) == 0 || webhook.Targets[0] == nil {
+		return "--", "--", "--"
+	}
+
+	target := webhook.Targets[0]
+	payloadFormat := "--"
+	if len(target.PayloadFormat) != 0 {
+		payloadFormat = string(target.PayloadFormat)
+	}
+
+	endpointURL := target.Address
+	if endpointURL == "" {
+		endpointURL = "--"
+	}
+
+	notifyType := target.Type
+	if notifyType == "" {
+		notifyType = "--"
+	}
+
+	return endpointURL, notifyType, payloadFormat
 }

--- a/pkg/views/webhook/list/view_test.go
+++ b/pkg/views/webhook/list/view_test.go
@@ -1,0 +1,49 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package list
+
+import (
+	"testing"
+
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWebhookTargetDetailsWithoutTargets(t *testing.T) {
+	webhook := &models.WebhookPolicy{}
+
+	endpointURL, notifyType, payloadFormat := webhookTargetDetails(webhook)
+
+	assert.Equal(t, "--", endpointURL)
+	assert.Equal(t, "--", notifyType)
+	assert.Equal(t, "--", payloadFormat)
+}
+
+func TestWebhookTargetDetailsWithTarget(t *testing.T) {
+	webhook := &models.WebhookPolicy{
+		Targets: []*models.WebhookTargetObject{
+			{
+				Address:       "https://example.com/hook",
+				Type:          "http",
+				PayloadFormat: "Default",
+			},
+		},
+	}
+
+	endpointURL, notifyType, payloadFormat := webhookTargetDetails(webhook)
+
+	assert.Equal(t, "https://example.com/hook", endpointURL)
+	assert.Equal(t, "http", notifyType)
+	assert.Equal(t, "Default", payloadFormat)
+}


### PR DESCRIPTION
## Description
Fix webhook list panic when a policy comes back with empty `targets`.
Pretty small fix, but it can blow up on real API data. `WebhookPolicy` treats `targets` as optional, and `webhook edit` already guards this shape.

- Fixes #973

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
- guard webhook target access in the list view
- show placeholders when target details are missing
- add a regression test for empty and populated targets

## Repro
1. Make Harbor return a webhook policy with `targets: []`
2. Run `harbor webhook list <project>`
3. Before this patch it panics with index out of range, after this patch it renders fine
