### PR TITLE
docs: update Go and Windows build instructions in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,12 +34,20 @@ source ~/.zshrc # or restart your terminal
 
 ### Build from Source
 
-Make sure [Go](https://go.dev/) is installed (≥ v1.24).
+Make sure [Go](https://go.dev/) is installed (≥ v1.26.3), matching the version declared in `go.mod`.
 
 ```bash
 git clone https://github.com/goharbor/harbor-cli.git && cd harbor-cli
 go build -o harbor-cli cmd/harbor/main.go
 ./harbor-cli --help
+```
+
+On Windows, use PowerShell commands and build the executable with the `.exe` suffix:
+
+```powershell
+git clone https://github.com/goharbor/harbor-cli.git; cd harbor-cli
+go build -o bin/harbor-cli.exe cmd/harbor/main.go
+.\bin\harbor-cli.exe --help
 ```
 
 Alternatively, use [Dagger](https://docs.dagger.io/) for isolated builds:


### PR DESCRIPTION
## Summary

This updates the Build from Source section in CONTRIBUTING.md so it matches the Go version currently declared in go.mod.

It also adds a short Windows PowerShell example so Windows contributors have a clear build and run path for harbor-cli.exe.

## Testing

Not run, documentation-only change.

Closes #1012