### PR TITLE
refactor: make HTTP error code parsing robust

### DIFF
--- a/pkg/utils/error.go
+++ b/pkg/utils/error.go
@@ -57,18 +57,14 @@ func ParseHarborErrorCode(err error) string {
 	errStr := err.Error()
 
 	// Try format: [METHOD /path][CODE] - e.g., [GET /projects][404]
-	parts := strings.Split(errStr, "]")
-	if len(parts) >= 2 {
-		codePart := strings.TrimSpace(parts[1])
-		if strings.HasPrefix(codePart, "[") && len(codePart) == 4 {
-			code := codePart[1:4]
-			return code
-		}
+	reBracket := regexp.MustCompile(`\]\s*\[(\d{3})\]`)
+	if matches := reBracket.FindStringSubmatch(errStr); len(matches) > 1 {
+		return matches[1]
 	}
 
 	// Try format: (status CODE) - e.g., (status 404)
-	re := regexp.MustCompile(`\(status\s+(\d{3})\)`)
-	if matches := re.FindStringSubmatch(errStr); len(matches) > 1 {
+	reStatus := regexp.MustCompile(`\(status\s+(\d{3})\)`)
+	if matches := reStatus.FindStringSubmatch(errStr); len(matches) > 1 {
 		return matches[1]
 	}
 

--- a/pkg/utils/error_test.go
+++ b/pkg/utils/error_test.go
@@ -93,6 +93,21 @@ func TestParseHarborErrorCode(t *testing.T) {
 			expected: "404",
 		},
 		{
+			name:     "error with brackets format and spaces",
+			err:      errors.New("[GET /api/v2.0/projects] [409] conflict"),
+			expected: "409",
+		},
+		{
+			name:     "error with wrapped bracket prefix",
+			err:      errors.New("[some-info] failed to view: [GET /api/v2.0/projects][403] forbidden"),
+			expected: "403",
+		},
+		{
+			name:     "error with multiple prefix brackets and spaces",
+			err:      errors.New("[Test] [some-info] [GET /api/v2.0/projects] [500] internal error"),
+			expected: "500",
+		},
+		{
 			name:     "error with status format",
 			err:      errors.New("failed to call api (status 500)"),
 			expected: "500",


### PR DESCRIPTION
Closes #1039
Branch: fix/robust-error-code-parsing
Commit: [fix/robust-error-code-parsing e275281]
Changes:
Refactored ParseHarborErrorCode in 
error.go
 to use a regular expression:
go

reBracket := regexp.MustCompile(`\]\s*\[(\d{3})\]`)
This matches any 3-digit status code enclosed in brackets that is preceded by a closing bracket (with or without spaces), rather than relying on splitting string indices.
Added new comprehensive unit test cases in 
error_test.go
 to ensure reliability for wrapped bracketed messages, spaced bracket formats, and prefix brackets.