### PR TITLE
fix: remove debug log statement from member view

### DIFF
--- a/pkg/views/member/view/view.go
+++ b/pkg/views/member/view/view.go
@@ -16,7 +16,6 @@ package view
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"strconv"
 
@@ -63,7 +62,6 @@ func ViewMember(member *models.ProjectMemberEntity, wide bool) {
 	} else {
 		colsToRemove := []string{"Role ID", "Project ID"}
 		columns = utils.RemoveColumns(columns, colsToRemove)
-		log.Println(columns)
 		rows = append(rows, table.Row{
 			memberID, // Member Name
 			member.EntityName,


### PR DESCRIPTION
## Summary
Removes a leftover debug `log.Println()` statement that was polluting terminal output when viewing project members.

## Problem
When users ran member view commands in non-wide format, they saw raw internal struct data printed to their terminal:
```
[{ID 4 false false 0} {Member Name 12 false false 0} {Type 8 false false 0} {Role Name 16 false false 0}]
```
This was noise from a debugging statement accidentally left in production code at line 66 of `pkg/views/member/view/view.go`.

## What This PR Does
✅ Removes the `log.Println(columns)` debug statement  
✅ Removes the now-unused `"log"` import (required by Go compiler)  

### What Stays the Same
The actual behavior is completely unchanged. The `columns` variable is still used exactly as before to build the table model on line 73. This PR only removes the unintended debug noise that was leaking into user-facing output.

## Changes
File | Modification
---|---
`pkg/views/member/view/view.go` | -2 lines (debug statement + unused import)

Total diff: **+0 additions, -2 deletions**

## Testing & Verification
✅ `go build ./...` passes with no errors  
✅ `go vet ./pkg/views/member/view/...` passes with no warnings  
✅ No functional changes to view rendering  
✅ Verified `columns` variable still correctly used in table model  
✅ Confirmed no other code in `pkg/views/` uses bare `log.Println` for debug  

## Impact
- **User Experience**: Cleaner terminal output, no more internal struct data visible  
- **Code Quality**: Removes dead code, follows project patterns  
- **Risk Level**: None — zero behavioral changes, purely cosmetic cleanup  

## Context
No other view files in `pkg/views/` use bare `log.Println` statements. The view layer should only render output, not perform logging.

Fixes #5