### PR TITLE
fix(project): handle registry list retrieval error gracefully

### DIFF
--- a/pkg/views/project/create/view.go
+++ b/pkg/views/project/create/view.go
@@ -53,15 +53,17 @@ func getRegistryList() (*registry.ListRegistriesOK, error) {
 
 func CreateProjectView(createView *CreateView) error {
 	theme := huh.ThemeCharm()
-	// I want it to be a map of registry ID to registry name
+	// Registry list is optional: if retrieval fails, the proxy-cache registry
+	// selector will simply be hidden and the form can still proceed.
+	registryOptions := map[string]string{}
 	registries, err := getRegistryList()
 	if err != nil {
-		return err
-	}
-	registryOptions := map[string]string{}
-	for _, registry := range registries.Payload {
-		regiId := fmt.Sprintf("%d", registry.ID)
-		registryOptions[regiId] = fmt.Sprintf("%s (%s)", registry.Name, registry.URL)
+		log.Warnf("failed to retrieve registry list, proxy cache registry selection will be unavailable: %v", err)
+	} else {
+		for _, r := range registries.Payload {
+			regiId := fmt.Sprintf("%d", r.ID)
+			registryOptions[regiId] = fmt.Sprintf("%s (%s)", r.Name, r.URL)
+		}
 	}
 
 	var registrySelectOptions []huh.Option[string]


### PR DESCRIPTION
Closes #1040
### Summary
This PR makes interactive project creation resilient to registry listing API failures.

### Rationale & Design Decisions
- Currently, if the `Registry` listing endpoint fails or is unauthorized, `CreateProjectView` fails immediately.
- Listing registries is only required for selecting a proxy cache registry.
- By handling the error gracefully (logging a debug message and passing an empty list of options), standard project creation remains functional for users without administrative registry access.
Signed-off-by: saiashok103@gmail.com