### PR TITLE
fix(info): prevent nil pointer panic when volumes payload is absent

### DIFF
--- a/pkg/views/info/list/view.go
+++ b/pkg/views/info/list/view.go
@@ -71,13 +71,13 @@ func CreateSystemInfo(
 		SystemInfo: generalInfo,
 		VolumeInfo: &Volumes{
 			Free: func() uint64 {
-				if volumes.Storage != nil && len(volumes.Storage) > 0 {
+				if volumes != nil && volumes.Storage != nil && len(volumes.Storage) > 0 {
 					return volumes.Storage[0].Free
 				}
 				return 0
 			}(),
 			Total: func() uint64 {
-				if volumes.Storage != nil && len(volumes.Storage) > 0 {
+				if volumes != nil && volumes.Storage != nil && len(volumes.Storage) > 0 {
 					return volumes.Storage[0].Total
 				}
 				return 0

--- a/pkg/views/info/list/view_test.go
+++ b/pkg/views/info/list/view_test.go
@@ -1,0 +1,66 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package list
+
+import (
+	"testing"
+
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateSystemInfo_WithVolumes(t *testing.T) {
+	generalInfo := &models.GeneralInfo{}
+	stats := &models.Statistic{}
+	volumes := &models.SystemInfo{
+		Storage: []*models.Storage{
+			{
+				Free:  1000,
+				Total: 5000,
+			},
+		},
+	}
+	cliInfo := &api.CLIInfo{
+		Username:           "admin",
+		RegistryAddress:    "localhost",
+		IsSysAdmin:         true,
+		PreviouslyLoggedIn: []string{},
+	}
+
+	result := CreateSystemInfo(generalInfo, stats, volumes, cliInfo, "v1.0.0", "linux")
+
+	assert.NotNil(t, result.VolumeInfo)
+	assert.Equal(t, uint64(1000), result.VolumeInfo.Free)
+	assert.Equal(t, uint64(5000), result.VolumeInfo.Total)
+}
+
+func TestCreateSystemInfo_NilVolumes(t *testing.T) {
+	generalInfo := &models.GeneralInfo{}
+	stats := &models.Statistic{}
+	var volumes *models.SystemInfo // Simulate missing payload
+
+	cliInfo := &api.CLIInfo{
+		Username:           "admin",
+		RegistryAddress:    "localhost",
+		IsSysAdmin:         true,
+		PreviouslyLoggedIn: []string{},
+	}
+
+	result := CreateSystemInfo(generalInfo, stats, volumes, cliInfo, "v1.0.0", "linux")
+
+	assert.NotNil(t, result.VolumeInfo)
+	assert.Equal(t, uint64(0), result.VolumeInfo.Free)
+	assert.Equal(t, uint64(0), result.VolumeInfo.Total)
+}


### PR DESCRIPTION
## Description

This PR fixes a nil pointer dereference in `harbor info` when the Harbor server returns a `SystemInfo` response without storage information.

The current implementation assumes the `volumes` pointer is always non-nil before accessing `volumes.Storage`, which can lead to a runtime panic when the API returns an incomplete response.

This change adds a nil guard before accessing the storage information so the command returns zero values instead of crashing.

Fixes #1031

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes

- Added a nil check before accessing `volumes.Storage`.
- Prevented a nil pointer dereference when `SystemInfo.Volumes` is nil.
- Preserved existing behavior for valid responses.

## Testing

- [x] Verified the code path.
- [x] Existing behavior remains unchanged for valid responses.
