### PR TITLE
pkg/api: paginate all repos in DeleteProject --force

### DIFF
--- a/pkg/api/project_handler.go
+++ b/pkg/api/project_handler.go
@@ -111,23 +111,34 @@ func DeleteProject(projectNameOrID string, forceDelete bool, useProjectID bool) 
 			}
 		}
 
-		resp, err = ListRepository(projectNameOrID, useProjectID)
-		if err != nil {
-			log.Errorf("failed to list repositories: %v", err)
-			return err
-		}
+		var page int64 = 1
+		const pageSize int64 = 100
 
-		for _, repo := range resp.Payload {
-			_, repoName, err := utils.ParseProjectRepo(repo.Name)
+		for {
+			resp, err = ListRepository(projectNameOrID, useProjectID, ListFlags{
+				Page:     page,
+				PageSize: pageSize,
+			})
 			if err != nil {
-				log.Errorf("failed to parse project/repo: %v", err)
+				log.Errorf("failed to list repositories: %v", err)
 				return err
 			}
-			err = RepoDelete(projectNameOrID, repoName, useProjectID)
-			if err != nil {
-				log.Errorf("failed to delete repository: %v", err)
-				return err
+			for _, repo := range resp.Payload {
+				_, repoName, err := utils.ParseProjectRepo(repo.Name)
+				if err != nil {
+					log.Errorf("failed to parse project/repo: %v", err)
+					return err
+				}
+				err = RepoDelete(projectNameOrID, repoName, useProjectID)
+				if err != nil {
+					log.Errorf("failed to delete repository: %v", err)
+					return err
+				}
 			}
+			if int64(len(resp.Payload)) < pageSize {
+				break
+			}
+			page++
 		}
 	}
 	useProjectName := !useProjectID


### PR DESCRIPTION
## Description

`ListRepository` was called once with no pagination opts inside `DeleteProject --force`, so the Harbor API defaulted to `page_size=10`. Projects with more than 10 repositories had only the first page deleted, causing the subsequent `DeleteProject` API call to return `412 Precondition Failed` - leaving remaining repositories orphaned.

This fix replaces the single `ListRepository` call with a paginated loop using `page_size=100` that advances page-by-page until all repositories are deleted, before attempting project deletion.

- Fixes #1010 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes

- Replaced single `ListRepository` call with a paginated loop in `DeleteProject` (`pkg/api/project_handler.go`)
- Loop uses `page_size=100` (API maximum) and increments page until fewer than 100 results are returned
- No behaviour change for projects with ≤10 repositories
