### PR TITLE
feat(schedule): add smart router for schedule create and delete commands

### DIFF
--- a/cmd/harbor/root/schedule/create.go
+++ b/cmd/harbor/root/schedule/create.go
@@ -1,0 +1,53 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schedule
+
+import (
+	"fmt"
+
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/spf13/cobra"
+)
+
+func CreateScheduleCommand() *cobra.Command {
+	var jobType string
+	var cronString string
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a schedule job (e.g. gc, scan-all)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if jobType == "" {
+				return fmt.Errorf("--type flag is required")
+			}
+			if cronString == "" {
+				return fmt.Errorf("--cron flag is required")
+			}
+
+			err := api.CreateSchedule(jobType, cronString)
+			if err != nil {
+				return fmt.Errorf("failed to create %s schedule: %v", jobType, err)
+			}
+
+			fmt.Printf("Successfully created schedule for %s with cron: %s\n", jobType, cronString)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&jobType, "type", "", "Type of job (gc, scan-all)")
+	cmd.Flags().StringVar(&cronString, "cron", "", "Cron string for the schedule (e.g. '0 0 * * *')")
+
+	return cmd
+}

--- a/cmd/harbor/root/schedule/delete.go
+++ b/cmd/harbor/root/schedule/delete.go
@@ -11,22 +11,38 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package schedule
 
 import (
+	"fmt"
+
+	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/spf13/cobra"
 )
 
-func Schedule() *cobra.Command {
+func DeleteScheduleCommand() *cobra.Command {
+	var jobType string
+
 	cmd := &cobra.Command{
-		Use:   "schedule",
-		Short: "Schedule jobs in Harbor",
+		Use:   "delete",
+		Short: "Delete a schedule job (e.g. gc, scan-all)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if jobType == "" {
+				return fmt.Errorf("--type flag is required")
+			}
+
+			err := api.DeleteSchedule(jobType)
+			if err != nil {
+				return fmt.Errorf("failed to delete %s schedule: %v", jobType, err)
+			}
+
+			fmt.Printf("Successfully deleted schedule for %s\n", jobType)
+			return nil
+		},
 	}
-	cmd.AddCommand(
-		ListScheduleCommand(),
-		CreateScheduleCommand(),
-		DeleteScheduleCommand(),
-	)
+
+	cmd.Flags().StringVar(&jobType, "type", "", "Type of job to delete schedule for (gc, scan-all)")
 
 	return cmd
 }

--- a/pkg/api/schedule_handler.go
+++ b/pkg/api/schedule_handler.go
@@ -14,9 +14,79 @@
 package api
 
 import (
+	"fmt"
+
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/gc"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/scan_all"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/schedule"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 )
+
+// CreateSchedule acts as a smart router, sending the schedule to the correct Harbor API
+func CreateSchedule(jobType string, cronString string) error {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return err
+	}
+
+	// Build the generic schedule payload
+	schedulePayload := &models.Schedule{
+		Parameters: map[string]interface{}{
+			"delete_untagged": false,
+		},
+		Schedule: &models.ScheduleObj{
+			Type: "Custom",
+			Cron: cronString,
+		},
+	}
+
+	// Route to the correct API based on the type
+	switch jobType {
+	case "gc":
+		_, err = client.GC.UpdateGCSchedule(ctx, &gc.UpdateGCScheduleParams{
+			Schedule: schedulePayload,
+		})
+	case "scan-all":
+		_, err = client.ScanAll.UpdateScanAllSchedule(ctx, &scan_all.UpdateScanAllScheduleParams{
+			Schedule: schedulePayload,
+		})
+	default:
+		return fmt.Errorf("unsupported schedule type: %s. Supported types are: gc, scan-all", jobType)
+	}
+
+	return err
+}
+
+// DeleteSchedule acts as a smart router to delete a schedule
+func DeleteSchedule(jobType string) error {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return err
+	}
+
+	// To delete a schedule in Harbor, we send a PUT request with Type "None"
+	schedulePayload := &models.Schedule{
+		Schedule: &models.ScheduleObj{
+			Type: "None",
+		},
+	}
+
+	switch jobType {
+	case "gc":
+		_, err = client.GC.UpdateGCSchedule(ctx, &gc.UpdateGCScheduleParams{
+			Schedule: schedulePayload,
+		})
+	case "scan-all":
+		_, err = client.ScanAll.UpdateScanAllSchedule(ctx, &scan_all.UpdateScanAllScheduleParams{
+			Schedule: schedulePayload,
+		})
+	default:
+		return fmt.Errorf("unsupported schedule type: %s. Supported types are: gc, scan-all", jobType)
+	}
+
+	return err
+}
 
 func ListSchedule(opts ...ListFlags) (schedule.ListSchedulesOK, error) {
 	ctx, client, err := utils.ContextWithClient()


### PR DESCRIPTION
## Description
This pull request introduces the ability to create and delete scheduled jobs directly from the CLI. 

Previously, the `harbor schedule` command only supported listing existing schedules. Because Harbor's Go client SDK has completely separate services for updating each job type (e.g., `client.GC`, `client.ScanAll`), this PR implements a unified "Smart Router" pattern in `pkg/api/schedule_handler.go`. 

This pattern allows users to pass a generic `--type` flag from a single CLI command and routes the schedule payload to the correct Harbor backend API automatically. **For this initial PR, we have implemented routing for the two most common system-wide schedules (`gc` and `scan-all`). The router is designed to be easily extensible so that the remaining schedule types (like `purgeaudit`, `replication`, etc.) can be seamlessly added in future PRs.**

Fixes #1009 

## Type of Change
Please select the relevant type.

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
- Created `pkg/api/schedule_handler.go` to act as a unified router for constructing schedule payloads and sending them to the correct Harbor endpoints.
- Added `harbor schedule create` command, requiring a `--type` (e.g., `gc`, `scan-all`) and a 6-field `--cron` string.
- Added `harbor schedule delete` command, which sends a schedule payload of type `None` to the specified job type to disable it.
- Registered the new subcommands in `cmd/harbor/root/schedule/cmd.go`.

## Examples & Usage
Here are the new commands that manage schedules, and examples of what the schedule format looks like:

**1. Create a Garbage Collection schedule:**
`harbor schedule create --type gc --cron "0 0 * * * *"`

**2. Create a Scan-All schedule:**
`harbor schedule create --type scan-all --cron "0 0 * * * *"`

**3. Delete schedules:**
`harbor schedule delete --type gc`
`harbor schedule delete --type scan-all`

### Schedule Format:
The `--cron` flag expects a 6-field cron string (which Harbor requires instead of the standard 5-field linux cron). The format is:
`Seconds Minutes Hours Day-of-month Month Day-of-week`

When a user runs the `delete` command, the CLI automatically passes `Type: "None"` to the backend Harbor API to disable the schedule.
