### PR TITLE
fix(api): propagate errors from GetLabel instead of returning nil

### DIFF
--- a/cmd/harbor/root/artifact/label/add.go
+++ b/cmd/harbor/root/artifact/label/add.go
@@ -88,7 +88,10 @@ Examples:
 				}
 			}
 
-			label := api.GetLabel(labelID)
+			label, err := api.GetLabel(labelID)
+			if err != nil {
+				return fmt.Errorf("failed to get label: %v", utils.ParseHarborErrorMsg(err))
+			}
 
 			if _, err := api.AddLabelArtifact(projectName, repoName, reference, label); err != nil {
 				return fmt.Errorf("failed to add label to artifact: %v", utils.ParseHarborErrorMsg(err))

--- a/cmd/harbor/root/labels/update.go
+++ b/cmd/harbor/root/labels/update.go
@@ -19,6 +19,7 @@ import (
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
+	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/label/update"
 	"github.com/spf13/cobra"
 )
@@ -68,9 +69,9 @@ func UpdateLableCommand() *cobra.Command {
 				return fmt.Errorf("failed to parse label id: %v", err)
 			}
 
-			existingLabel := api.GetLabel(labelId)
-			if existingLabel == nil {
-				return fmt.Errorf("label is not found")
+			existingLabel, err := api.GetLabel(labelId)
+			if err != nil {
+				return fmt.Errorf("failed to get label: %v", utils.ParseHarborErrorMsg(err))
 			}
 			updateView := &models.Label{
 				Name:        existingLabel.Name,

--- a/pkg/api/label_handler.go
+++ b/pkg/api/label_handler.go
@@ -107,17 +107,22 @@ func UpdateLabel(updateView *models.Label, Labelid int64) error {
 	return nil
 }
 
-func GetLabel(labelid int64) *models.Label {
+func GetLabel(labelid int64) (*models.Label, error) {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	response, err := client.Label.GetLabelByID(ctx, &label.GetLabelByIDParams{LabelID: labelid})
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
-	return response.GetPayload()
+	payload := response.GetPayload()
+	if payload == nil || payload.ID == 0 {
+		return nil, fmt.Errorf("label with id %d not found", labelid)
+	}
+
+	return payload, nil
 }
 
 func GetLabelIdByName(labelName string, opts ListFlags) (int64, error) {


### PR DESCRIPTION
Fixes #1003

GetLabel was the only API handler that returned a bare pointer with no error.
Every failure got replaced with nil, leaving callers blind to what happened.
In the artifact label add path this meant a nil pointer dereference when
the code later accessed label.Name.

The fix is straightforward — change the signature to return an error like
every other function in the API layer does, and update both callers to
handle it properly.

Changes:

- pkg/api/label_handler.go: GetLabel now returns (*models.Label, error).
  Both error paths return the actual error instead of nil.
- cmd/harbor/root/labels/update.go: Replaced the nil check with a proper
  error check so users see the real error instead of "label is not found".
- cmd/harbor/root/artifact/label/add.go: Added an error check after the
  GetLabel call so label.Name is only accessed when we have a valid label.

All existing tests pass. No new dependencies introduced.