### PR TITLE
fix: set XIsResourceName for immutable rule API calls during force project delete

### DIFF
--- a/pkg/api/immutable_handler.go
+++ b/pkg/api/immutable_handler.go
@@ -56,7 +56,8 @@ func ListImmutable(projectName string) (immutable.ListImmuRulesOK, error) {
 	if err != nil {
 		return immutable.ListImmuRulesOK{}, err
 	}
-	response, err := client.Immutable.ListImmuRules(ctx, &immutable.ListImmuRulesParams{ProjectNameOrID: projectName})
+	XIsResourceName := true
+	response, err := client.Immutable.ListImmuRules(ctx, &immutable.ListImmuRulesParams{ProjectNameOrID: projectName, XIsResourceName: &XIsResourceName})
 	if err != nil {
 		return immutable.ListImmuRulesOK{}, err
 	}
@@ -69,7 +70,8 @@ func DeleteImmutable(projectName string, ImmutableID int64) error {
 	if err != nil {
 		return err
 	}
-	_, err = client.Immutable.DeleteImmuRule(ctx, &immutable.DeleteImmuRuleParams{ProjectNameOrID: projectName, ImmutableRuleID: ImmutableID})
+	XIsResourceName := true
+	_, err = client.Immutable.DeleteImmuRule(ctx, &immutable.DeleteImmuRuleParams{ProjectNameOrID: projectName, ImmutableRuleID: ImmutableID, XIsResourceName: &XIsResourceName})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #981
When deleting a project with a numeric name using force, the immutable rule APIs were not telling Harbor to treat the value as a project name. Harbor interpreted it as an ID instead, so the CLI failed to find and remove the immutable rules. This caused repository deletion to fail with an HTTP 412 error and blocked the entire project deletion.

The fix sets XIsResourceName true on ListImmutable and DeleteImmutable API calls so Harbor correctly resolves the value as a project name, allowing projects with numeric names to be force deleted successfully.

## BEFORE: 

https://github.com/user-attachments/assets/9bee0c7f-e178-4b3b-9fff-122bb7ea7e25




## AFTER:

https://github.com/user-attachments/assets/97754054-aa22-4c47-9125-95209db99bd1


