### PR TITLE
fix(config): support nested configurations in config apply

### DIFF
--- a/cmd/harbor/root/configurations/apply.go
+++ b/cmd/harbor/root/configurations/apply.go
@@ -54,12 +54,22 @@ Make sure to run 'harbor config get' first to populate the local config file wit
 				fileType := filepath.Ext(cfgFile)
 				switch fileType {
 				case ".yaml", ".yml":
-					if err := yaml.Unmarshal(data, &configurations); err != nil {
-						return fmt.Errorf("failed to parse YAML: %v", err)
+					var wrapper configWrapper
+					if err := yaml.Unmarshal(data, &wrapper); err == nil && wrapper.Configurations != nil {
+						configurations = wrapper.Configurations
+					} else {
+						if err := yaml.Unmarshal(data, &configurations); err != nil {
+							return fmt.Errorf("failed to parse YAML: %v", err)
+						}
 					}
 				case ".json":
-					if err := json.Unmarshal(data, &configurations); err != nil {
-						return fmt.Errorf("failed to parse JSON: %v", err)
+					var wrapper configWrapper
+					if err := json.Unmarshal(data, &wrapper); err == nil && wrapper.Configurations != nil {
+						configurations = wrapper.Configurations
+					} else {
+						if err := json.Unmarshal(data, &configurations); err != nil {
+							return fmt.Errorf("failed to parse JSON: %v", err)
+						}
 					}
 				default:
 					return fmt.Errorf("unsupported file type: %s, expected '.yaml/.yml' or '.json'", fileType)
@@ -124,4 +134,8 @@ Make sure to run 'harbor config get' first to populate the local config file wit
 	flags.BoolVarP(&skipConfirm, "yes", "y", false, "Skip confirmation prompt before applying changes.")
 
 	return cmd
+}
+
+type configWrapper struct {
+	Configurations *models.Configurations `yaml:"configurations" json:"configurations"`
 }

--- a/cmd/harbor/root/configurations/apply.go
+++ b/cmd/harbor/root/configurations/apply.go
@@ -54,22 +54,14 @@ Make sure to run 'harbor config get' first to populate the local config file wit
 				fileType := filepath.Ext(cfgFile)
 				switch fileType {
 				case ".yaml", ".yml":
-					var wrapper configWrapper
-					if err := yaml.Unmarshal(data, &wrapper); err == nil && wrapper.Configurations != nil {
-						configurations = wrapper.Configurations
-					} else {
-						if err := yaml.Unmarshal(data, &configurations); err != nil {
-							return fmt.Errorf("failed to parse YAML: %v", err)
-						}
+					configurations, err = parseYAMLConfig(data)
+					if err != nil {
+						return err
 					}
 				case ".json":
-					var wrapper configWrapper
-					if err := json.Unmarshal(data, &wrapper); err == nil && wrapper.Configurations != nil {
-						configurations = wrapper.Configurations
-					} else {
-						if err := json.Unmarshal(data, &configurations); err != nil {
-							return fmt.Errorf("failed to parse JSON: %v", err)
-						}
+					configurations, err = parseJSONConfig(data)
+					if err != nil {
+						return err
 					}
 				default:
 					return fmt.Errorf("unsupported file type: %s, expected '.yaml/.yml' or '.json'", fileType)
@@ -138,4 +130,71 @@ Make sure to run 'harbor config get' first to populate the local config file wit
 
 type configWrapper struct {
 	Configurations *models.Configurations `yaml:"configurations" json:"configurations"`
+}
+
+// parseYAMLConfig parses a YAML configuration file into *models.Configurations.
+//
+// If the file contains a top-level "configurations" key (the documented wrapped
+// format), that key is decoded exclusively. A malformed wrapper (e.g. wrong
+// value type under "configurations") is treated as a fatal error so it cannot
+// silently fall back and produce an empty no-op apply.
+//
+// If no "configurations" key is present the file is treated as a legacy flat
+// configuration document for backward compatibility.
+func parseYAMLConfig(data []byte) (*models.Configurations, error) {
+	// Use a raw map to detect whether the top-level "configurations" key exists.
+	var rawMap map[string]interface{}
+	if err := yaml.Unmarshal(data, &rawMap); err != nil {
+		return nil, fmt.Errorf("failed to parse YAML: %v", err)
+	}
+
+	if _, hasWrapper := rawMap["configurations"]; hasWrapper {
+		// Wrapped format: decode strictly into configWrapper.
+		var wrapper configWrapper
+		if err := yaml.Unmarshal(data, &wrapper); err != nil {
+			return nil, fmt.Errorf("failed to parse wrapped YAML configurations: %v", err)
+		}
+		if wrapper.Configurations == nil {
+			return nil, fmt.Errorf("'configurations' key is present in YAML but its value is empty or invalid")
+		}
+		return wrapper.Configurations, nil
+	}
+
+	// Legacy flat format.
+	var configurations models.Configurations
+	if err := yaml.Unmarshal(data, &configurations); err != nil {
+		return nil, fmt.Errorf("failed to parse YAML: %v", err)
+	}
+	return &configurations, nil
+}
+
+// parseJSONConfig parses a JSON configuration file into *models.Configurations.
+//
+// Same detection strategy as parseYAMLConfig: check for a top-level
+// "configurations" key and treat a malformed wrapper as fatal.
+func parseJSONConfig(data []byte) (*models.Configurations, error) {
+	// Use a raw map to detect whether the top-level "configurations" key exists.
+	var rawMap map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMap); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON: %v", err)
+	}
+
+	if _, hasWrapper := rawMap["configurations"]; hasWrapper {
+		// Wrapped format: decode strictly into configWrapper.
+		var wrapper configWrapper
+		if err := json.Unmarshal(data, &wrapper); err != nil {
+			return nil, fmt.Errorf("failed to parse wrapped JSON configurations: %v", err)
+		}
+		if wrapper.Configurations == nil {
+			return nil, fmt.Errorf("'configurations' key is present in JSON but its value is empty or invalid")
+		}
+		return wrapper.Configurations, nil
+	}
+
+	// Legacy flat format.
+	var configurations models.Configurations
+	if err := json.Unmarshal(data, &configurations); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON: %v", err)
+	}
+	return &configurations, nil
 }

--- a/cmd/harbor/root/configurations/apply_test.go
+++ b/cmd/harbor/root/configurations/apply_test.go
@@ -1,0 +1,101 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configurations
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/goharbor/harbor-cli/pkg/testutil"
+	"github.com/spf13/cobra"
+)
+
+func TestApplyConfigCmd_Metadata(t *testing.T) {
+	cmd := ApplyConfigCmd()
+
+	if cmd == nil {
+		t.Fatal("command should not be nil")
+	}
+
+	if cmd.Use != "apply" {
+		t.Fatalf("expected command 'apply', got %s", cmd.Use)
+	}
+
+	if cmd.Short == "" {
+		t.Fatal("Short description should not be empty")
+	}
+}
+
+func TestApplyConfigCmd_RunExists(t *testing.T) {
+	cmd := ApplyConfigCmd()
+
+	if cmd.RunE == nil {
+		t.Fatal("Run function should be defined")
+	}
+}
+
+func TestApplyConfigCmd_IsCobraCommand(t *testing.T) {
+	cmd := ApplyConfigCmd()
+
+	if _, ok := interface{}(cmd).(*cobra.Command); !ok {
+		t.Fatal("expected cobra command")
+	}
+}
+
+func TestApplyConfigCmd_Errors(t *testing.T) {
+	tests := []struct {
+		name        string
+		flags       []string
+		expectError bool
+		errContains string
+	}{
+		{
+			name:        "no config file specified",
+			flags:       []string{},
+			expectError: true,
+			errContains: "no config file specified",
+		},
+		{
+			name:        "extra arguments",
+			flags:       []string{"-f", "test.yaml", "extra-arg"},
+			expectError: true,
+		},
+		{
+			name:        "unknown flag",
+			flags:       []string{"--invalid-flag"},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := testutil.TestCmd(t, ApplyConfigCmd, tt.flags...)
+
+			if tt.expectError && err == nil {
+				t.Fatalf("expected error but got nil")
+			}
+
+			if !tt.expectError && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tt.errContains != "" && err != nil {
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Fatalf("expected error containing %q, got %q", tt.errContains, err.Error())
+				}
+			}
+		})
+	}
+}

--- a/cmd/harbor/root/configurations/apply_test.go
+++ b/cmd/harbor/root/configurations/apply_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// --- Command metadata tests ---
+
 func TestApplyConfigCmd_Metadata(t *testing.T) {
 	cmd := ApplyConfigCmd()
 
@@ -95,6 +97,197 @@ func TestApplyConfigCmd_Errors(t *testing.T) {
 				if !strings.Contains(err.Error(), tt.errContains) {
 					t.Fatalf("expected error containing %q, got %q", tt.errContains, err.Error())
 				}
+			}
+		})
+	}
+}
+
+// --- YAML parsing regression tests (fixes #1023) ---
+//
+// These tests directly exercise parseYAMLConfig to verify that:
+//   - the documented wrapped format (configurations: ...) is parsed correctly
+//   - a malformed wrapped file (wrong type under "configurations") is rejected
+//     with an error and does NOT silently fall back to a no-op flat parse
+//   - legacy flat files continue to work for backward compatibility
+//   - an empty "configurations" key is an explicit error
+
+func TestParseYAMLConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantErr     bool
+		errContains string
+		// checkResult is called only when wantErr is false.
+		checkResult func(t *testing.T, got interface{})
+	}{
+		{
+			name: "valid wrapped YAML",
+			input: `
+configurations:
+  auth_mode: db_auth
+`,
+			wantErr: false,
+			checkResult: func(t *testing.T, got interface{}) {
+				if got == nil {
+					t.Fatal("expected non-nil configurations")
+				}
+			},
+		},
+		{
+			// Regression test for #1023: a file that starts with "configurations:"
+			// but has an invalid value type must NOT silently succeed and produce
+			// a no-op apply.
+			name: "malformed wrapped YAML — configurations is a scalar not a map",
+			input: `
+configurations: "this should be a map"
+`,
+			wantErr:     true,
+			errContains: "configurations",
+		},
+		{
+			// Regression test for #1023: a list under configurations must be rejected.
+			name: "malformed wrapped YAML — configurations is a list not a map",
+			input: `
+configurations:
+  - invalid_list_item
+`,
+			wantErr:     true,
+			errContains: "configurations",
+		},
+		{
+			// Legacy flat files must continue to work (backward compatibility).
+			name: "legacy flat YAML",
+			input: `
+auth_mode: db_auth
+`,
+			wantErr: false,
+			checkResult: func(t *testing.T, got interface{}) {
+				if got == nil {
+					t.Fatal("expected non-nil configurations")
+				}
+			},
+		},
+		{
+			// "configurations:" with a null/empty value must return an error,
+			// not an empty configurations object that silently no-ops.
+			name:        "empty configurations key in YAML",
+			input:       "configurations:\n",
+			wantErr:     true,
+			errContains: "configurations",
+		},
+		{
+			name:        "invalid YAML syntax",
+			input:       ":\t: invalid yaml :::",
+			wantErr:     true,
+			errContains: "failed to parse YAML",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseYAMLConfig([]byte(tt.input))
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Fatalf("expected error containing %q, got: %v", tt.errContains, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.checkResult != nil {
+				tt.checkResult(t, got)
+			}
+		})
+	}
+}
+
+// --- JSON parsing regression tests (fixes #1023) ---
+
+func TestParseJSONConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantErr     bool
+		errContains string
+		checkResult func(t *testing.T, got interface{})
+	}{
+		{
+			name:    "valid wrapped JSON",
+			input:   `{"configurations": {"auth_mode": "db_auth"}}`,
+			wantErr: false,
+			checkResult: func(t *testing.T, got interface{}) {
+				if got == nil {
+					t.Fatal("expected non-nil configurations")
+				}
+			},
+		},
+		{
+			// Regression test for #1023: "configurations" pointing to a scalar
+			// must be rejected, not silently treated as empty.
+			name:        "malformed wrapped JSON — configurations is a string not an object",
+			input:       `{"configurations": "not-an-object"}`,
+			wantErr:     true,
+			errContains: "configurations",
+		},
+		{
+			// Regression test for #1023: "configurations" pointing to a list
+			// must be rejected.
+			name:        "malformed wrapped JSON — configurations is an array",
+			input:       `{"configurations": ["a", "b"]}`,
+			wantErr:     true,
+			errContains: "configurations",
+		},
+		{
+			// Legacy flat files must continue to work (backward compatibility).
+			name:    "legacy flat JSON",
+			input:   `{"auth_mode": "db_auth"}`,
+			wantErr: false,
+			checkResult: func(t *testing.T, got interface{}) {
+				if got == nil {
+					t.Fatal("expected non-nil configurations")
+				}
+			},
+		},
+		{
+			// "configurations": null must return an error.
+			name:        "null configurations value in JSON",
+			input:       `{"configurations": null}`,
+			wantErr:     true,
+			errContains: "configurations",
+		},
+		{
+			name:        "invalid JSON syntax",
+			input:       `{not valid json`,
+			wantErr:     true,
+			errContains: "failed to parse JSON",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseJSONConfig([]byte(tt.input))
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Fatalf("expected error containing %q, got: %v", tt.errContains, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.checkResult != nil {
+				tt.checkResult(t, got)
 			}
 		})
 	}


### PR DESCRIPTION
## Description
This pull request resolves an issue where the `harbor config apply` command fails silently when applying configuration files that nest configuration parameters under a top-level `configurations:` key.

The unmarshaling block has been updated to attempt to parse the wrapped structure first, falling back to flat parsing if the wrapper is absent, ensuring full backward compatibility.

- Fixes #1023 

## Type of Change
Please select the relevant type.

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
- Defined `configWrapper` helper struct in `apply.go` to match the nested configurations block.
- Updated JSON/YAML unmarshaling blocks in `cmd/harbor/root/configurations/apply.go` to attempt wrapper unmarshaling first and fall back to direct unmarshaling on failure or nil.
- Created `cmd/harbor/root/configurations/apply_test.go` implementing metadata validation and CLI-level error checks using `testutil.TestCmd`.

