### PR TITLE
fix(config): handle directory paths for --config and HARBOR_CLI_CONFIG

### DIFF
--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -79,14 +79,14 @@ func InitConfig(cfgFile string, userSpecifiedConfig bool) {
 			log.Fatalf("%v", configInitError)
 		}
 
-		// Update or create data file
-		if err := ApplyDataFile(harborDataPath, harborConfigPath); err != nil {
+		// Ensure config file exists before persisting the path to data.yaml
+		if err := EnsureConfigFileExists(harborConfigPath); err != nil {
 			configInitError = err
 			log.Fatalf("%v", err)
 		}
 
-		// Ensure config file exists
-		if err := EnsureConfigFileExists(harborConfigPath); err != nil {
+		// Update or create data file
+		if err := ApplyDataFile(harborDataPath, harborConfigPath); err != nil {
 			configInitError = err
 			log.Fatalf("%v", err)
 		}
@@ -126,6 +126,21 @@ func GetDataPaths() (harborDataPath string, harborDataDir string) {
 	return
 }
 
+// normalizeConfigPath resolves an absolute config file path. If the given path
+// is an existing directory, it appends config.yaml to match the default layout.
+func normalizeConfigPath(path string) (string, error) {
+	harborConfigPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve absolute path for config file: %w", err)
+	}
+
+	if fileInfo, err := os.Stat(harborConfigPath); err == nil && fileInfo.IsDir() {
+		harborConfigPath = filepath.Join(harborConfigPath, "config.yaml")
+	}
+
+	return harborConfigPath, nil
+}
+
 // Helper function to determine the config path
 func DetermineConfigPath(cfgFile string, userSpecifiedConfig bool) (string, error) {
 	var harborConfigPath string
@@ -133,20 +148,12 @@ func DetermineConfigPath(cfgFile string, userSpecifiedConfig bool) (string, erro
 
 	// 1. Check if user specified --config
 	if userSpecifiedConfig && cfgFile != "" {
-		harborConfigPath, err = filepath.Abs(cfgFile)
-		if err != nil {
-			return "", fmt.Errorf("failed to resolve absolute path for config file: %w", err)
-		}
-		return harborConfigPath, nil
+		return normalizeConfigPath(cfgFile)
 	}
 	// 2. Check HARBOR_CLI_CONFIG environment variable
 	harborEnvVar := os.Getenv("HARBOR_CLI_CONFIG")
 	if harborEnvVar != "" {
-		harborConfigPath, err = filepath.Abs(harborEnvVar)
-		if err != nil {
-			return "", fmt.Errorf("failed to resolve absolute path for config file from HARBOR_CLI_CONFIG: %w", err)
-		}
-		return harborConfigPath, nil
+		return normalizeConfigPath(harborEnvVar)
 	}
 
 	// 3. Use default XDG config path

--- a/pkg/utils/config_test.go
+++ b/pkg/utils/config_test.go
@@ -14,6 +14,7 @@
 package utils_test
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -106,4 +107,41 @@ func Test_Config_Flag(t *testing.T) {
 	assert.NotNil(t, currentConfig.CurrentCredentialName, "CurrentCredentialName should not be nil")
 	assert.NotNil(t, currentConfig.Credentials, "Credentials should not be nil")
 	assert.NotNil(t, data.ConfigPath, "ConfigPath should not be nil")
+}
+
+func Test_Config_EnvVar_Directory(t *testing.T) {
+	utils.ConfigInitialization.Reset()
+	helpers.SetMockKeyring(t)
+	tempDir := t.TempDir()
+	configDir := filepath.Join(tempDir, "harbor-cli")
+	assert.NoError(t, os.MkdirAll(configDir, os.ModePerm))
+
+	helpers.SafeSetEnv("HARBOR_CLI_CONFIG", configDir)
+	helpers.SafeSetEnv("XDG_DATA_HOME", filepath.Join(tempDir, ".data"))
+	utils.InitConfig("", false)
+
+	currentData, err := utils.GetCurrentHarborData()
+	assert.NoError(t, err)
+	defer helpers.ConfigCleanup(t, currentData)
+
+	expectedConfigPath := filepath.Join(configDir, "config.yaml")
+	assert.Equal(t, expectedConfigPath, currentData.ConfigPath)
+}
+
+func Test_Config_Flag_Directory(t *testing.T) {
+	utils.ConfigInitialization.Reset()
+	helpers.SetMockKeyring(t)
+	tempDir := t.TempDir()
+	configDir := filepath.Join(tempDir, "harbor-cli")
+	assert.NoError(t, os.MkdirAll(configDir, os.ModePerm))
+	helpers.SafeSetEnv("XDG_DATA_HOME", filepath.Join(tempDir, ".data"))
+
+	utils.InitConfig(configDir, true)
+
+	currentData, err := utils.GetCurrentHarborData()
+	assert.NoError(t, err)
+	defer helpers.ConfigCleanup(t, currentData)
+
+	expectedConfigPath := filepath.Join(configDir, "config.yaml")
+	assert.Equal(t, expectedConfigPath, currentData.ConfigPath)
 }


### PR DESCRIPTION
## Description
Briefly describe what this pull request does and why the change is needed.

- Fixes #993

When `--config` or `HARBOR_CLI_CONFIG` pointed to a directory (as documented in the README), Harbor CLI persisted that directory path into `data.yaml` before validating it was a file. This caused a fatal error on every subsequent run until `data.yaml` was manually repaired.

This PR resolves directory paths to `<dir>/config.yaml` and ensures the config file is validated before updating `data.yaml`.

## Type of Change
Please select the relevant type.

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
- Add `normalizeConfigPath` to resolve directory paths to `config.yaml` for `--config` and `HARBOR_CLI_CONFIG`
- Reorder `InitConfig` to call `EnsureConfigFileExists` before `ApplyDataFile`, preventing invalid paths from being persisted
- Add unit tests for directory-based config paths (`Test_Config_EnvVar_Directory`, `Test_Config_Flag_Directory`)

## Test plan
- [x] `go test ./pkg/utils/... -run Test_Config`
- [x] `harbor -c ~/.config/harbor-cli version` — exits 0, `data.yaml` stores file path
- [x] `HARBOR_CLI_CONFIG=$HOME/.config/harbor-cli harbor version` — exits 0
- [x] Subsequent `harbor version` runs work without manual `data.yaml` repair