### PR TITLE
fix: stop mutating package-level columns variable in member list view

### DIFF
--- a/pkg/views/member/list/view.go
+++ b/pkg/views/member/list/view.go
@@ -37,6 +37,13 @@ var columns = []table.Column{
 
 func ListMembers(members []*models.ProjectMemberEntity, wide bool) {
 	var rows []table.Row
+	localColumns := columns
+
+	if !wide {
+		colsToRemove := []string{"Role ID", "Project ID"}
+		localColumns = utils.RemoveColumns(localColumns, colsToRemove)
+	}
+
 	for _, member := range members {
 		memberID := strconv.FormatInt(member.ID, 10)
 		roleName := utils.CamelCaseToHR(member.RoleName)
@@ -61,10 +68,8 @@ func ListMembers(members []*models.ProjectMemberEntity, wide bool) {
 				projectID,
 			})
 		} else {
-			colsToRemove := []string{"Role ID", "Project ID"}
-			columns = utils.RemoveColumns(columns, colsToRemove)
 			rows = append(rows, table.Row{
-				memberID, // Member Name
+				memberID,
 				member.EntityName,
 				memberType,
 				roleName,
@@ -72,7 +77,7 @@ func ListMembers(members []*models.ProjectMemberEntity, wide bool) {
 		}
 	}
 
-	m := tablelist.NewModel(columns, rows, len(rows))
+	m := tablelist.NewModel(localColumns, rows, len(rows))
 
 	if _, err := tea.NewProgram(m).Run(); err != nil {
 		fmt.Println("Error running program:", err)


### PR DESCRIPTION
## Description

`ListMembers` in `pkg/views/member/list/view.go` modifies a package-level `var columns` slice when rendering in non-wide mode. Since the variable is global, a non-wide call permanently strips columns from it — meaning subsequent calls with `--wide` will render an incomplete table.

This is a classic shared-mutable-state bug. The fix is straightforward: make a local copy at function entry and operate on that instead. The global now acts as an immutable template.

## Changes

-   `pkg/views/member/list/view.go` — copy `columns` into a local variable, use it for both mutation and the table model

## Testing

-   `go build ./pkg/views/member/...` — passes
-   `go vet ./pkg/views/member/...` — passes
-   Manually verified: `harbor project member list` and `--wide` both render correctly after the change

Fixes #1038