### PR TITLE
fix(cli): correct spelling typo and append newline to apply output

### DIFF
--- a/cmd/harbor/root/configurations/apply.go
+++ b/cmd/harbor/root/configurations/apply.go
@@ -115,7 +115,7 @@ Make sure to run 'harbor config get' first to populate the local config file wit
 				return fmt.Errorf("failed to update Harbor configurations: %v", err)
 			}
 
-			fmt.Printf("harbor configurations updated successfully from %s.", cfgFile)
+			fmt.Printf("harbor configurations updated successfully from %s.\n", cfgFile)
 			return nil
 		},
 	}

--- a/cmd/harbor/root/replication/start.go
+++ b/cmd/harbor/root/replication/start.go
@@ -47,7 +47,7 @@ func StartCommand() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to start replication: %v", utils.ParseHarborErrorMsg(err))
 			}
-			fmt.Printf("Repliation started successfully with ID: %s\n", response.Location)
+			fmt.Printf("Replication started successfully with ID: %s\n", response.Location)
 			return nil
 		},
 	}


### PR DESCRIPTION
Closes #1041

### Summary
This PR applies formatting and spelling polish to two CLI commands:
- Fixes a typo in `replication start` output ("Repliation" -> "Replication").
- Adds a missing trailing newline in `config apply` success print statement to prevent shell prompt overlap.
Signed-off-by: saiashok103@gmail.com