### PR TITLE
fix: Skip Permission Mode selector when robot create has sufficient CLI flags

### DIFF
--- a/cmd/harbor/root/robot/create.go
+++ b/cmd/harbor/root/robot/create.go
@@ -181,7 +181,7 @@ func handleInteractiveInput(opts *create.CreateView, all bool, permissions *[]mo
 	}
 
 	// Get project permissions
-	return getProjectPermissions(opts, projectPermissionsMap)
+	return getProjectPermissions(opts, projectPermissionsMap, all)
 }
 
 func getSystemPermissions(all bool, permissions *[]models.Permission) error {
@@ -209,7 +209,34 @@ func getSystemPermissions(all bool, permissions *[]models.Permission) error {
 	return nil
 }
 
-func getProjectPermissions(opts *create.CreateView, projectPermissionsMap map[string][]models.Permission) error {
+func getProjectPermissions(opts *create.CreateView, projectPermissionsMap map[string][]models.Permission, all bool) error {
+	if opts.ProjectName != "" {
+		if all {
+			perms, err := api.GetPermissions()
+			if err != nil {
+				return fmt.Errorf("failed to get project permissions: %v", utils.ParseHarborErrorMsg(err))
+			}
+			var choices []models.Permission
+			for _, perm := range perms.Payload.Project {
+				choices = append(choices, *perm)
+			}
+			projectPermissionsMap[opts.ProjectName] = choices
+			return nil
+		} else {
+			projectPermissions, err := prompt.GetRobotPermissionsFromUser("project")
+			if err != nil {
+				return fmt.Errorf("failed to get permissions: %v", utils.ParseHarborErrorMsg(err))
+			}
+			projectPermissionsMap[opts.ProjectName] = projectPermissions
+			return nil
+		}
+	}
+
+	if all {
+		// If --all-permission is set, but no project is specified, we assume only system-level permissions
+		return nil
+	}
+
 	permissionMode, err := promptPermissionMode()
 	if err != nil {
 		return fmt.Errorf("error selecting permission mode: %v", err)


### PR DESCRIPTION
fixes #979
## Summary

This PR fixes a bug where harbor robot create still opened the interactive Permission Mode selector even when sufficient CLI flags were provided for a non-interactive workflow.

- [x] Bug fix

## Changes

* Updated getProjectPermissions() to accept the all flag.
* Added a non-interactive path when --project is provided:
    * If --all-permission is set, automatically assign all project permissions and skip all permission prompts.
    * If --all-permission is not set, skip the Permission Mode selector and go directly to project permission selection.
* Added handling for system-level robots created with --all-permission.
* Preserved the existing interactive workflow when required flags are not provided.




## Before:



https://github.com/user-attachments/assets/073bdf28-7cea-4d1f-8f40-909d749acd3b

## After:


https://github.com/user-attachments/assets/ac20b45f-8506-479f-845c-f2db827caffb

