### PR TITLE
fix(robot): handle empty permissions in robot view

### DIFF
--- a/pkg/views/robot/view/view.go
+++ b/pkg/views/robot/view/view.go
@@ -87,7 +87,8 @@ func ViewRobot(robot *models.Robot) {
 		enabledStatus = views.GreenStyle.Render("Enabled")
 	}
 
-	TotalPermissions := strconv.FormatInt(int64(len(robot.Permissions[0].Access)), 10)
+	totalPermissions, namespace := robotPermissionSummary(robot)
+	TotalPermissions := strconv.FormatInt(int64(totalPermissions), 10)
 
 	if robot.ExpiresAt == -1 {
 		expires = "Never"
@@ -127,7 +128,7 @@ func ViewRobot(robot *models.Robot) {
 		permissionsColumns = projectPermissionsColumns
 		resourceStrings = projectResourceStrings
 		systemLevel = false
-		fmt.Printf("\n%s\n\n", views.BoldStyle.Render(fmt.Sprintf("System-level robot with access across projects: %s", robot.Permissions[0].Namespace)))
+		fmt.Printf("\n%s\n\n", views.BoldStyle.Render(fmt.Sprintf("System-level robot with access across projects: %s", namespace)))
 	}
 
 	var permissionRows []table.Row
@@ -214,6 +215,15 @@ func ViewRobot(robot *models.Robot) {
 			os.Exit(1)
 		}
 	}
+}
+
+func robotPermissionSummary(robot *models.Robot) (permissionCount int, namespace string) {
+	namespace = "--"
+	if len(robot.Permissions) == 0 || robot.Permissions[0] == nil {
+		return 0, namespace
+	}
+
+	return len(robot.Permissions[0].Access), robot.Permissions[0].Namespace
 }
 
 func createProjectPermissionRows(perm *models.RobotPermission, availablePerms map[string][]string) []table.Row {

--- a/pkg/views/robot/view/view_test.go
+++ b/pkg/views/robot/view/view_test.go
@@ -1,0 +1,49 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package view
+
+import (
+	"testing"
+
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRobotPermissionSummaryWithoutPermissions(t *testing.T) {
+	robot := &models.Robot{}
+
+	permissionCount, namespace := robotPermissionSummary(robot)
+
+	assert.Equal(t, 0, permissionCount)
+	assert.Equal(t, "--", namespace)
+}
+
+func TestRobotPermissionSummaryWithPermissions(t *testing.T) {
+	robot := &models.Robot{
+		Permissions: []*models.RobotPermission{
+			{
+				Namespace: "demo",
+				Access: []*models.Access{
+					{Resource: "repository", Action: "pull"},
+					{Resource: "artifact", Action: "read"},
+				},
+			},
+		},
+	}
+
+	permissionCount, namespace := robotPermissionSummary(robot)
+
+	assert.Equal(t, 2, permissionCount)
+	assert.Equal(t, "demo", namespace)
+}


### PR DESCRIPTION
## Description

- Fixes #997

`harbor robot view` panics when the Harbor API returns a robot with an empty or nil `permissions` array. The view indexed `robot.Permissions[0]` unconditionally, while `harbor robot list` already guarded this case.

This PR adds safe fallbacks for the permission count and project namespace header, matching the list view behavior.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes

- Add `robotPermissionSummary` helper to safely read permission count and namespace
- Use placeholders (`0`, `--`) when permission details are missing
- Add unit tests for nil/empty and populated permissions

## Test plan

- [x] `go test ./pkg/views/robot/view/... -v`
- [x] Verified `robotPermissionSummary` returns safe defaults for nil/empty permissions (no index panic)