### PR TITLE
fix(doc): resolve file descriptor leaks in documentation generators

### DIFF
--- a/doc/doc.go
+++ b/doc/doc.go
@@ -194,10 +194,10 @@ func MarkdownTreeCustom(cmd *cobra.Command, dir string, filePrepender, linkHandl
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 	if _, err := io.WriteString(f, preblock); err != nil {
 		return err
 	}
-	defer f.Close()
 	if err := MarkdownCustom(cmd, f, linkHandler); err != nil {
 		return err
 	}

--- a/doc/man-docs/man_doc.go
+++ b/doc/man-docs/man_doc.go
@@ -79,12 +79,14 @@ func cleanManPages(docDir string) error {
 			if err != nil {
 				return err
 			}
-			f, err := root.Open(relPath)
-			if err != nil {
-				return err
-			}
-			content, err := io.ReadAll(f)
-			f.Close()
+			content, err := func() ([]byte, error) {
+				f, err := root.Open(relPath)
+				if err != nil {
+					return nil, err
+				}
+				defer f.Close()
+				return io.ReadAll(f)
+			}()
 			if err != nil {
 				return err
 			}
@@ -110,8 +112,8 @@ func cleanManPages(docDir string) error {
 			if err != nil {
 				return err
 			}
+			defer wf.Close()
 			_, err = wf.Write([]byte(cleanedContent))
-			wf.Close()
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Description
This PR fixes a subtle file descriptor leak vulnerability within the CLI documentation generator logic (`doc/doc.go` and `doc/man-docs/man_doc.go`). 

Previously, `defer f.Close()` was placed *after* write operations (like `io.WriteString`), or handled manually in a way that missed early `err != nil` return paths. If an I/O operation failed mid-way, the function exited prematurely, leaving the file descriptor open and causing potential resource exhaustion.

### Changes Made
* **doc/doc.go**: Moved `defer f.Close()` to execute immediately after checking `os.Create` errors, guaranteeing closure on subsequent write failures.
* **doc/man-docs/man_doc.go**: Replaced manual/conditional closing logic with immediate `defer` calls for robust resource management.

## Verification Results
I have verified these changes locally:
* `go build ./...` completes successfully.
* `go test ./...` passes without regressions.

## Closes
Closes #991

### Screenshots of Tests

<img width="1022" height="630" alt="image" src="https://github.com/user-attachments/assets/8d3a7b3f-b8cd-4769-be44-1b57ea3764e7" />

also I ran general go test ./... for man_doc.go as there are no dedicated test for it 