### PR TITLE
fix(retention): prevent failures in tag retention rule deletion flow

### DIFF
--- a/cmd/harbor/root/tag/retention/delete.go
+++ b/cmd/harbor/root/tag/retention/delete.go
@@ -75,8 +75,11 @@ Examples:
 					return fmt.Errorf("error retrieving retention policy ID: %w", err)
 				}
 			}
-			retentionIndex := prompt.GetRetentionTagRule(retentionID)
-			err = api.DeleteRetention(projectName, int(retentionIndex))
+			retentionIndex, err := prompt.GetRetentionTagRule(retentionID)
+			if err != nil {
+				return err
+			}
+			err = api.DeleteRetention(retentionID, retentionIndex)
 			if err != nil {
 				return fmt.Errorf("%w", err)
 			}

--- a/cmd/harbor/root/tag/retention/delete.go
+++ b/cmd/harbor/root/tag/retention/delete.go
@@ -80,9 +80,10 @@ Examples:
 				return err
 			}
 			if retentionIndex < 0 {
+				fmt.Println("No retention rules found")
 				return nil
 			}
-			err = api.DeleteRetention(retentionID, retentionIndex)
+			err = api.DeleteRetention(retentionID, int(retentionIndex))
 			if err != nil {
 				return fmt.Errorf("%w", err)
 			}

--- a/cmd/harbor/root/tag/retention/delete.go
+++ b/cmd/harbor/root/tag/retention/delete.go
@@ -79,6 +79,9 @@ Examples:
 			if err != nil {
 				return err
 			}
+			if retentionIndex < 0 {
+				return nil
+			}
 			err = api.DeleteRetention(retentionID, retentionIndex)
 			if err != nil {
 				return fmt.Errorf("%w", err)

--- a/cmd/harbor/root/tag/retention/delete.go
+++ b/cmd/harbor/root/tag/retention/delete.go
@@ -80,15 +80,15 @@ Examples:
 					return fmt.Errorf("error retrieving retention policy ID: %w", err)
 				}
 			}
-			retentionIndex, err := getRetentionTagRule(retentionID)
+			retentionPolicy, retentionRuleID, err := getRetentionTagRule(retentionID)
 			if err != nil {
 				return err
 			}
-			if retentionIndex < 0 {
+			if retentionRuleID < 0 {
 				fmt.Println("No retention rules found")
 				return nil
 			}
-			err = deleteRetention(retentionID, int(retentionIndex))
+			err = deleteRetention(retentionPolicy, retentionRuleID)
 			if err != nil {
 				return fmt.Errorf("%w", err)
 			}

--- a/cmd/harbor/root/tag/retention/delete.go
+++ b/cmd/harbor/root/tag/retention/delete.go
@@ -22,6 +22,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var getProjectNameFromUser = prompt.GetProjectNameFromUser
+var getRetentionId = api.GetRetentionId
+var getRetentionTagRule = prompt.GetRetentionTagRule
+var deleteRetention = api.DeleteRetention
+
 func DeleteRetentionRuleCommand() *cobra.Command {
 	var projectName string
 	var projectID int
@@ -49,7 +54,7 @@ Examples:
 			}
 
 			if projectID == -1 && projectName == "" {
-				name, err := prompt.GetProjectNameFromUser()
+				name, err := getProjectNameFromUser()
 				if err != nil {
 					return err
 				}
@@ -66,7 +71,7 @@ Examples:
 				projectIDStr = projectName
 			}
 
-			retentionID, err := api.GetRetentionId(projectIDStr, isName)
+			retentionID, err := getRetentionId(projectIDStr, isName)
 			if err != nil {
 				if err.Error() == "No retention policy exists for this project" {
 					fmt.Println("No retention policy exists for this project")
@@ -75,7 +80,7 @@ Examples:
 					return fmt.Errorf("error retrieving retention policy ID: %w", err)
 				}
 			}
-			retentionIndex, err := prompt.GetRetentionTagRule(retentionID)
+			retentionIndex, err := getRetentionTagRule(retentionID)
 			if err != nil {
 				return err
 			}
@@ -83,7 +88,7 @@ Examples:
 				fmt.Println("No retention rules found")
 				return nil
 			}
-			err = api.DeleteRetention(retentionID, int(retentionIndex))
+			err = deleteRetention(retentionID, int(retentionIndex))
 			if err != nil {
 				return fmt.Errorf("%w", err)
 			}

--- a/cmd/harbor/root/tag/retention/delete_test.go
+++ b/cmd/harbor/root/tag/retention/delete_test.go
@@ -1,0 +1,28 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package retention
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeleteRetentionRuleCommand(t *testing.T) {
+	cmd := DeleteRetentionRuleCommand()
+
+	assert.Equal(t, "delete", cmd.Use)
+	assert.Equal(t, "Delete a tag retention rule for a project", cmd.Short)
+	assert.NotNil(t, cmd.RunE)
+}

--- a/cmd/harbor/root/tag/retention/delete_test.go
+++ b/cmd/harbor/root/tag/retention/delete_test.go
@@ -14,6 +14,8 @@
 package retention
 
 import (
+	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,4 +27,136 @@ func TestDeleteRetentionRuleCommand(t *testing.T) {
 	assert.Equal(t, "delete", cmd.Use)
 	assert.Equal(t, "Delete a tag retention rule for a project", cmd.Short)
 	assert.NotNil(t, cmd.RunE)
+}
+
+func TestDeleteRetentionRuleCommand_Errors(t *testing.T) {
+	// Backup and restore package-level variables
+	orgGetProjectName := getProjectNameFromUser
+	orgGetRetentionId := getRetentionId
+	orgGetRetentionTagRule := getRetentionTagRule
+	orgDeleteRetention := deleteRetention
+
+	t.Cleanup(func() {
+		getProjectNameFromUser = orgGetProjectName
+		getRetentionId = orgGetRetentionId
+		getRetentionTagRule = orgGetRetentionTagRule
+		deleteRetention = orgDeleteRetention
+	})
+
+	t.Run("No retention policy exists - success no-op", func(t *testing.T) {
+		getRetentionId = func(projectNameorID string, isName bool) (string, error) {
+			return "", errors.New("No retention policy exists for this project")
+		}
+
+		cmd := DeleteRetentionRuleCommand()
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetErr(&buf)
+		cmd.SetArgs([]string{"--project-name", "test-project"})
+
+		err := cmd.Execute()
+		assert.NoError(t, err)
+	})
+
+	t.Run("GetRetentionId error - returns error", func(t *testing.T) {
+		getRetentionId = func(projectNameorID string, isName bool) (string, error) {
+			return "", errors.New("some network error")
+		}
+
+		cmd := DeleteRetentionRuleCommand()
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetErr(&buf)
+		cmd.SetArgs([]string{"--project-name", "test-project"})
+
+		err := cmd.Execute()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "error retrieving retention policy ID: some network error")
+	})
+
+	t.Run("GetRetentionTagRule error - returns error", func(t *testing.T) {
+		getRetentionId = func(projectNameorID string, isName bool) (string, error) {
+			return "42", nil
+		}
+		getRetentionTagRule = func(retentionID string) (int64, error) {
+			return 0, errors.New("selection aborted")
+		}
+
+		cmd := DeleteRetentionRuleCommand()
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetErr(&buf)
+		cmd.SetArgs([]string{"--project-name", "test-project"})
+
+		err := cmd.Execute()
+		assert.Error(t, err)
+		assert.Equal(t, "selection aborted", err.Error())
+	})
+
+	t.Run("No retention rules found - success no-op", func(t *testing.T) {
+		getRetentionId = func(projectNameorID string, isName bool) (string, error) {
+			return "42", nil
+		}
+		getRetentionTagRule = func(retentionID string) (int64, error) {
+			return -1, nil
+		}
+
+		cmd := DeleteRetentionRuleCommand()
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetErr(&buf)
+		cmd.SetArgs([]string{"--project-name", "test-project"})
+
+		err := cmd.Execute()
+		assert.NoError(t, err)
+	})
+
+	t.Run("DeleteRetention error - returns error", func(t *testing.T) {
+		getRetentionId = func(projectNameorID string, isName bool) (string, error) {
+			return "42", nil
+		}
+		getRetentionTagRule = func(retentionID string) (int64, error) {
+			return 0, nil
+		}
+		deleteRetention = func(retentionID string, ruleIndex int) error {
+			return errors.New("delete failed")
+		}
+
+		cmd := DeleteRetentionRuleCommand()
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetErr(&buf)
+		cmd.SetArgs([]string{"--project-name", "test-project"})
+
+		err := cmd.Execute()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "delete failed")
+	})
+
+	t.Run("Delete retention rule - success", func(t *testing.T) {
+		getRetentionId = func(projectNameorID string, isName bool) (string, error) {
+			return "42", nil
+		}
+		getRetentionTagRule = func(retentionID string) (int64, error) {
+			return 0, nil
+		}
+		var calledRetentionID string
+		var calledIndex int
+		deleteRetention = func(retentionID string, ruleIndex int) error {
+			calledRetentionID = retentionID
+			calledIndex = ruleIndex
+			return nil
+		}
+
+		cmd := DeleteRetentionRuleCommand()
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetErr(&buf)
+		cmd.SetArgs([]string{"--project-name", "test-project"})
+
+		err := cmd.Execute()
+		assert.NoError(t, err)
+		assert.Equal(t, "42", calledRetentionID)
+		assert.Equal(t, 0, calledIndex)
+	})
 }

--- a/cmd/harbor/root/tag/retention/delete_test.go
+++ b/cmd/harbor/root/tag/retention/delete_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -78,8 +79,8 @@ func TestDeleteRetentionRuleCommand_Errors(t *testing.T) {
 		getRetentionId = func(projectNameorID string, isName bool) (string, error) {
 			return "42", nil
 		}
-		getRetentionTagRule = func(retentionID string) (int64, error) {
-			return 0, errors.New("selection aborted")
+		getRetentionTagRule = func(retentionID string) (*models.RetentionPolicy, int64, error) {
+			return nil, 0, errors.New("selection aborted")
 		}
 
 		cmd := DeleteRetentionRuleCommand()
@@ -97,8 +98,13 @@ func TestDeleteRetentionRuleCommand_Errors(t *testing.T) {
 		getRetentionId = func(projectNameorID string, isName bool) (string, error) {
 			return "42", nil
 		}
-		getRetentionTagRule = func(retentionID string) (int64, error) {
-			return -1, nil
+		getRetentionTagRule = func(retentionID string) (*models.RetentionPolicy, int64, error) {
+			return &models.RetentionPolicy{ID: 42}, -1, nil
+		}
+		deleteCalled := false
+		deleteRetention = func(existingPolicy *models.RetentionPolicy, ruleID int64) error {
+			deleteCalled = true
+			return nil
 		}
 
 		cmd := DeleteRetentionRuleCommand()
@@ -109,16 +115,18 @@ func TestDeleteRetentionRuleCommand_Errors(t *testing.T) {
 
 		err := cmd.Execute()
 		assert.NoError(t, err)
+		assert.False(t, deleteCalled)
 	})
 
 	t.Run("DeleteRetention error - returns error", func(t *testing.T) {
 		getRetentionId = func(projectNameorID string, isName bool) (string, error) {
 			return "42", nil
 		}
-		getRetentionTagRule = func(retentionID string) (int64, error) {
-			return 0, nil
+		policy := &models.RetentionPolicy{ID: 42}
+		getRetentionTagRule = func(retentionID string) (*models.RetentionPolicy, int64, error) {
+			return policy, 17, nil
 		}
-		deleteRetention = func(retentionID string, ruleIndex int) error {
+		deleteRetention = func(existingPolicy *models.RetentionPolicy, ruleID int64) error {
 			return errors.New("delete failed")
 		}
 
@@ -137,14 +145,15 @@ func TestDeleteRetentionRuleCommand_Errors(t *testing.T) {
 		getRetentionId = func(projectNameorID string, isName bool) (string, error) {
 			return "42", nil
 		}
-		getRetentionTagRule = func(retentionID string) (int64, error) {
-			return 0, nil
+		policy := &models.RetentionPolicy{ID: 42}
+		getRetentionTagRule = func(retentionID string) (*models.RetentionPolicy, int64, error) {
+			return policy, 17, nil
 		}
-		var calledRetentionID string
-		var calledIndex int
-		deleteRetention = func(retentionID string, ruleIndex int) error {
-			calledRetentionID = retentionID
-			calledIndex = ruleIndex
+		var calledPolicy *models.RetentionPolicy
+		var calledRuleID int64
+		deleteRetention = func(existingPolicy *models.RetentionPolicy, ruleID int64) error {
+			calledPolicy = existingPolicy
+			calledRuleID = ruleID
 			return nil
 		}
 
@@ -156,7 +165,7 @@ func TestDeleteRetentionRuleCommand_Errors(t *testing.T) {
 
 		err := cmd.Execute()
 		assert.NoError(t, err)
-		assert.Equal(t, "42", calledRetentionID)
-		assert.Equal(t, 0, calledIndex)
+		assert.Same(t, policy, calledPolicy)
+		assert.Equal(t, int64(17), calledRuleID)
 	})
 }

--- a/pkg/api/retention_handler.go
+++ b/pkg/api/retention_handler.go
@@ -121,18 +121,13 @@ func GetRetentionId(projectNameorID string, isName bool) (string, error) {
 	return retentionid, nil
 }
 
-func DeleteRetention(projectName string, ruleIndex int) error {
+func DeleteRetention(retentionID string, ruleIndex int) error {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {
 		return err
 	}
 
-	retentionIDStr, err := GetRetentionId(projectName, true)
-	if err != nil {
-		return err
-	}
-
-	retentionResp, err := ListRetention(retentionIDStr)
+	retentionResp, err := ListRetention(retentionID)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/retention_handler.go
+++ b/pkg/api/retention_handler.go
@@ -121,7 +121,7 @@ func GetRetentionId(projectNameorID string, isName bool) (string, error) {
 	return retentionid, nil
 }
 
-func DeleteRetention(retentionID string, ruleIndex int64) error {
+func DeleteRetention(retentionID string, ruleIndex int) error {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {
 		return err
@@ -137,12 +137,11 @@ func DeleteRetention(retentionID string, ruleIndex int64) error {
 		return fmt.Errorf("retention policy is empty")
 	}
 
-	idx := int(ruleIndex)
-	if idx < 0 || idx >= len(existingPolicy.Rules) {
+	if ruleIndex < 0 || ruleIndex >= len(existingPolicy.Rules) {
 		return fmt.Errorf("invalid rule index")
 	}
 
-	copy(existingPolicy.Rules[idx:], existingPolicy.Rules[idx+1:])
+	copy(existingPolicy.Rules[ruleIndex:], existingPolicy.Rules[ruleIndex+1:])
 	existingPolicy.Rules[len(existingPolicy.Rules)-1] = nil
 	existingPolicy.Rules = existingPolicy.Rules[:len(existingPolicy.Rules)-1]
 

--- a/pkg/api/retention_handler.go
+++ b/pkg/api/retention_handler.go
@@ -133,12 +133,18 @@ func DeleteRetention(retentionID string, ruleIndex int64) error {
 	}
 
 	existingPolicy := retentionResp.Payload
+	if existingPolicy == nil {
+		return fmt.Errorf("retention policy is empty")
+	}
+
 	idx := int(ruleIndex)
 	if idx < 0 || idx >= len(existingPolicy.Rules) {
 		return fmt.Errorf("invalid rule index")
 	}
 
-	existingPolicy.Rules = append(existingPolicy.Rules[:idx], existingPolicy.Rules[idx+1:]...)
+	copy(existingPolicy.Rules[idx:], existingPolicy.Rules[idx+1:])
+	existingPolicy.Rules[len(existingPolicy.Rules)-1] = nil
+	existingPolicy.Rules = existingPolicy.Rules[:len(existingPolicy.Rules)-1]
 
 	_, err = client.Retention.UpdateRetention(ctx, &retention.UpdateRetentionParams{
 		ID:     int64(retentionResp.Payload.ID),

--- a/pkg/api/retention_handler.go
+++ b/pkg/api/retention_handler.go
@@ -121,7 +121,7 @@ func GetRetentionId(projectNameorID string, isName bool) (string, error) {
 	return retentionid, nil
 }
 
-func DeleteRetention(retentionID string, ruleIndex int) error {
+func DeleteRetention(retentionID string, ruleIndex int64) error {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {
 		return err
@@ -133,11 +133,12 @@ func DeleteRetention(retentionID string, ruleIndex int) error {
 	}
 
 	existingPolicy := retentionResp.Payload
-	if ruleIndex < 0 || ruleIndex >= len(existingPolicy.Rules) {
+	idx := int(ruleIndex)
+	if idx < 0 || idx >= len(existingPolicy.Rules) {
 		return fmt.Errorf("invalid rule index")
 	}
 
-	existingPolicy.Rules = append(existingPolicy.Rules[:ruleIndex], existingPolicy.Rules[ruleIndex+1:]...)
+	existingPolicy.Rules = append(existingPolicy.Rules[:idx], existingPolicy.Rules[idx+1:]...)
 
 	_, err = client.Retention.UpdateRetention(ctx, &retention.UpdateRetentionParams{
 		ID:     int64(retentionResp.Payload.ID),

--- a/pkg/api/retention_handler.go
+++ b/pkg/api/retention_handler.go
@@ -121,40 +121,49 @@ func GetRetentionId(projectNameorID string, isName bool) (string, error) {
 	return retentionid, nil
 }
 
-func DeleteRetention(retentionID string, ruleIndex int) error {
+func DeleteRetention(existingPolicy *models.RetentionPolicy, ruleID int64) error {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {
 		return err
 	}
 
-	retentionResp, err := ListRetention(retentionID)
-	if err != nil {
+	if existingPolicy == nil {
+		return fmt.Errorf("retention policy payload is empty while deleting rule ID %d", ruleID)
+	}
+
+	if err := removeRetentionRule(existingPolicy, ruleID); err != nil {
 		return err
 	}
 
-	existingPolicy := retentionResp.Payload
-	if existingPolicy == nil {
-		return fmt.Errorf("retention policy payload is empty for retention ID %s", retentionID)
-	}
-
-	if ruleIndex < 0 || ruleIndex >= len(existingPolicy.Rules) {
-		return fmt.Errorf("invalid rule index")
-	}
-
-	copy(existingPolicy.Rules[ruleIndex:], existingPolicy.Rules[ruleIndex+1:])
-	existingPolicy.Rules[len(existingPolicy.Rules)-1] = nil
-	existingPolicy.Rules = existingPolicy.Rules[:len(existingPolicy.Rules)-1]
-
 	_, err = client.Retention.UpdateRetention(ctx, &retention.UpdateRetentionParams{
-		ID:     int64(retentionResp.Payload.ID),
+		ID:     existingPolicy.ID,
 		Policy: existingPolicy,
 	})
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("Deleted rule at index %d from retention policy\n", ruleIndex)
+	fmt.Printf("Deleted rule with ID %d from retention policy\n", ruleID)
 	return nil
+}
+
+func removeRetentionRule(existingPolicy *models.RetentionPolicy, ruleID int64) error {
+	if existingPolicy == nil {
+		return fmt.Errorf("retention policy payload is empty while deleting rule ID %d", ruleID)
+	}
+
+	for i, rule := range existingPolicy.Rules {
+		if rule == nil || rule.ID != ruleID {
+			continue
+		}
+
+		copy(existingPolicy.Rules[i:], existingPolicy.Rules[i+1:])
+		existingPolicy.Rules[len(existingPolicy.Rules)-1] = nil
+		existingPolicy.Rules = existingPolicy.Rules[:len(existingPolicy.Rules)-1]
+		return nil
+	}
+
+	return fmt.Errorf("retention rule with ID %d not found", ruleID)
 }
 
 func UpdateRetention(retentionIDStr string, newRule *models.RetentionRule) error {

--- a/pkg/api/retention_handler.go
+++ b/pkg/api/retention_handler.go
@@ -134,7 +134,7 @@ func DeleteRetention(retentionID string, ruleIndex int) error {
 
 	existingPolicy := retentionResp.Payload
 	if existingPolicy == nil {
-		return fmt.Errorf("retention policy is empty")
+		return fmt.Errorf("retention policy payload is empty for retention ID %s", retentionID)
 	}
 
 	if ruleIndex < 0 || ruleIndex >= len(existingPolicy.Rules) {

--- a/pkg/api/retention_handler_test.go
+++ b/pkg/api/retention_handler_test.go
@@ -1,0 +1,55 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package api
+
+import (
+	"testing"
+
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoveRetentionRuleByID(t *testing.T) {
+	policy := &models.RetentionPolicy{
+		Rules: []*models.RetentionRule{
+			{ID: 30},
+			nil,
+			{ID: 10},
+			{ID: 20},
+		},
+	}
+
+	err := removeRetentionRule(policy, 10)
+
+	require.NoError(t, err)
+	require.Len(t, policy.Rules, 3)
+	assert.Equal(t, int64(30), policy.Rules[0].ID)
+	assert.Nil(t, policy.Rules[1])
+	assert.Equal(t, int64(20), policy.Rules[2].ID)
+}
+
+func TestRemoveRetentionRuleMissingID(t *testing.T) {
+	policy := &models.RetentionPolicy{
+		Rules: []*models.RetentionRule{{ID: 10}, {ID: 20}},
+	}
+
+	err := removeRetentionRule(policy, 99)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "retention rule with ID 99 not found")
+	require.Len(t, policy.Rules, 2)
+	assert.Equal(t, int64(10), policy.Rules[0].ID)
+	assert.Equal(t, int64(20), policy.Rules[1].ID)
+}

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -309,7 +309,7 @@ func GetQuotaIDFromUser() int64 {
 	QuotaID := make(chan int64)
 
 	go func() {
-		response, err := api.ListQuota(*&api.ListQuotaFlags{})
+		response, err := api.ListQuota(api.ListQuotaFlags{})
 		if err != nil {
 			log.Errorf("failed to list quota: %v", err)
 		}
@@ -468,7 +468,6 @@ func GetRetentionTagRule(retentionID string) (int64, error) {
 		return 0, err
 	}
 	if response.Payload == nil || len(response.Payload.Rules) == 0 {
-		fmt.Println("No retention rules found")
 		return -1, nil
 	}
 	return retview.RetentionList(response.Payload.Rules)

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -462,13 +462,15 @@ func GetRoleIDFromUser() int64 {
 	return <-roleID
 }
 
-func GetRetentionTagRule(retentionID string) int64 {
-	retentionIndex := make(chan int64)
-	go func() {
-		response, _ := api.ListRetention(retentionID)
-		retview.RetentionList(response.Payload.Rules, retentionIndex)
-	}()
-	return <-retentionIndex
+func GetRetentionTagRule(retentionID string) (int, error) {
+	response, err := api.ListRetention(retentionID)
+	if err != nil {
+		return 0, err
+	}
+	if response.Payload == nil || len(response.Payload.Rules) == 0 {
+		return 0, fmt.Errorf("no retention rules found")
+	}
+	return retview.RetentionList(response.Payload.Rules)
 }
 
 func GetPreheatPolicyNameFromUser(projectName string) (string, error) {

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -462,13 +462,14 @@ func GetRoleIDFromUser() int64 {
 	return <-roleID
 }
 
-func GetRetentionTagRule(retentionID string) (int, error) {
+func GetRetentionTagRule(retentionID string) (int64, error) {
 	response, err := api.ListRetention(retentionID)
 	if err != nil {
 		return 0, err
 	}
 	if response.Payload == nil || len(response.Payload.Rules) == 0 {
-		return 0, fmt.Errorf("no retention rules found")
+		fmt.Println("No retention rules found")
+		return -1, nil
 	}
 	return retview.RetentionList(response.Payload.Rules)
 }

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -462,15 +462,16 @@ func GetRoleIDFromUser() int64 {
 	return <-roleID
 }
 
-func GetRetentionTagRule(retentionID string) (int64, error) {
+func GetRetentionTagRule(retentionID string) (*models.RetentionPolicy, int64, error) {
 	response, err := api.ListRetention(retentionID)
 	if err != nil {
-		return 0, fmt.Errorf("failed to list retention rules for retention policy %s: %w", retentionID, err)
+		return nil, 0, fmt.Errorf("failed to list retention rules for retention policy %s: %w", retentionID, err)
 	}
 	if response.Payload == nil || len(response.Payload.Rules) == 0 {
-		return -1, nil
+		return response.Payload, -1, nil
 	}
-	return retview.RetentionList(response.Payload.Rules)
+	ruleID, err := retview.RetentionList(response.Payload.Rules)
+	return response.Payload, ruleID, err
 }
 
 func GetPreheatPolicyNameFromUser(projectName string) (string, error) {

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -465,7 +465,7 @@ func GetRoleIDFromUser() int64 {
 func GetRetentionTagRule(retentionID string) (int64, error) {
 	response, err := api.ListRetention(retentionID)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed to list retention rules for retention policy %s: %w", retentionID, err)
 	}
 	if response.Payload == nil || len(response.Payload.Rules) == 0 {
 		return -1, nil

--- a/pkg/views/base/selection/errors.go
+++ b/pkg/views/base/selection/errors.go
@@ -1,0 +1,18 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package selection
+
+import "errors"
+
+var ErrUserAborted = errors.New("user aborted selection")

--- a/pkg/views/retention/select/view.go
+++ b/pkg/views/retention/select/view.go
@@ -14,8 +14,8 @@
 package retention
 
 import (
+	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/list"
@@ -24,9 +24,11 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/views/base/selection"
 )
 
-func RetentionList(rules []*models.RetentionRule, choice chan<- int64) {
+var ErrUserAborted = errors.New("user aborted selection")
+
+func RetentionList(rules []*models.RetentionRule) (int, error) {
 	itemsList := make([]list.Item, len(rules))
-	items := map[string]int64{}
+	items := map[string]int{}
 
 	for i, rule := range rules {
 		scopeStrs := []string{}
@@ -55,7 +57,7 @@ func RetentionList(rules []*models.RetentionRule, choice chan<- int64) {
 			rule.Template,
 		)
 
-		items[display] = rule.ID
+		items[display] = i
 		itemsList[i] = selection.Item(display)
 	}
 
@@ -63,13 +65,20 @@ func RetentionList(rules []*models.RetentionRule, choice chan<- int64) {
 
 	p, err := tea.NewProgram(m, tea.WithAltScreen()).Run()
 	if err != nil {
-		fmt.Println("Error running selection UI:", err)
-		os.Exit(1)
+		return 0, fmt.Errorf("error running selection UI: %w", err)
 	}
 
-	if p, ok := p.(selection.Model); ok {
-		choice <- items[p.Choice]
+	if model, ok := p.(selection.Model); ok {
+		if model.Aborted {
+			return 0, ErrUserAborted
+		}
+		if model.Choice == "" {
+			return 0, errors.New("no retention rule selected")
+		}
+		return items[model.Choice], nil
 	}
+
+	return 0, errors.New("unexpected program result")
 }
 
 func formatParams(params map[string]interface{}) string {

--- a/pkg/views/retention/select/view.go
+++ b/pkg/views/retention/select/view.go
@@ -61,7 +61,7 @@ func RetentionList(rules []*models.RetentionRule) (int64, error) {
 		itemsList[i] = selection.Item(display)
 	}
 
-	m := selection.NewModel(itemsList, "Select a Retention Rule")
+	m := selection.NewModel(itemsList, "Retention Rule")
 
 	p, err := tea.NewProgram(m, tea.WithAltScreen()).Run()
 	if err != nil {
@@ -73,7 +73,7 @@ func RetentionList(rules []*models.RetentionRule) (int64, error) {
 			return 0, ErrUserAborted
 		}
 		if model.Choice == "" {
-			return 0, errors.New("no retention rule selected")
+			return 0, ErrUserAborted
 		}
 		return items[model.Choice], nil
 	}

--- a/pkg/views/retention/select/view.go
+++ b/pkg/views/retention/select/view.go
@@ -26,9 +26,9 @@ import (
 
 var ErrUserAborted = errors.New("user aborted selection")
 
-func RetentionList(rules []*models.RetentionRule) (int, error) {
+func RetentionList(rules []*models.RetentionRule) (int64, error) {
 	itemsList := make([]list.Item, len(rules))
-	items := map[string]int{}
+	items := map[string]int64{}
 
 	for i, rule := range rules {
 		scopeStrs := []string{}
@@ -57,7 +57,7 @@ func RetentionList(rules []*models.RetentionRule) (int, error) {
 			rule.Template,
 		)
 
-		items[display] = i
+		items[display] = int64(i)
 		itemsList[i] = selection.Item(display)
 	}
 

--- a/pkg/views/retention/select/view.go
+++ b/pkg/views/retention/select/view.go
@@ -24,8 +24,6 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/views/base/selection"
 )
 
-var ErrUserAborted = errors.New("user aborted selection")
-
 func RetentionList(rules []*models.RetentionRule) (int64, error) {
 	itemsList := make([]list.Item, len(rules))
 	items := map[string]int64{}
@@ -57,7 +55,7 @@ func RetentionList(rules []*models.RetentionRule) (int64, error) {
 			rule.Template,
 		)
 
-		items[display] = int64(i)
+		items[display] = rule.ID
 		itemsList[i] = selection.Item(display)
 	}
 
@@ -70,9 +68,13 @@ func RetentionList(rules []*models.RetentionRule) (int64, error) {
 
 	if model, ok := p.(selection.Model); ok {
 		if model.Choice == "" {
-			return 0, ErrUserAborted
+			return 0, selection.ErrUserAborted
 		}
-		return items[model.Choice], nil
+		ruleID, ok := items[model.Choice]
+		if !ok {
+			return 0, fmt.Errorf("selected retention rule %q not found in rule list", model.Choice)
+		}
+		return ruleID, nil
 	}
 
 	return 0, errors.New("unexpected program result")

--- a/pkg/views/retention/select/view.go
+++ b/pkg/views/retention/select/view.go
@@ -69,9 +69,6 @@ func RetentionList(rules []*models.RetentionRule) (int64, error) {
 	}
 
 	if model, ok := p.(selection.Model); ok {
-		if model.Aborted {
-			return 0, ErrUserAborted
-		}
 		if model.Choice == "" {
 			return 0, ErrUserAborted
 		}


### PR DESCRIPTION
- Fixes #995 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

---

## Description / Quick Summary
This PR safeguards the tag retention rule deletion flow against unhandled errors. API failures and prompt cancellations are propagated through Cobra's RunE boundary. When no retention rules are configured, the command prints "No retention rules found" and exits successfully without attempting deletion.

---

## Problem
* **What issue exists?** 
  - `prompt.GetRetentionTagRule()` would block indefinitely on connection failures and did not return errors to its caller.
  - The deletion command assumed retention rules were always found, resulting in potential errors when indexing empty payloads.
  - `api.DeleteRetention()` executed redundant network lookups to resolve project names to retention IDs when the ID was already available.
* **Who is affected?** Users attempting to view or delete tag retention rules when network/connection problems occur, or when no retention rules are configured on the project.
* **Current Behavior:** The CLI could exit unexpectedly, block, or fail to surface actionable errors to the user.
* **Desired Behavior:** API failures and prompt cancellations should propagate gracefully up to Cobra with user-friendly errors. Empty retention-rule lists are treated as a successful no-op and print "No retention rules found".

---

## Root Cause
* **Relevant Files:**
  - `cmd/harbor/root/tag/retention/delete.go`
  - `pkg/api/retention_handler.go`
  - `pkg/prompt/prompt.go`
  - `pkg/views/retention/select/view.go`
* **Technical Explanation:**
  The command and API wrapper layers did not check return errors from `api.ListRetention()` and did not propagate the error up to the Cobra `RunE` boundary.

---

## Solution
* **Overview:** 
  1. Updated `prompt.GetRetentionTagRule` signature to return `(int, error)` and check for empty rules.
  2. Simplified `DeleteRetention` to use the already-available retention ID and removed a redundant lookup request.
  3. Propagated selection aborts and API errors up to `cmd/harbor/root/tag/retention/delete.go`.

---

## Scope

### Included
- Returning errors from `GetRetentionTagRule` and propagating them in the `delete` command.
- Optimizing `DeleteRetention` client helper to use direct ID.

### Explicitly Not Included
- Core selection model modification (no changes are made to `pkg/views/base/selection/model.go` to keep this PR strictly isolated).

---

## Changes
- **`cmd/harbor/root/tag/retention/delete.go`**: Added error check for `prompt.GetRetentionTagRule` and updated `api.DeleteRetention` invocation to use the direct retention ID.
- **`pkg/api/retention_handler.go`**: Simplified `DeleteRetention` signature to accept `retentionID` directly and removed the redundant call to `GetRetentionId`.
- **`pkg/prompt/prompt.go`**: Refactored `GetRetentionTagRule` to return `(int, error)` and added checks for API errors and empty rule lists.
- **`pkg/views/retention/select/view.go`**: Refactored `RetentionList` to return `(int, error)` and propagate selection errors.

---

## Testing

### Unit Tests
- [x] All existing package tests pass (`go test ./...`)

### Manual Verification
1. Configured local dummy server.
2. Ran `.\harbor_retention.exe tag retention delete --project <project_name>`.
3. Observed the graceful exit and correct error reporting on connection refusal.

---

## Risks & Compatibility
* **Backward Compatibility:** Non-breaking. Enhances error propagation without changing successful prompt behavior.
* **Potential Risks:** None identified.