### PR TITLE
Fix wrong package declarations across 6 view files (copy-paste leftovers)

### DIFF
--- a/pkg/views/artifact/select/view.go
+++ b/pkg/views/artifact/select/view.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package registry
+package artifact
 
 import (
 	"fmt"

--- a/pkg/views/artifact/tags/select/view.go
+++ b/pkg/views/artifact/tags/select/view.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package registry
+package tags
 
 import (
 	"fmt"

--- a/pkg/views/label/select/view.go
+++ b/pkg/views/label/select/view.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package delete
+package label
 
 import (
 	"fmt"

--- a/pkg/views/replication/task/list/view.go
+++ b/pkg/views/replication/task/list/view.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package view
+package list
 
 import (
 	"fmt"

--- a/pkg/views/repository/select/view.go
+++ b/pkg/views/repository/select/view.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package project
+package repository
 
 import (
 	"fmt"

--- a/pkg/views/webhook/select/view.go
+++ b/pkg/views/webhook/select/view.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package project
+package webhook
 
 import (
 	"errors"


### PR DESCRIPTION
This fixes a set of copy-paste errors where files were duplicated from other packages but the `package` declaration was never updated to match their actual location.

**Whats wrong?**

Six files declare a package name that has nothing to do with where they live. For example, a file inside `artifact/select/` said `package registry` — clearly carried over from `pkg/views/registry/select/view.go`. Same story for the others.

**Whats changing?**

| File | Was | Now |
|------|-----|-----|
| `pkg/views/artifact/select/view.go` | `package registry` | `package artifact` |
| `pkg/views/artifact/tags/select/view.go` | `package registry` | `package tags` |
| `pkg/views/repository/select/view.go` | `package project` | `package repository` |
| `pkg/views/webhook/select/view.go` | `package project` | `package webhook` |
| `pkg/views/label/select/view.go` | `package delete` | `package label` |
| `pkg/views/replication/task/list/view.go` | `package view` | `package list` |

**Could this break anything?**

No. Every single one of these files is imported with an explicit Go alias (`aview "..."`, `tview "..."`, etc.), so the declared package name is completely irrelevant at the call site. Zero callers touch, zero tests change.

**Verification**

-   `go build ./...` passes
-   `go vet ./pkg/views/...` clean
-   All 7 test suites across 103 packages pass

Fixes #1037