### PR TITLE
feat(user): implement user update command

### DIFF
--- a/cmd/harbor/root/user/cmd.go
+++ b/cmd/harbor/root/user/cmd.go
@@ -31,6 +31,7 @@ func User() *cobra.Command {
 		UserDeleteCmd(),
 		ElevateUserCmd(),
 		UserPasswordChangeCmd(),
+		UserUpdateCmd(),
 	)
 
 	return cmd

--- a/cmd/harbor/root/user/update.go
+++ b/cmd/harbor/root/user/update.go
@@ -96,10 +96,9 @@ func UserUpdateCmd() *cobra.Command {
 
 			if err != nil {
 				if isUnauthorizedError(err) {
-					return fmt.Errorf("Permission denied: Admin privileges are required to execute this command.")
-				} else {
-					return fmt.Errorf("failed to update user: %v", err)
+					return fmt.Errorf("permission denied: admin privileges are required to execute this command")
 				}
+				return fmt.Errorf("failed to update user: %v", err)
 			}
 			return nil
 		},

--- a/cmd/harbor/root/user/update.go
+++ b/cmd/harbor/root/user/update.go
@@ -1,0 +1,119 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package user
+
+import (
+	"fmt"
+	"net/mail"
+
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/prompt"
+	"github.com/goharbor/harbor-cli/pkg/views/user/update"
+	"github.com/spf13/cobra"
+)
+
+func UserUpdateCmd() *cobra.Command {
+	var opts update.UpdateView
+
+	cmd := &cobra.Command{
+		Use:   "update [USER_NAME_OR_ID]",
+		Short: "update user profile",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+			var userID int64
+			var existingUser *models.UserResp
+
+			if len(args) > 0 {
+				existingUser, err = api.GetUserByIDOrName(args[0])
+				if err != nil {
+					return err
+				}
+				userID = existingUser.UserID
+			} else {
+				// Interactive mode: select user from list
+				userID, err = prompt.GetUserIdFromUser()
+				if err != nil {
+					return fmt.Errorf("failed to get user id: %v", err)
+				}
+				existingUser, err = api.GetUserByID(userID)
+				if err != nil {
+					return err
+				}
+			}
+
+			// If flags are provided, run non-interactively using the flags
+			// If no flags are provided, open interactive UpdateView
+			emailFlagSelected := cmd.Flags().Changed("email")
+			realnameFlagSelected := cmd.Flags().Changed("realname")
+			commentFlagSelected := cmd.Flags().Changed("comment")
+
+			if emailFlagSelected || realnameFlagSelected || commentFlagSelected {
+				// In non-interactive mode, use existing user values for flags not specified
+				email := existingUser.Email
+				if emailFlagSelected {
+					email = opts.Email
+				}
+				realname := existingUser.Realname
+				if realnameFlagSelected {
+					realname = opts.Realname
+				}
+				comment := existingUser.Comment
+				if commentFlagSelected {
+					comment = opts.Comment
+				}
+
+				// Validate email format if it changed
+				if email != "" && email != existingUser.Email {
+					addr, err := mail.ParseAddress(email)
+					if err != nil || addr.Address != email {
+						return fmt.Errorf("invalid email format: %q", email)
+					}
+				}
+
+				err = api.UpdateUserProfile(userID, email, realname, comment)
+			} else {
+				// Interactive mode
+				updateView := &update.UpdateView{
+					Email:    existingUser.Email,
+					Realname: existingUser.Realname,
+					Comment:  existingUser.Comment,
+				}
+				err = updateUserView(userID, updateView)
+			}
+
+			if err != nil {
+				if isUnauthorizedError(err) {
+					return fmt.Errorf("Permission denied: Admin privileges are required to execute this command.")
+				} else {
+					return fmt.Errorf("failed to update user: %v", err)
+				}
+			}
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.Email, "email", "", "", "Email")
+	flags.StringVarP(&opts.Realname, "realname", "", "", "Realname")
+	flags.StringVarP(&opts.Comment, "comment", "", "", "Comment")
+
+	return cmd
+}
+
+func updateUserView(userID int64, updateView *update.UpdateView) error {
+	update.UpdateUserView(updateView)
+	return api.UpdateUserProfile(userID, updateView.Email, updateView.Realname, updateView.Comment)
+}

--- a/cmd/harbor/root/user/update.go
+++ b/cmd/harbor/root/user/update.go
@@ -28,9 +28,11 @@ func UserUpdateCmd() *cobra.Command {
 	var opts update.UpdateView
 
 	cmd := &cobra.Command{
-		Use:   "update [USER_NAME_OR_ID]",
-		Short: "update user profile",
-		Args:  cobra.MaximumNArgs(1),
+		Use:     "update [USER_NAME_OR_ID]",
+		Short:   "update user profile",
+		Long:    `The 'update' command allows sysadmins to modify an existing user's profile information, such as their email, realname, or comment.`,
+		Example: `  harbor user update admin --email newadmin@example.com --realname "System Admin"`,
+		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			var userID int64
@@ -52,6 +54,15 @@ func UserUpdateCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
+			}
+
+			cliInfo, err := api.GetCLIInfo()
+			if err != nil {
+				return err
+			}
+
+			if !cliInfo.IsSysAdmin && cliInfo.Username != existingUser.Username {
+				return fmt.Errorf("permission denied: admin privileges are required to view or update other users")
 			}
 
 			// If flags are provided, run non-interactively using the flags
@@ -95,9 +106,6 @@ func UserUpdateCmd() *cobra.Command {
 			}
 
 			if err != nil {
-				if isUnauthorizedError(err) {
-					return fmt.Errorf("permission denied: admin privileges are required to execute this command")
-				}
 				return fmt.Errorf("failed to update user: %v", err)
 			}
 			return nil

--- a/cmd/harbor/root/user/update.go
+++ b/cmd/harbor/root/user/update.go
@@ -24,6 +24,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	getUserByIDOrNameFunc = api.GetUserByIDOrName
+	getUserIdFromUserFunc = prompt.GetUserIdFromUser
+	getUserByIDFunc       = api.GetUserByID
+	getCLIInfoFunc        = api.GetCLIInfo
+	updateUserProfileFunc = api.UpdateUserProfile
+	runUpdateUserViewFunc = update.UpdateUserView
+)
+
 func UserUpdateCmd() *cobra.Command {
 	var opts update.UpdateView
 
@@ -39,24 +48,24 @@ func UserUpdateCmd() *cobra.Command {
 			var existingUser *models.UserResp
 
 			if len(args) > 0 {
-				existingUser, err = api.GetUserByIDOrName(args[0])
+				existingUser, err = getUserByIDOrNameFunc(args[0])
 				if err != nil {
 					return err
 				}
 				userID = existingUser.UserID
 			} else {
 				// Interactive mode: select user from list
-				userID, err = prompt.GetUserIdFromUser()
+				userID, err = getUserIdFromUserFunc()
 				if err != nil {
 					return fmt.Errorf("failed to get user id: %v", err)
 				}
-				existingUser, err = api.GetUserByID(userID)
+				existingUser, err = getUserByIDFunc(userID)
 				if err != nil {
 					return err
 				}
 			}
 
-			cliInfo, err := api.GetCLIInfo()
+			cliInfo, err := getCLIInfoFunc()
 			if err != nil {
 				return err
 			}
@@ -94,7 +103,7 @@ func UserUpdateCmd() *cobra.Command {
 					}
 				}
 
-				err = api.UpdateUserProfile(userID, email, realname, comment)
+				err = updateUserProfileFunc(userID, email, realname, comment)
 			} else {
 				// Interactive mode
 				updateView := &update.UpdateView{
@@ -121,6 +130,6 @@ func UserUpdateCmd() *cobra.Command {
 }
 
 func updateUserView(userID int64, updateView *update.UpdateView) error {
-	update.UpdateUserView(updateView)
-	return api.UpdateUserProfile(userID, updateView.Email, updateView.Realname, updateView.Comment)
+	runUpdateUserViewFunc(updateView)
+	return updateUserProfileFunc(userID, updateView.Email, updateView.Realname, updateView.Comment)
 }

--- a/cmd/harbor/root/user/update.go
+++ b/cmd/harbor/root/user/update.go
@@ -53,6 +53,9 @@ func UserUpdateCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
+				if existingUser == nil {
+					return fmt.Errorf("user %q not found", args[0])
+				}
 				userID = existingUser.UserID
 			} else {
 				// Interactive mode: select user from list
@@ -63,6 +66,9 @@ func UserUpdateCmd() *cobra.Command {
 				existingUser, err = getUserByIDFunc(userID)
 				if err != nil {
 					return err
+				}
+				if existingUser == nil {
+					return fmt.Errorf("user with ID %d not found", userID)
 				}
 			}
 

--- a/cmd/harbor/root/user/update.go
+++ b/cmd/harbor/root/user/update.go
@@ -20,6 +20,7 @@ import (
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
+	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/user/update"
 	"github.com/spf13/cobra"
 )
@@ -95,12 +96,15 @@ func UserUpdateCmd() *cobra.Command {
 					comment = opts.Comment
 				}
 
-				// Validate email format if it changed
-				if email != "" && email != existingUser.Email {
+				// Validate fields explicitly provided via flags
+				if emailFlagSelected {
 					addr, err := mail.ParseAddress(email)
 					if err != nil || addr.Address != email {
 						return fmt.Errorf("invalid email format: %q", email)
 					}
+				}
+				if realnameFlagSelected && realname == "" {
+					return fmt.Errorf("realname cannot be empty")
 				}
 
 				err = updateUserProfileFunc(userID, email, realname, comment)
@@ -118,7 +122,7 @@ func UserUpdateCmd() *cobra.Command {
 			}
 
 			if err != nil {
-				return fmt.Errorf("failed to update user: %v", err)
+				return fmt.Errorf("failed to update user: %v", utils.ParseHarborErrorMsg(err))
 			}
 			return nil
 		},

--- a/cmd/harbor/root/user/update.go
+++ b/cmd/harbor/root/user/update.go
@@ -141,4 +141,3 @@ func UserUpdateCmd() *cobra.Command {
 
 	return cmd
 }
-

--- a/cmd/harbor/root/user/update.go
+++ b/cmd/harbor/root/user/update.go
@@ -111,7 +111,10 @@ func UserUpdateCmd() *cobra.Command {
 					Realname: existingUser.Realname,
 					Comment:  existingUser.Comment,
 				}
-				err = updateUserView(userID, updateView)
+				err = runUpdateUserViewFunc(updateView)
+				if err == nil {
+					err = updateUserProfileFunc(userID, updateView.Email, updateView.Realname, updateView.Comment)
+				}
 			}
 
 			if err != nil {
@@ -129,7 +132,3 @@ func UserUpdateCmd() *cobra.Command {
 	return cmd
 }
 
-func updateUserView(userID int64, updateView *update.UpdateView) error {
-	runUpdateUserViewFunc(updateView)
-	return updateUserProfileFunc(userID, updateView.Email, updateView.Realname, updateView.Comment)
-}

--- a/cmd/harbor/root/user/update_test.go
+++ b/cmd/harbor/root/user/update_test.go
@@ -1,0 +1,71 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package user
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestUserUpdateCmd_Metadata(t *testing.T) {
+	cmd := UserUpdateCmd()
+
+	if cmd == nil {
+		t.Fatal("command should not be nil")
+	}
+
+	if cmd.Use != "update [USER_NAME_OR_ID]" {
+		t.Fatalf("expected command 'update [USER_NAME_OR_ID]', got %s", cmd.Use)
+	}
+
+	if cmd.Short == "" {
+		t.Fatal("Short description should not be empty")
+	}
+}
+
+func TestUserUpdateCmd_RunExists(t *testing.T) {
+	cmd := UserUpdateCmd()
+
+	if cmd.RunE == nil {
+		t.Fatal("Run function should be defined")
+	}
+}
+
+func TestUserUpdateCmd_IsCobraCommand(t *testing.T) {
+	cmd := UserUpdateCmd()
+
+	if _, ok := interface{}(cmd).(*cobra.Command); !ok {
+		t.Fatal("expected cobra command")
+	}
+}
+
+func TestUserUpdateCmd_Flags(t *testing.T) {
+	cmd := UserUpdateCmd()
+
+	emailFlag := cmd.Flags().Lookup("email")
+	if emailFlag == nil {
+		t.Fatal("expected 'email' flag")
+	}
+
+	realnameFlag := cmd.Flags().Lookup("realname")
+	if realnameFlag == nil {
+		t.Fatal("expected 'realname' flag")
+	}
+
+	commentFlag := cmd.Flags().Lookup("comment")
+	if commentFlag == nil {
+		t.Fatal("expected 'comment' flag")
+	}
+}

--- a/cmd/harbor/root/user/update_test.go
+++ b/cmd/harbor/root/user/update_test.go
@@ -14,58 +14,221 @@
 package user
 
 import (
+	"fmt"
 	"testing"
 
-	"github.com/spf13/cobra"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/views/user/update"
+	"github.com/stretchr/testify/assert"
 )
+
+func mockSetup(
+	mockGetUserByIDOrName func(arg string) (*models.UserResp, error),
+	mockGetUserIdFromUser func() (int64, error),
+	mockGetUserByID func(userID int64) (*models.UserResp, error),
+	mockGetCLIInfo func() (*api.CLIInfo, error),
+	mockUpdateUserProfile func(userID int64, email, realname, comment string) error,
+	mockRunUpdateUserView func(updateView *update.UpdateView),
+) func() {
+	origGetUserByIDOrName := getUserByIDOrNameFunc
+	origGetUserIdFromUser := getUserIdFromUserFunc
+	origGetUserByID := getUserByIDFunc
+	origGetCLIInfo := getCLIInfoFunc
+	origUpdateUserProfile := updateUserProfileFunc
+	origRunUpdateUserView := runUpdateUserViewFunc
+
+	getUserByIDOrNameFunc = mockGetUserByIDOrName
+	getUserIdFromUserFunc = mockGetUserIdFromUser
+	getUserByIDFunc = mockGetUserByID
+	getCLIInfoFunc = mockGetCLIInfo
+	updateUserProfileFunc = mockUpdateUserProfile
+	runUpdateUserViewFunc = mockRunUpdateUserView
+
+	return func() {
+		getUserByIDOrNameFunc = origGetUserByIDOrName
+		getUserIdFromUserFunc = origGetUserIdFromUser
+		getUserByIDFunc = origGetUserByID
+		getCLIInfoFunc = origGetCLIInfo
+		updateUserProfileFunc = origUpdateUserProfile
+		runUpdateUserViewFunc = origRunUpdateUserView
+	}
+}
+
+func TestUserUpdateCmd_RunE(t *testing.T) {
+	defaultUser := &models.UserResp{
+		UserID:   1,
+		Username: "testuser",
+		Email:    "test@example.com",
+		Realname: "Test User",
+		Comment:  "Comment",
+	}
+	defaultCLIInfo := &api.CLIInfo{
+		IsSysAdmin: true,
+		Username:   "admin",
+	}
+
+	tests := []struct {
+		name        string
+		args        []string
+		flags       map[string]string
+		setupMocks  func() func()
+		expectedErr string
+	}{
+		{
+			name: "non-interactive with valid flags",
+			args: []string{"testuser"},
+			flags: map[string]string{
+				"email":    "new@example.com",
+				"realname": "New Name",
+				"comment":  "New Comment",
+			},
+			setupMocks: func() func() {
+				return mockSetup(
+					func(arg string) (*models.UserResp, error) { return defaultUser, nil },
+					func() (int64, error) { return 0, nil },
+					func(userID int64) (*models.UserResp, error) { return defaultUser, nil },
+					func() (*api.CLIInfo, error) { return defaultCLIInfo, nil },
+					func(userID int64, email, realname, comment string) error {
+						if email != "new@example.com" {
+							return fmt.Errorf("wrong email")
+						}
+						return nil
+					},
+					func(updateView *update.UpdateView) {},
+				)
+			},
+			expectedErr: "",
+		},
+		{
+			name:  "interactive mode fallback",
+			args:  []string{},
+			flags: map[string]string{},
+			setupMocks: func() func() {
+				return mockSetup(
+					func(arg string) (*models.UserResp, error) { return nil, nil },
+					func() (int64, error) { return 1, nil },
+					func(userID int64) (*models.UserResp, error) { return defaultUser, nil },
+					func() (*api.CLIInfo, error) { return defaultCLIInfo, nil },
+					func(userID int64, email, realname, comment string) error { return nil },
+					func(updateView *update.UpdateView) {
+						updateView.Email = "interactive@example.com"
+					},
+				)
+			},
+			expectedErr: "",
+		},
+		{
+			name: "invalid email format",
+			args: []string{"testuser"},
+			flags: map[string]string{
+				"email": "invalid-email",
+			},
+			setupMocks: func() func() {
+				return mockSetup(
+					func(arg string) (*models.UserResp, error) { return defaultUser, nil },
+					func() (int64, error) { return 0, nil },
+					func(userID int64) (*models.UserResp, error) { return defaultUser, nil },
+					func() (*api.CLIInfo, error) { return defaultCLIInfo, nil },
+					func(userID int64, email, realname, comment string) error { return nil },
+					func(updateView *update.UpdateView) {},
+				)
+			},
+			expectedErr: "invalid email format",
+		},
+		{
+			name: "permission denied for non-admin",
+			args: []string{"testuser"},
+			flags: map[string]string{
+				"email": "new@example.com",
+			},
+			setupMocks: func() func() {
+				return mockSetup(
+					func(arg string) (*models.UserResp, error) { return defaultUser, nil },
+					func() (int64, error) { return 0, nil },
+					func(userID int64) (*models.UserResp, error) { return defaultUser, nil },
+					func() (*api.CLIInfo, error) {
+						return &api.CLIInfo{IsSysAdmin: false, Username: "otheruser"}, nil
+					},
+					func(userID int64, email, realname, comment string) error { return nil },
+					func(updateView *update.UpdateView) {},
+				)
+			},
+			expectedErr: "permission denied",
+		},
+		{
+			name: "self update for non-admin",
+			args: []string{"testuser"},
+			flags: map[string]string{
+				"email": "new@example.com",
+			},
+			setupMocks: func() func() {
+				return mockSetup(
+					func(arg string) (*models.UserResp, error) { return defaultUser, nil },
+					func() (int64, error) { return 0, nil },
+					func(userID int64) (*models.UserResp, error) { return defaultUser, nil },
+					func() (*api.CLIInfo, error) {
+						return &api.CLIInfo{IsSysAdmin: false, Username: "testuser"}, nil
+					},
+					func(userID int64, email, realname, comment string) error { return nil },
+					func(updateView *update.UpdateView) {},
+				)
+			},
+			expectedErr: "",
+		},
+		{
+			name:  "user resolution error",
+			args:  []string{"testuser"},
+			flags: map[string]string{},
+			setupMocks: func() func() {
+				return mockSetup(
+					func(arg string) (*models.UserResp, error) { return nil, fmt.Errorf("user not found") },
+					func() (int64, error) { return 0, nil },
+					func(userID int64) (*models.UserResp, error) { return nil, nil },
+					func() (*api.CLIInfo, error) { return defaultCLIInfo, nil },
+					func(userID int64, email, realname, comment string) error { return nil },
+					func(updateView *update.UpdateView) {},
+				)
+			},
+			expectedErr: "user not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cleanup := tt.setupMocks()
+			defer cleanup()
+
+			cmd := UserUpdateCmd()
+			for k, v := range tt.flags {
+				err := cmd.Flags().Set(k, v)
+				assert.NoError(t, err)
+			}
+
+			err := cmd.RunE(cmd, tt.args)
+			if tt.expectedErr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
 
 func TestUserUpdateCmd_Metadata(t *testing.T) {
 	cmd := UserUpdateCmd()
-
-	if cmd == nil {
-		t.Fatal("command should not be nil")
-	}
-
-	if cmd.Use != "update [USER_NAME_OR_ID]" {
-		t.Fatalf("expected command 'update [USER_NAME_OR_ID]', got %s", cmd.Use)
-	}
-
-	if cmd.Short == "" {
-		t.Fatal("Short description should not be empty")
-	}
-}
-
-func TestUserUpdateCmd_RunExists(t *testing.T) {
-	cmd := UserUpdateCmd()
-
-	if cmd.RunE == nil {
-		t.Fatal("Run function should be defined")
-	}
-}
-
-func TestUserUpdateCmd_IsCobraCommand(t *testing.T) {
-	cmd := UserUpdateCmd()
-
-	if _, ok := interface{}(cmd).(*cobra.Command); !ok {
-		t.Fatal("expected cobra command")
-	}
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "update [USER_NAME_OR_ID]", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
+	assert.NotEmpty(t, cmd.Long)
+	assert.NotEmpty(t, cmd.Example)
+	assert.NotNil(t, cmd.RunE)
 }
 
 func TestUserUpdateCmd_Flags(t *testing.T) {
 	cmd := UserUpdateCmd()
-
-	emailFlag := cmd.Flags().Lookup("email")
-	if emailFlag == nil {
-		t.Fatal("expected 'email' flag")
-	}
-
-	realnameFlag := cmd.Flags().Lookup("realname")
-	if realnameFlag == nil {
-		t.Fatal("expected 'realname' flag")
-	}
-
-	commentFlag := cmd.Flags().Lookup("comment")
-	if commentFlag == nil {
-		t.Fatal("expected 'comment' flag")
-	}
+	assert.NotNil(t, cmd.Flags().Lookup("email"))
+	assert.NotNil(t, cmd.Flags().Lookup("realname"))
+	assert.NotNil(t, cmd.Flags().Lookup("comment"))
 }

--- a/cmd/harbor/root/user/update_test.go
+++ b/cmd/harbor/root/user/update_test.go
@@ -252,6 +252,90 @@ func TestUserUpdateCmd_RunE(t *testing.T) {
 			},
 			expectedErr: "user with ID 999 not found",
 		},
+		{
+			name:  "interactive mode getUserIdFromUserFunc error",
+			args:  []string{},
+			flags: map[string]string{},
+			setupMocks: func() func() {
+				return mockSetup(
+					func(arg string) (*models.UserResp, error) { return nil, nil },
+					func() (int64, error) { return 0, fmt.Errorf("prompt error") },
+					func(userID int64) (*models.UserResp, error) { return nil, nil },
+					func() (*api.CLIInfo, error) { return defaultCLIInfo, nil },
+					func(userID int64, email, realname, comment string) error { return nil },
+					func(updateView *update.UpdateView) error { return nil },
+				)
+			},
+			expectedErr: "failed to get user id",
+		},
+		{
+			name:  "interactive mode getUserByIDFunc error",
+			args:  []string{},
+			flags: map[string]string{},
+			setupMocks: func() func() {
+				return mockSetup(
+					func(arg string) (*models.UserResp, error) { return nil, nil },
+					func() (int64, error) { return 1, nil },
+					func(userID int64) (*models.UserResp, error) { return nil, fmt.Errorf("api error") },
+					func() (*api.CLIInfo, error) { return defaultCLIInfo, nil },
+					func(userID int64, email, realname, comment string) error { return nil },
+					func(updateView *update.UpdateView) error { return nil },
+				)
+			},
+			expectedErr: "api error",
+		},
+		{
+			name:  "getCLIInfoFunc error",
+			args:  []string{"testuser"},
+			flags: map[string]string{},
+			setupMocks: func() func() {
+				return mockSetup(
+					func(arg string) (*models.UserResp, error) { return defaultUser, nil },
+					func() (int64, error) { return 0, nil },
+					func(userID int64) (*models.UserResp, error) { return nil, nil },
+					func() (*api.CLIInfo, error) { return nil, fmt.Errorf("cli info error") },
+					func(userID int64, email, realname, comment string) error { return nil },
+					func(updateView *update.UpdateView) error { return nil },
+				)
+			},
+			expectedErr: "cli info error",
+		},
+		{
+			name: "realname flag empty",
+			args: []string{"testuser"},
+			flags: map[string]string{
+				"realname": "",
+			},
+			setupMocks: func() func() {
+				return mockSetup(
+					func(arg string) (*models.UserResp, error) { return defaultUser, nil },
+					func() (int64, error) { return 0, nil },
+					func(userID int64) (*models.UserResp, error) { return nil, nil },
+					func() (*api.CLIInfo, error) { return defaultCLIInfo, nil },
+					func(userID int64, email, realname, comment string) error { return nil },
+					func(updateView *update.UpdateView) error { return nil },
+				)
+			},
+			expectedErr: "realname cannot be empty",
+		},
+		{
+			name: "updateUserProfileFunc error",
+			args: []string{"testuser"},
+			flags: map[string]string{
+				"comment": "New Comment",
+			},
+			setupMocks: func() func() {
+				return mockSetup(
+					func(arg string) (*models.UserResp, error) { return defaultUser, nil },
+					func() (int64, error) { return 0, nil },
+					func(userID int64) (*models.UserResp, error) { return nil, nil },
+					func() (*api.CLIInfo, error) { return defaultCLIInfo, nil },
+					func(userID int64, email, realname, comment string) error { return fmt.Errorf("update error") },
+					func(updateView *update.UpdateView) error { return nil },
+				)
+			},
+			expectedErr: "failed to update user: update error",
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/harbor/root/user/update_test.go
+++ b/cmd/harbor/root/user/update_test.go
@@ -220,6 +220,38 @@ func TestUserUpdateCmd_RunE(t *testing.T) {
 			},
 			expectedErr: "user not found",
 		},
+		{
+			name:  "user resolution returns nil without error",
+			args:  []string{"testuser"},
+			flags: map[string]string{},
+			setupMocks: func() func() {
+				return mockSetup(
+					func(arg string) (*models.UserResp, error) { return nil, nil }, // returns nil, nil
+					func() (int64, error) { return 0, nil },
+					func(userID int64) (*models.UserResp, error) { return nil, nil },
+					func() (*api.CLIInfo, error) { return defaultCLIInfo, nil },
+					func(userID int64, email, realname, comment string) error { return nil },
+					func(updateView *update.UpdateView) error { return nil },
+				)
+			},
+			expectedErr: "user \"testuser\" not found",
+		},
+		{
+			name:  "interactive mode user returns nil without error",
+			args:  []string{},
+			flags: map[string]string{},
+			setupMocks: func() func() {
+				return mockSetup(
+					func(arg string) (*models.UserResp, error) { return nil, nil },
+					func() (int64, error) { return 999, nil },
+					func(userID int64) (*models.UserResp, error) { return nil, nil }, // returns nil, nil
+					func() (*api.CLIInfo, error) { return defaultCLIInfo, nil },
+					func(userID int64, email, realname, comment string) error { return nil },
+					func(updateView *update.UpdateView) error { return nil },
+				)
+			},
+			expectedErr: "user with ID 999 not found",
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/harbor/root/user/update_test.go
+++ b/cmd/harbor/root/user/update_test.go
@@ -29,7 +29,7 @@ func mockSetup(
 	mockGetUserByID func(userID int64) (*models.UserResp, error),
 	mockGetCLIInfo func() (*api.CLIInfo, error),
 	mockUpdateUserProfile func(userID int64, email, realname, comment string) error,
-	mockRunUpdateUserView func(updateView *update.UpdateView),
+	mockRunUpdateUserView func(updateView *update.UpdateView) error,
 ) func() {
 	origGetUserByIDOrName := getUserByIDOrNameFunc
 	origGetUserIdFromUser := getUserIdFromUserFunc
@@ -95,7 +95,34 @@ func TestUserUpdateCmd_RunE(t *testing.T) {
 						}
 						return nil
 					},
-					func(updateView *update.UpdateView) {},
+					func(updateView *update.UpdateView) error { return nil },
+				)
+			},
+			expectedErr: "",
+		},
+		{
+			name: "non-interactive with realname and comment flags only",
+			args: []string{"testuser"},
+			flags: map[string]string{
+				"realname": "New Name Only",
+				"comment":  "New Comment Only",
+			},
+			setupMocks: func() func() {
+				return mockSetup(
+					func(arg string) (*models.UserResp, error) { return defaultUser, nil },
+					func() (int64, error) { return 0, nil },
+					func(userID int64) (*models.UserResp, error) { return defaultUser, nil },
+					func() (*api.CLIInfo, error) { return defaultCLIInfo, nil },
+					func(userID int64, email, realname, comment string) error {
+						if realname != "New Name Only" {
+							return fmt.Errorf("wrong realname")
+						}
+						if email != "test@example.com" { // should be existing user's email
+							return fmt.Errorf("email should be unchanged")
+						}
+						return nil
+					},
+					func(updateView *update.UpdateView) error { return nil },
 				)
 			},
 			expectedErr: "",
@@ -111,8 +138,9 @@ func TestUserUpdateCmd_RunE(t *testing.T) {
 					func(userID int64) (*models.UserResp, error) { return defaultUser, nil },
 					func() (*api.CLIInfo, error) { return defaultCLIInfo, nil },
 					func(userID int64, email, realname, comment string) error { return nil },
-					func(updateView *update.UpdateView) {
+					func(updateView *update.UpdateView) error {
 						updateView.Email = "interactive@example.com"
+						return nil
 					},
 				)
 			},
@@ -131,7 +159,7 @@ func TestUserUpdateCmd_RunE(t *testing.T) {
 					func(userID int64) (*models.UserResp, error) { return defaultUser, nil },
 					func() (*api.CLIInfo, error) { return defaultCLIInfo, nil },
 					func(userID int64, email, realname, comment string) error { return nil },
-					func(updateView *update.UpdateView) {},
+					func(updateView *update.UpdateView) error { return nil },
 				)
 			},
 			expectedErr: "invalid email format",
@@ -151,7 +179,7 @@ func TestUserUpdateCmd_RunE(t *testing.T) {
 						return &api.CLIInfo{IsSysAdmin: false, Username: "otheruser"}, nil
 					},
 					func(userID int64, email, realname, comment string) error { return nil },
-					func(updateView *update.UpdateView) {},
+					func(updateView *update.UpdateView) error { return nil },
 				)
 			},
 			expectedErr: "permission denied",
@@ -171,7 +199,7 @@ func TestUserUpdateCmd_RunE(t *testing.T) {
 						return &api.CLIInfo{IsSysAdmin: false, Username: "testuser"}, nil
 					},
 					func(userID int64, email, realname, comment string) error { return nil },
-					func(updateView *update.UpdateView) {},
+					func(updateView *update.UpdateView) error { return nil },
 				)
 			},
 			expectedErr: "",
@@ -187,7 +215,7 @@ func TestUserUpdateCmd_RunE(t *testing.T) {
 					func(userID int64) (*models.UserResp, error) { return nil, nil },
 					func() (*api.CLIInfo, error) { return defaultCLIInfo, nil },
 					func(userID int64, email, realname, comment string) error { return nil },
-					func(updateView *update.UpdateView) {},
+					func(updateView *update.UpdateView) error { return nil },
 				)
 			},
 			expectedErr: "user not found",

--- a/doc/cli-docs/harbor-artifact-delete.md
+++ b/doc/cli-docs/harbor-artifact-delete.md
@@ -1,6 +1,6 @@
 ---
 title: harbor artifact delete
-weight: 35
+weight: 60
 ---
 ## harbor artifact delete
 

--- a/doc/cli-docs/harbor-artifact-label-add.md
+++ b/doc/cli-docs/harbor-artifact-label-add.md
@@ -1,6 +1,6 @@
 ---
 title: harbor artifact label add
-weight: 95
+weight: 60
 ---
 ## harbor artifact label add
 

--- a/doc/cli-docs/harbor-artifact-label-list.md
+++ b/doc/cli-docs/harbor-artifact-label-list.md
@@ -1,6 +1,6 @@
 ---
 title: harbor artifact label list
-weight: 30
+weight: 70
 ---
 ## harbor artifact label list
 

--- a/doc/cli-docs/harbor-artifact-label.md
+++ b/doc/cli-docs/harbor-artifact-label.md
@@ -1,6 +1,6 @@
 ---
 title: harbor artifact label
-weight: 70
+weight: 90
 ---
 ## harbor artifact label
 

--- a/doc/cli-docs/harbor-artifact-list.md
+++ b/doc/cli-docs/harbor-artifact-list.md
@@ -1,6 +1,6 @@
 ---
 title: harbor artifact list
-weight: 20
+weight: 10
 ---
 ## harbor artifact list
 

--- a/doc/cli-docs/harbor-artifact-scan-start.md
+++ b/doc/cli-docs/harbor-artifact-scan-start.md
@@ -1,6 +1,6 @@
 ---
 title: harbor artifact scan start
-weight: 80
+weight: 50
 ---
 ## harbor artifact scan start
 

--- a/doc/cli-docs/harbor-artifact-scan-stop.md
+++ b/doc/cli-docs/harbor-artifact-scan-stop.md
@@ -1,6 +1,6 @@
 ---
 title: harbor artifact scan stop
-weight: 10
+weight: 20
 ---
 ## harbor artifact scan stop
 

--- a/doc/cli-docs/harbor-artifact-scan.md
+++ b/doc/cli-docs/harbor-artifact-scan.md
@@ -1,6 +1,6 @@
 ---
 title: harbor artifact scan
-weight: 60
+weight: 75
 ---
 ## harbor artifact scan
 

--- a/doc/cli-docs/harbor-artifact-tags-create.md
+++ b/doc/cli-docs/harbor-artifact-tags-create.md
@@ -1,6 +1,6 @@
 ---
 title: harbor artifact tags create
-weight: 65
+weight: 90
 ---
 ## harbor artifact tags create
 

--- a/doc/cli-docs/harbor-artifact-tags-delete.md
+++ b/doc/cli-docs/harbor-artifact-tags-delete.md
@@ -1,6 +1,6 @@
 ---
 title: harbor artifact tags delete
-weight: 80
+weight: 65
 ---
 ## harbor artifact tags delete
 

--- a/doc/cli-docs/harbor-artifact-tags-list.md
+++ b/doc/cli-docs/harbor-artifact-tags-list.md
@@ -1,6 +1,6 @@
 ---
 title: harbor artifact tags list
-weight: 90
+weight: 15
 ---
 ## harbor artifact tags list
 

--- a/doc/cli-docs/harbor-artifact-tags.md
+++ b/doc/cli-docs/harbor-artifact-tags.md
@@ -1,6 +1,6 @@
 ---
 title: harbor artifact tags
-weight: 85
+weight: 30
 ---
 ## harbor artifact tags
 

--- a/doc/cli-docs/harbor-artifact-view.md
+++ b/doc/cli-docs/harbor-artifact-view.md
@@ -1,6 +1,6 @@
 ---
 title: harbor artifact view
-weight: 95
+weight: 55
 ---
 ## harbor artifact view
 

--- a/doc/cli-docs/harbor-artifact.md
+++ b/doc/cli-docs/harbor-artifact.md
@@ -1,6 +1,6 @@
 ---
 title: harbor artifact
-weight: 35
+weight: 25
 ---
 ## harbor artifact
 

--- a/doc/cli-docs/harbor-config-apply.md
+++ b/doc/cli-docs/harbor-config-apply.md
@@ -1,6 +1,6 @@
 ---
 title: harbor config apply
-weight: 85
+weight: 45
 ---
 ## harbor config apply
 

--- a/doc/cli-docs/harbor-config-view.md
+++ b/doc/cli-docs/harbor-config-view.md
@@ -1,6 +1,6 @@
 ---
 title: harbor config view
-weight: 95
+weight: 85
 ---
 ## harbor config view
 

--- a/doc/cli-docs/harbor-context-delete.md
+++ b/doc/cli-docs/harbor-context-delete.md
@@ -1,6 +1,6 @@
 ---
 title: harbor context delete
-weight: 85
+weight: 90
 ---
 ## harbor context delete
 

--- a/doc/cli-docs/harbor-context-get.md
+++ b/doc/cli-docs/harbor-context-get.md
@@ -1,6 +1,6 @@
 ---
 title: harbor context get
-weight: 85
+weight: 40
 ---
 ## harbor context get
 

--- a/doc/cli-docs/harbor-context-list.md
+++ b/doc/cli-docs/harbor-context-list.md
@@ -1,6 +1,6 @@
 ---
 title: harbor context list
-weight: 25
+weight: 75
 ---
 ## harbor context list
 

--- a/doc/cli-docs/harbor-context-update.md
+++ b/doc/cli-docs/harbor-context-update.md
@@ -1,6 +1,6 @@
 ---
 title: harbor context update
-weight: 10
+weight: 80
 ---
 ## harbor context update
 

--- a/doc/cli-docs/harbor-context.md
+++ b/doc/cli-docs/harbor-context.md
@@ -1,6 +1,6 @@
 ---
 title: harbor context
-weight: 30
+weight: 50
 ---
 ## harbor context
 

--- a/doc/cli-docs/harbor-cve-allowlist-add.md
+++ b/doc/cli-docs/harbor-cve-allowlist-add.md
@@ -1,6 +1,6 @@
 ---
 title: harbor cve allowlist add
-weight: 60
+weight: 45
 ---
 ## harbor cve-allowlist add
 

--- a/doc/cli-docs/harbor-cve-allowlist-list.md
+++ b/doc/cli-docs/harbor-cve-allowlist-list.md
@@ -1,6 +1,6 @@
 ---
 title: harbor cve allowlist list
-weight: 60
+weight: 95
 ---
 ## harbor cve-allowlist list
 

--- a/doc/cli-docs/harbor-cve-allowlist.md
+++ b/doc/cli-docs/harbor-cve-allowlist.md
@@ -1,6 +1,6 @@
 ---
 title: harbor cve allowlist
-weight: 70
+weight: 10
 ---
 ## harbor cve-allowlist
 

--- a/doc/cli-docs/harbor-health.md
+++ b/doc/cli-docs/harbor-health.md
@@ -1,6 +1,6 @@
 ---
 title: harbor health
-weight: 80
+weight: 5
 ---
 ## harbor health
 

--- a/doc/cli-docs/harbor-info.md
+++ b/doc/cli-docs/harbor-info.md
@@ -1,6 +1,6 @@
 ---
 title: harbor info
-weight: 65
+weight: 75
 ---
 ## harbor info
 

--- a/doc/cli-docs/harbor-instance-create.md
+++ b/doc/cli-docs/harbor-instance-create.md
@@ -1,6 +1,6 @@
 ---
 title: harbor instance create
-weight: 10
+weight: 85
 ---
 ## harbor instance create
 

--- a/doc/cli-docs/harbor-instance-list.md
+++ b/doc/cli-docs/harbor-instance-list.md
@@ -1,6 +1,6 @@
 ---
 title: harbor instance list
-weight: 95
+weight: 90
 ---
 ## harbor instance list
 

--- a/doc/cli-docs/harbor-instance-ping.md
+++ b/doc/cli-docs/harbor-instance-ping.md
@@ -1,6 +1,6 @@
 ---
 title: harbor instance ping
-weight: 25
+weight: 90
 ---
 ## harbor instance ping
 

--- a/doc/cli-docs/harbor-instance-update.md
+++ b/doc/cli-docs/harbor-instance-update.md
@@ -1,6 +1,6 @@
 ---
 title: harbor instance update
-weight: 20
+weight: 25
 ---
 ## harbor instance update
 

--- a/doc/cli-docs/harbor-instance.md
+++ b/doc/cli-docs/harbor-instance.md
@@ -1,6 +1,6 @@
 ---
 title: harbor instance
-weight: 5
+weight: 35
 ---
 ## harbor instance
 

--- a/doc/cli-docs/harbor-jobservice-queues-pause.md
+++ b/doc/cli-docs/harbor-jobservice-queues-pause.md
@@ -1,6 +1,6 @@
 ---
 title: harbor jobservice queues pause
-weight: 80
+weight: 35
 ---
 ## harbor jobservice queues pause
 

--- a/doc/cli-docs/harbor-jobservice-queues-resume.md
+++ b/doc/cli-docs/harbor-jobservice-queues-resume.md
@@ -1,6 +1,6 @@
 ---
 title: harbor jobservice queues resume
-weight: 90
+weight: 75
 ---
 ## harbor jobservice queues resume
 

--- a/doc/cli-docs/harbor-jobservice-queues-stop.md
+++ b/doc/cli-docs/harbor-jobservice-queues-stop.md
@@ -1,6 +1,6 @@
 ---
 title: harbor jobservice queues stop
-weight: 60
+weight: 35
 ---
 ## harbor jobservice queues stop
 

--- a/doc/cli-docs/harbor-jobservice-queues.md
+++ b/doc/cli-docs/harbor-jobservice-queues.md
@@ -1,6 +1,6 @@
 ---
 title: harbor jobservice queues
-weight: 65
+weight: 60
 ---
 ## harbor jobservice queues
 

--- a/doc/cli-docs/harbor-jobservice.md
+++ b/doc/cli-docs/harbor-jobservice.md
@@ -1,6 +1,6 @@
 ---
 title: harbor jobservice
-weight: 75
+weight: 55
 ---
 ## harbor jobservice
 

--- a/doc/cli-docs/harbor-label-create.md
+++ b/doc/cli-docs/harbor-label-create.md
@@ -1,6 +1,6 @@
 ---
 title: harbor label create
-weight: 80
+weight: 35
 ---
 ## harbor label create
 

--- a/doc/cli-docs/harbor-label-delete.md
+++ b/doc/cli-docs/harbor-label-delete.md
@@ -1,6 +1,6 @@
 ---
 title: harbor label delete
-weight: 30
+weight: 25
 ---
 ## harbor label delete
 

--- a/doc/cli-docs/harbor-label-list.md
+++ b/doc/cli-docs/harbor-label-list.md
@@ -1,6 +1,6 @@
 ---
 title: harbor label list
-weight: 15
+weight: 5
 ---
 ## harbor label list
 

--- a/doc/cli-docs/harbor-label-update.md
+++ b/doc/cli-docs/harbor-label-update.md
@@ -1,6 +1,6 @@
 ---
 title: harbor label update
-weight: 70
+weight: 35
 ---
 ## harbor label update
 

--- a/doc/cli-docs/harbor-label.md
+++ b/doc/cli-docs/harbor-label.md
@@ -1,6 +1,6 @@
 ---
 title: harbor label
-weight: 65
+weight: 5
 ---
 ## harbor label
 

--- a/doc/cli-docs/harbor-ldap-import.md
+++ b/doc/cli-docs/harbor-ldap-import.md
@@ -1,6 +1,6 @@
 ---
 title: harbor ldap import
-weight: 15
+weight: 35
 ---
 ## harbor ldap import
 

--- a/doc/cli-docs/harbor-ldap-ping.md
+++ b/doc/cli-docs/harbor-ldap-ping.md
@@ -1,6 +1,6 @@
 ---
 title: harbor ldap ping
-weight: 90
+weight: 85
 ---
 ## harbor ldap ping
 

--- a/doc/cli-docs/harbor-ldap-search.md
+++ b/doc/cli-docs/harbor-ldap-search.md
@@ -1,6 +1,6 @@
 ---
 title: harbor ldap search
-weight: 70
+weight: 15
 ---
 ## harbor ldap search
 

--- a/doc/cli-docs/harbor-ldap.md
+++ b/doc/cli-docs/harbor-ldap.md
@@ -1,6 +1,6 @@
 ---
 title: harbor ldap
-weight: 20
+weight: 15
 ---
 ## harbor ldap
 

--- a/doc/cli-docs/harbor-login.md
+++ b/doc/cli-docs/harbor-login.md
@@ -1,6 +1,6 @@
 ---
 title: harbor login
-weight: 15
+weight: 55
 ---
 ## harbor login
 

--- a/doc/cli-docs/harbor-logs.md
+++ b/doc/cli-docs/harbor-logs.md
@@ -1,6 +1,6 @@
 ---
 title: harbor logs
-weight: 30
+weight: 25
 ---
 ## harbor logs
 

--- a/doc/cli-docs/harbor-password.md
+++ b/doc/cli-docs/harbor-password.md
@@ -1,6 +1,6 @@
 ---
 title: harbor password
-weight: 55
+weight: 5
 ---
 ## harbor password
 

--- a/doc/cli-docs/harbor-project-config-list.md
+++ b/doc/cli-docs/harbor-project-config-list.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project config list
-weight: 85
+weight: 5
 ---
 ## harbor project config list
 

--- a/doc/cli-docs/harbor-project-config-update.md
+++ b/doc/cli-docs/harbor-project-config-update.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project config update
-weight: 10
+weight: 30
 ---
 ## harbor project config update
 

--- a/doc/cli-docs/harbor-project-config.md
+++ b/doc/cli-docs/harbor-project-config.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project config
-weight: 45
+weight: 60
 ---
 ## harbor project config
 

--- a/doc/cli-docs/harbor-project-create.md
+++ b/doc/cli-docs/harbor-project-create.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project create
-weight: 80
+weight: 45
 ---
 ## harbor project create
 

--- a/doc/cli-docs/harbor-project-delete.md
+++ b/doc/cli-docs/harbor-project-delete.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project delete
-weight: 100
+weight: 50
 ---
 ## harbor project delete
 

--- a/doc/cli-docs/harbor-project-list.md
+++ b/doc/cli-docs/harbor-project-list.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project list
-weight: 85
+weight: 55
 ---
 ## harbor project list
 

--- a/doc/cli-docs/harbor-project-logs.md
+++ b/doc/cli-docs/harbor-project-logs.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project logs
-weight: 90
+weight: 5
 ---
 ## harbor project logs
 

--- a/doc/cli-docs/harbor-project-member-create.md
+++ b/doc/cli-docs/harbor-project-member-create.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project member create
-weight: 15
+weight: 70
 ---
 ## harbor project member create
 

--- a/doc/cli-docs/harbor-project-member-delete.md
+++ b/doc/cli-docs/harbor-project-member-delete.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project member delete
-weight: 30
+weight: 90
 ---
 ## harbor project member delete
 

--- a/doc/cli-docs/harbor-project-member-update.md
+++ b/doc/cli-docs/harbor-project-member-update.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project member update
-weight: 20
+weight: 80
 ---
 ## harbor project member update
 

--- a/doc/cli-docs/harbor-project-member.md
+++ b/doc/cli-docs/harbor-project-member.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project member
-weight: 70
+weight: 85
 ---
 ## harbor project member
 

--- a/doc/cli-docs/harbor-project-preheat-execution-list.md
+++ b/doc/cli-docs/harbor-project-preheat-execution-list.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project preheat execution list
-weight: 70
+weight: 60
 ---
 ## harbor project preheat execution list
 

--- a/doc/cli-docs/harbor-project-preheat-execution-stop.md
+++ b/doc/cli-docs/harbor-project-preheat-execution-stop.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project preheat execution stop
-weight: 5
+weight: 80
 ---
 ## harbor project preheat execution stop
 

--- a/doc/cli-docs/harbor-project-preheat-execution-view.md
+++ b/doc/cli-docs/harbor-project-preheat-execution-view.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project preheat execution view
-weight: 50
+weight: 25
 ---
 ## harbor project preheat execution view
 

--- a/doc/cli-docs/harbor-project-preheat-execution.md
+++ b/doc/cli-docs/harbor-project-preheat-execution.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project preheat execution
-weight: 95
+weight: 5
 ---
 ## harbor project preheat execution
 

--- a/doc/cli-docs/harbor-project-preheat-policy-create.md
+++ b/doc/cli-docs/harbor-project-preheat-policy-create.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project preheat policy create
-weight: 50
+weight: 90
 ---
 ## harbor project preheat policy create
 

--- a/doc/cli-docs/harbor-project-preheat-policy-delete.md
+++ b/doc/cli-docs/harbor-project-preheat-policy-delete.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project preheat policy delete
-weight: 20
+weight: 25
 ---
 ## harbor project preheat policy delete
 

--- a/doc/cli-docs/harbor-project-preheat-policy-list.md
+++ b/doc/cli-docs/harbor-project-preheat-policy-list.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project preheat policy list
-weight: 20
+weight: 65
 ---
 ## harbor project preheat policy list
 

--- a/doc/cli-docs/harbor-project-preheat-policy-start.md
+++ b/doc/cli-docs/harbor-project-preheat-policy-start.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project preheat policy start
-weight: 55
+weight: 40
 ---
 ## harbor project preheat policy start
 

--- a/doc/cli-docs/harbor-project-preheat-policy-update.md
+++ b/doc/cli-docs/harbor-project-preheat-policy-update.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project preheat policy update
-weight: 25
+weight: 50
 ---
 ## harbor project preheat policy update
 

--- a/doc/cli-docs/harbor-project-preheat-policy-view.md
+++ b/doc/cli-docs/harbor-project-preheat-policy-view.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project preheat policy view
-weight: 30
+weight: 70
 ---
 ## harbor project preheat policy view
 

--- a/doc/cli-docs/harbor-project-preheat-policy.md
+++ b/doc/cli-docs/harbor-project-preheat-policy.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project preheat policy
-weight: 90
+weight: 5
 ---
 ## harbor project preheat policy
 

--- a/doc/cli-docs/harbor-project-preheat.md
+++ b/doc/cli-docs/harbor-project-preheat.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project preheat
-weight: 15
+weight: 85
 ---
 ## harbor project preheat
 

--- a/doc/cli-docs/harbor-project-robot-create.md
+++ b/doc/cli-docs/harbor-project-robot-create.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project robot create
-weight: 15
+weight: 50
 ---
 ## harbor project robot create
 

--- a/doc/cli-docs/harbor-project-robot-delete.md
+++ b/doc/cli-docs/harbor-project-robot-delete.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project robot delete
-weight: 5
+weight: 45
 ---
 ## harbor project robot delete
 

--- a/doc/cli-docs/harbor-project-robot-list.md
+++ b/doc/cli-docs/harbor-project-robot-list.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project robot list
-weight: 35
+weight: 45
 ---
 ## harbor project robot list
 

--- a/doc/cli-docs/harbor-project-robot-refresh.md
+++ b/doc/cli-docs/harbor-project-robot-refresh.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project robot refresh
-weight: 25
+weight: 40
 ---
 ## harbor project robot refresh
 

--- a/doc/cli-docs/harbor-project-robot-update.md
+++ b/doc/cli-docs/harbor-project-robot-update.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project robot update
-weight: 55
+weight: 25
 ---
 ## harbor project robot update
 

--- a/doc/cli-docs/harbor-project-robot-view.md
+++ b/doc/cli-docs/harbor-project-robot-view.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project robot view
-weight: 50
+weight: 15
 ---
 ## harbor project robot view
 

--- a/doc/cli-docs/harbor-project-robot.md
+++ b/doc/cli-docs/harbor-project-robot.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project robot
-weight: 40
+weight: 95
 ---
 ## harbor project robot
 

--- a/doc/cli-docs/harbor-project-search.md
+++ b/doc/cli-docs/harbor-project-search.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project search
-weight: 20
+weight: 90
 ---
 ## harbor project search
 

--- a/doc/cli-docs/harbor-project-view.md
+++ b/doc/cli-docs/harbor-project-view.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project view
-weight: 95
+weight: 35
 ---
 ## harbor project view
 

--- a/doc/cli-docs/harbor-project.md
+++ b/doc/cli-docs/harbor-project.md
@@ -1,6 +1,6 @@
 ---
 title: harbor project
-weight: 75
+weight: 90
 ---
 ## harbor project
 

--- a/doc/cli-docs/harbor-quota-list.md
+++ b/doc/cli-docs/harbor-quota-list.md
@@ -1,6 +1,6 @@
 ---
 title: harbor quota list
-weight: 85
+weight: 30
 ---
 ## harbor quota list
 

--- a/doc/cli-docs/harbor-quota-update.md
+++ b/doc/cli-docs/harbor-quota-update.md
@@ -1,6 +1,6 @@
 ---
 title: harbor quota update
-weight: 70
+weight: 5
 ---
 ## harbor quota update
 

--- a/doc/cli-docs/harbor-quota-view.md
+++ b/doc/cli-docs/harbor-quota-view.md
@@ -1,6 +1,6 @@
 ---
 title: harbor quota view
-weight: 30
+weight: 55
 ---
 ## harbor quota view
 

--- a/doc/cli-docs/harbor-quota.md
+++ b/doc/cli-docs/harbor-quota.md
@@ -1,6 +1,6 @@
 ---
 title: harbor quota
-weight: 30
+weight: 25
 ---
 ## harbor quota
 

--- a/doc/cli-docs/harbor-registry-create.md
+++ b/doc/cli-docs/harbor-registry-create.md
@@ -1,6 +1,6 @@
 ---
 title: harbor registry create
-weight: 110
+weight: 70
 ---
 ## harbor registry create
 

--- a/doc/cli-docs/harbor-registry-delete.md
+++ b/doc/cli-docs/harbor-registry-delete.md
@@ -1,6 +1,6 @@
 ---
 title: harbor registry delete
-weight: 140
+weight: 15
 ---
 ## harbor registry delete
 

--- a/doc/cli-docs/harbor-registry-list.md
+++ b/doc/cli-docs/harbor-registry-list.md
@@ -1,6 +1,6 @@
 ---
 title: harbor registry list
-weight: 115
+weight: 5
 ---
 ## harbor registry list
 

--- a/doc/cli-docs/harbor-registry-update.md
+++ b/doc/cli-docs/harbor-registry-update.md
@@ -1,6 +1,6 @@
 ---
 title: harbor registry update
-weight: 125
+weight: 55
 ---
 ## harbor registry update
 

--- a/doc/cli-docs/harbor-registry-view.md
+++ b/doc/cli-docs/harbor-registry-view.md
@@ -1,6 +1,6 @@
 ---
 title: harbor registry view
-weight: 130
+weight: 40
 ---
 ## harbor registry view
 

--- a/doc/cli-docs/harbor-registry.md
+++ b/doc/cli-docs/harbor-registry.md
@@ -1,6 +1,6 @@
 ---
 title: harbor registry
-weight: 105
+weight: 10
 ---
 ## harbor registry
 

--- a/doc/cli-docs/harbor-replication-executions-list.md
+++ b/doc/cli-docs/harbor-replication-executions-list.md
@@ -1,6 +1,6 @@
 ---
 title: harbor replication executions list
-weight: 10
+weight: 50
 ---
 ## harbor replication executions list
 

--- a/doc/cli-docs/harbor-replication-executions-view.md
+++ b/doc/cli-docs/harbor-replication-executions-view.md
@@ -1,6 +1,6 @@
 ---
 title: harbor replication executions view
-weight: 65
+weight: 25
 ---
 ## harbor replication executions view
 

--- a/doc/cli-docs/harbor-replication-executions.md
+++ b/doc/cli-docs/harbor-replication-executions.md
@@ -1,6 +1,6 @@
 ---
 title: harbor replication executions
-weight: 70
+weight: 45
 ---
 ## harbor replication executions
 

--- a/doc/cli-docs/harbor-replication-log.md
+++ b/doc/cli-docs/harbor-replication-log.md
@@ -1,6 +1,6 @@
 ---
 title: harbor replication log
-weight: 10
+weight: 95
 ---
 ## harbor replication log
 

--- a/doc/cli-docs/harbor-replication-policies-create.md
+++ b/doc/cli-docs/harbor-replication-policies-create.md
@@ -1,6 +1,6 @@
 ---
 title: harbor replication policies create
-weight: 85
+weight: 75
 ---
 ## harbor replication policies create
 

--- a/doc/cli-docs/harbor-replication-policies-delete.md
+++ b/doc/cli-docs/harbor-replication-policies-delete.md
@@ -1,6 +1,6 @@
 ---
 title: harbor replication policies delete
-weight: 55
+weight: 50
 ---
 ## harbor replication policies delete
 

--- a/doc/cli-docs/harbor-replication-policies-list.md
+++ b/doc/cli-docs/harbor-replication-policies-list.md
@@ -1,6 +1,6 @@
 ---
 title: harbor replication policies list
-weight: 85
+weight: 65
 ---
 ## harbor replication policies list
 

--- a/doc/cli-docs/harbor-replication-policies-update.md
+++ b/doc/cli-docs/harbor-replication-policies-update.md
@@ -1,6 +1,6 @@
 ---
 title: harbor replication policies update
-weight: 5
+weight: 95
 ---
 ## harbor replication policies update
 

--- a/doc/cli-docs/harbor-replication-policies-view.md
+++ b/doc/cli-docs/harbor-replication-policies-view.md
@@ -1,6 +1,6 @@
 ---
 title: harbor replication policies view
-weight: 20
+weight: 45
 ---
 ## harbor replication policies view
 

--- a/doc/cli-docs/harbor-replication-policies.md
+++ b/doc/cli-docs/harbor-replication-policies.md
@@ -1,6 +1,6 @@
 ---
 title: harbor replication policies
-weight: 50
+weight: 80
 ---
 ## harbor replication policies
 

--- a/doc/cli-docs/harbor-replication-start.md
+++ b/doc/cli-docs/harbor-replication-start.md
@@ -1,6 +1,6 @@
 ---
 title: harbor replication start
-weight: 35
+weight: 45
 ---
 ## harbor replication start
 

--- a/doc/cli-docs/harbor-replication-stop.md
+++ b/doc/cli-docs/harbor-replication-stop.md
@@ -1,6 +1,6 @@
 ---
 title: harbor replication stop
-weight: 70
+weight: 55
 ---
 ## harbor replication stop
 

--- a/doc/cli-docs/harbor-replication.md
+++ b/doc/cli-docs/harbor-replication.md
@@ -1,6 +1,6 @@
 ---
 title: harbor replication
-weight: 5
+weight: 10
 ---
 ## harbor replication
 

--- a/doc/cli-docs/harbor-repo-delete.md
+++ b/doc/cli-docs/harbor-repo-delete.md
@@ -1,6 +1,6 @@
 ---
 title: harbor repo delete
-weight: 160
+weight: 20
 ---
 ## harbor repo delete
 

--- a/doc/cli-docs/harbor-repo-list.md
+++ b/doc/cli-docs/harbor-repo-list.md
@@ -1,6 +1,6 @@
 ---
 title: harbor repo list
-weight: 150
+weight: 30
 ---
 ## harbor repo list
 

--- a/doc/cli-docs/harbor-repo-search.md
+++ b/doc/cli-docs/harbor-repo-search.md
@@ -1,6 +1,6 @@
 ---
 title: harbor repo search
-weight: 30
+weight: 65
 ---
 ## harbor repo search
 

--- a/doc/cli-docs/harbor-repo-update.md
+++ b/doc/cli-docs/harbor-repo-update.md
@@ -1,6 +1,6 @@
 ---
 title: harbor repo update
-weight: 55
+weight: 60
 ---
 ## harbor repo update
 

--- a/doc/cli-docs/harbor-repo-view.md
+++ b/doc/cli-docs/harbor-repo-view.md
@@ -1,6 +1,6 @@
 ---
 title: harbor repo view
-weight: 55
+weight: 70
 ---
 ## harbor repo view
 

--- a/doc/cli-docs/harbor-repo.md
+++ b/doc/cli-docs/harbor-repo.md
@@ -1,6 +1,6 @@
 ---
 title: harbor repo
-weight: 145
+weight: 55
 ---
 ## harbor repo
 

--- a/doc/cli-docs/harbor-robot-create.md
+++ b/doc/cli-docs/harbor-robot-create.md
@@ -1,6 +1,6 @@
 ---
 title: harbor robot create
-weight: 15
+weight: 95
 ---
 ## harbor robot create
 

--- a/doc/cli-docs/harbor-robot-delete.md
+++ b/doc/cli-docs/harbor-robot-delete.md
@@ -1,6 +1,6 @@
 ---
 title: harbor robot delete
-weight: 10
+weight: 5
 ---
 ## harbor robot delete
 

--- a/doc/cli-docs/harbor-robot-list.md
+++ b/doc/cli-docs/harbor-robot-list.md
@@ -1,6 +1,6 @@
 ---
 title: harbor robot list
-weight: 65
+weight: 85
 ---
 ## harbor robot list
 

--- a/doc/cli-docs/harbor-robot-refresh.md
+++ b/doc/cli-docs/harbor-robot-refresh.md
@@ -1,6 +1,6 @@
 ---
 title: harbor robot refresh
-weight: 40
+weight: 30
 ---
 ## harbor robot refresh
 

--- a/doc/cli-docs/harbor-robot-update.md
+++ b/doc/cli-docs/harbor-robot-update.md
@@ -1,6 +1,6 @@
 ---
 title: harbor robot update
-weight: 40
+weight: 70
 ---
 ## harbor robot update
 

--- a/doc/cli-docs/harbor-robot-view.md
+++ b/doc/cli-docs/harbor-robot-view.md
@@ -1,6 +1,6 @@
 ---
 title: harbor robot view
-weight: 25
+weight: 15
 ---
 ## harbor robot view
 

--- a/doc/cli-docs/harbor-robot.md
+++ b/doc/cli-docs/harbor-robot.md
@@ -1,6 +1,6 @@
 ---
 title: harbor robot
-weight: 75
+weight: 25
 ---
 ## harbor robot
 

--- a/doc/cli-docs/harbor-scan-all-metrics.md
+++ b/doc/cli-docs/harbor-scan-all-metrics.md
@@ -1,6 +1,6 @@
 ---
 title: harbor scan all metrics
-weight: 50
+weight: 35
 ---
 ## harbor scan-all metrics
 

--- a/doc/cli-docs/harbor-scan-all-run.md
+++ b/doc/cli-docs/harbor-scan-all-run.md
@@ -1,6 +1,6 @@
 ---
 title: harbor scan all run
-weight: 80
+weight: 65
 ---
 ## harbor scan-all run
 

--- a/doc/cli-docs/harbor-scan-all-stop.md
+++ b/doc/cli-docs/harbor-scan-all-stop.md
@@ -1,6 +1,6 @@
 ---
 title: harbor scan all stop
-weight: 40
+weight: 30
 ---
 ## harbor scan-all stop
 

--- a/doc/cli-docs/harbor-scan-all-update-schedule.md
+++ b/doc/cli-docs/harbor-scan-all-update-schedule.md
@@ -1,6 +1,6 @@
 ---
 title: harbor scan all update schedule
-weight: 50
+weight: 80
 ---
 ## harbor scan-all update-schedule
 

--- a/doc/cli-docs/harbor-scan-all-view-schedule.md
+++ b/doc/cli-docs/harbor-scan-all-view-schedule.md
@@ -1,6 +1,6 @@
 ---
 title: harbor scan all view schedule
-weight: 35
+weight: 30
 ---
 ## harbor scan-all view-schedule
 

--- a/doc/cli-docs/harbor-scan-all.md
+++ b/doc/cli-docs/harbor-scan-all.md
@@ -1,6 +1,6 @@
 ---
 title: harbor scan all
-weight: 85
+weight: 5
 ---
 ## harbor scan-all
 

--- a/doc/cli-docs/harbor-scanner-create.md
+++ b/doc/cli-docs/harbor-scanner-create.md
@@ -1,6 +1,6 @@
 ---
 title: harbor scanner create
-weight: 95
+weight: 75
 ---
 ## harbor scanner create
 

--- a/doc/cli-docs/harbor-scanner-delete.md
+++ b/doc/cli-docs/harbor-scanner-delete.md
@@ -1,6 +1,6 @@
 ---
 title: harbor scanner delete
-weight: 45
+weight: 60
 ---
 ## harbor scanner delete
 

--- a/doc/cli-docs/harbor-scanner-list.md
+++ b/doc/cli-docs/harbor-scanner-list.md
@@ -1,6 +1,6 @@
 ---
 title: harbor scanner list
-weight: 50
+weight: 95
 ---
 ## harbor scanner list
 

--- a/doc/cli-docs/harbor-scanner-metadata.md
+++ b/doc/cli-docs/harbor-scanner-metadata.md
@@ -1,6 +1,6 @@
 ---
 title: harbor scanner metadata
-weight: 60
+weight: 75
 ---
 ## harbor scanner metadata
 

--- a/doc/cli-docs/harbor-scanner-set-default.md
+++ b/doc/cli-docs/harbor-scanner-set-default.md
@@ -1,6 +1,6 @@
 ---
 title: harbor scanner set default
-weight: 25
+weight: 5
 ---
 ## harbor scanner set-default
 

--- a/doc/cli-docs/harbor-scanner-update.md
+++ b/doc/cli-docs/harbor-scanner-update.md
@@ -1,6 +1,6 @@
 ---
 title: harbor scanner update
-weight: 90
+weight: 40
 ---
 ## harbor scanner update
 

--- a/doc/cli-docs/harbor-scanner-view.md
+++ b/doc/cli-docs/harbor-scanner-view.md
@@ -1,6 +1,6 @@
 ---
 title: harbor scanner view
-weight: 95
+weight: 85
 ---
 ## harbor scanner view
 

--- a/doc/cli-docs/harbor-scanner.md
+++ b/doc/cli-docs/harbor-scanner.md
@@ -1,6 +1,6 @@
 ---
 title: harbor scanner
-weight: 70
+weight: 90
 ---
 ## harbor scanner
 

--- a/doc/cli-docs/harbor-schedule-list.md
+++ b/doc/cli-docs/harbor-schedule-list.md
@@ -1,6 +1,6 @@
 ---
 title: harbor schedule list
-weight: 70
+weight: 10
 ---
 ## harbor schedule list
 

--- a/doc/cli-docs/harbor-schedule.md
+++ b/doc/cli-docs/harbor-schedule.md
@@ -1,6 +1,6 @@
 ---
 title: harbor schedule
-weight: 25
+weight: 95
 ---
 ## harbor schedule
 

--- a/doc/cli-docs/harbor-tag-immutable-create.md
+++ b/doc/cli-docs/harbor-tag-immutable-create.md
@@ -1,6 +1,6 @@
 ---
 title: harbor tag immutable create
-weight: 70
+weight: 85
 ---
 ## harbor tag immutable create
 

--- a/doc/cli-docs/harbor-tag-immutable-delete.md
+++ b/doc/cli-docs/harbor-tag-immutable-delete.md
@@ -1,6 +1,6 @@
 ---
 title: harbor tag immutable delete
-weight: 30
+weight: 10
 ---
 ## harbor tag immutable delete
 

--- a/doc/cli-docs/harbor-tag-immutable.md
+++ b/doc/cli-docs/harbor-tag-immutable.md
@@ -1,6 +1,6 @@
 ---
 title: harbor tag immutable
-weight: 25
+weight: 45
 ---
 ## harbor tag immutable
 

--- a/doc/cli-docs/harbor-tag-retention-create.md
+++ b/doc/cli-docs/harbor-tag-retention-create.md
@@ -1,6 +1,6 @@
 ---
 title: harbor tag retention create
-weight: 95
+weight: 10
 ---
 ## harbor tag retention create
 

--- a/doc/cli-docs/harbor-tag-retention-delete.md
+++ b/doc/cli-docs/harbor-tag-retention-delete.md
@@ -1,6 +1,6 @@
 ---
 title: harbor tag retention delete
-weight: 15
+weight: 30
 ---
 ## harbor tag retention delete
 

--- a/doc/cli-docs/harbor-tag-retention-list.md
+++ b/doc/cli-docs/harbor-tag-retention-list.md
@@ -1,6 +1,6 @@
 ---
 title: harbor tag retention list
-weight: 45
+weight: 95
 ---
 ## harbor tag retention list
 

--- a/doc/cli-docs/harbor-tag-retention.md
+++ b/doc/cli-docs/harbor-tag-retention.md
@@ -1,6 +1,6 @@
 ---
 title: harbor tag retention
-weight: 95
+weight: 85
 ---
 ## harbor tag retention
 

--- a/doc/cli-docs/harbor-tag.md
+++ b/doc/cli-docs/harbor-tag.md
@@ -1,6 +1,6 @@
 ---
 title: harbor tag
-weight: 95
+weight: 15
 ---
 ## harbor tag
 

--- a/doc/cli-docs/harbor-user-create.md
+++ b/doc/cli-docs/harbor-user-create.md
@@ -1,6 +1,6 @@
 ---
 title: harbor user create
-weight: 170
+weight: 35
 ---
 ## harbor user create
 

--- a/doc/cli-docs/harbor-user-delete.md
+++ b/doc/cli-docs/harbor-user-delete.md
@@ -1,6 +1,6 @@
 ---
 title: harbor user delete
-weight: 185
+weight: 85
 ---
 ## harbor user delete
 

--- a/doc/cli-docs/harbor-user-elevate.md
+++ b/doc/cli-docs/harbor-user-elevate.md
@@ -1,6 +1,6 @@
 ---
 title: harbor user elevate
-weight: 180
+weight: 95
 ---
 ## harbor user elevate
 

--- a/doc/cli-docs/harbor-user-list.md
+++ b/doc/cli-docs/harbor-user-list.md
@@ -1,6 +1,6 @@
 ---
 title: harbor user list
-weight: 175
+weight: 10
 ---
 ## harbor user list
 

--- a/doc/cli-docs/harbor-user-password.md
+++ b/doc/cli-docs/harbor-user-password.md
@@ -1,6 +1,6 @@
 ---
 title: harbor user password
-weight: 30
+weight: 10
 ---
 ## harbor user password
 

--- a/doc/cli-docs/harbor-user-update.md
+++ b/doc/cli-docs/harbor-user-update.md
@@ -1,0 +1,45 @@
+---
+title: harbor user update
+weight: 5
+---
+## harbor user update
+
+### Description
+
+##### update user profile
+
+### Synopsis
+
+The 'update' command allows sysadmins to modify an existing user's profile information, such as their email, realname, or comment.
+
+```sh
+harbor user update [USER_NAME_OR_ID] [flags]
+```
+
+### Examples
+
+```sh
+  harbor user update admin --email newadmin@example.com --realname "System Admin"
+```
+
+### Options
+
+```sh
+      --comment string    Comment
+      --email string      Email
+  -h, --help              help for update
+      --realname string   Realname
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml|csv
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor user](harbor-user.md)	 - Manage users
+

--- a/doc/cli-docs/harbor-user.md
+++ b/doc/cli-docs/harbor-user.md
@@ -1,6 +1,6 @@
 ---
 title: harbor user
-weight: 165
+weight: 70
 ---
 ## harbor user
 
@@ -40,4 +40,5 @@ Manage users in Harbor
 * [harbor user elevate](harbor-user-elevate.md)	 - elevate user
 * [harbor user list](harbor-user-list.md)	 - List users
 * [harbor user password](harbor-user-password.md)	 - Reset user password by name or id
+* [harbor user update](harbor-user-update.md)	 - update user profile
 

--- a/doc/cli-docs/harbor-version.md
+++ b/doc/cli-docs/harbor-version.md
@@ -1,6 +1,6 @@
 ---
 title: harbor version
-weight: 10
+weight: 25
 ---
 ## harbor version
 

--- a/doc/cli-docs/harbor-vulnerability-list.md
+++ b/doc/cli-docs/harbor-vulnerability-list.md
@@ -1,6 +1,6 @@
 ---
 title: harbor vulnerability list
-weight: 90
+weight: 85
 ---
 ## harbor vulnerability list
 

--- a/doc/cli-docs/harbor-vulnerability-summary.md
+++ b/doc/cli-docs/harbor-vulnerability-summary.md
@@ -1,6 +1,6 @@
 ---
 title: harbor vulnerability summary
-weight: 35
+weight: 85
 ---
 ## harbor vulnerability summary
 

--- a/doc/cli-docs/harbor-vulnerability.md
+++ b/doc/cli-docs/harbor-vulnerability.md
@@ -1,6 +1,6 @@
 ---
 title: harbor vulnerability
-weight: 70
+weight: 15
 ---
 ## harbor vulnerability
 

--- a/doc/cli-docs/harbor-webhook-create.md
+++ b/doc/cli-docs/harbor-webhook-create.md
@@ -1,6 +1,6 @@
 ---
 title: harbor webhook create
-weight: 60
+weight: 35
 ---
 ## harbor webhook create
 

--- a/doc/cli-docs/harbor-webhook-delete.md
+++ b/doc/cli-docs/harbor-webhook-delete.md
@@ -1,6 +1,6 @@
 ---
 title: harbor webhook delete
-weight: 70
+weight: 85
 ---
 ## harbor webhook delete
 

--- a/doc/cli-docs/harbor-webhook-edit.md
+++ b/doc/cli-docs/harbor-webhook-edit.md
@@ -1,6 +1,6 @@
 ---
 title: harbor webhook edit
-weight: 55
+weight: 85
 ---
 ## harbor webhook edit
 

--- a/doc/cli-docs/harbor-webhook-list.md
+++ b/doc/cli-docs/harbor-webhook-list.md
@@ -1,6 +1,6 @@
 ---
 title: harbor webhook list
-weight: 60
+weight: 95
 ---
 ## harbor webhook list
 

--- a/doc/cli-docs/harbor-webhook.md
+++ b/doc/cli-docs/harbor-webhook.md
@@ -1,6 +1,6 @@
 ---
 title: harbor webhook
-weight: 20
+weight: 25
 ---
 ## harbor webhook
 

--- a/doc/cli-docs/harbor.md
+++ b/doc/cli-docs/harbor.md
@@ -1,6 +1,6 @@
 ---
 title: harbor
-weight: 95
+weight: 50
 ---
 ## harbor
 

--- a/doc/man-docs/man1/harbor-user-update.1
+++ b/doc/man-docs/man1/harbor-user-update.1
@@ -2,20 +2,32 @@
 .TH "HARBOR" "1"  "Harbor Community" "Harbor User Manuals"
 
 .SH NAME
-harbor-user - Manage users
+harbor-user-update - update user profile
 
 
 .SH SYNOPSIS
-\fBharbor user [flags]\fP
+\fBharbor user update [USER_NAME_OR_ID] [flags]\fP
 
 
 .SH DESCRIPTION
-Manage users in Harbor
+The 'update' command allows sysadmins to modify an existing user's profile information, such as their email, realname, or comment.
 
 
 .SH OPTIONS
+\fB--comment\fP=""
+	Comment
+
+.PP
+\fB--email\fP=""
+	Email
+
+.PP
 \fB-h\fP, \fB--help\fP[=false]
-	help for user
+	help for update
+
+.PP
+\fB--realname\fP=""
+	Realname
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
@@ -33,9 +45,9 @@ Manage users in Harbor
 
 .SH EXAMPLE
 .EX
-  harbor user list
+  harbor user update admin --email newadmin@example.com --realname "System Admin"
 .EE
 
 
 .SH SEE ALSO
-\fBharbor(1)\fP, \fBharbor-user-create(1)\fP, \fBharbor-user-delete(1)\fP, \fBharbor-user-elevate(1)\fP, \fBharbor-user-list(1)\fP, \fBharbor-user-password(1)\fP, \fBharbor-user-update(1)\fP
+\fBharbor-user(1)\fP

--- a/pkg/api/immutable_handler.go
+++ b/pkg/api/immutable_handler.go
@@ -64,12 +64,12 @@ func ListImmutable(projectName string) (immutable.ListImmuRulesOK, error) {
 	return *response, nil
 }
 
-func DeleteImmutable(projectName string, ImmutableID int64) error {
+func DeleteImmutable(projectName string, immutableID int64) error {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {
 		return err
 	}
-	_, err = client.Immutable.DeleteImmuRule(ctx, &immutable.DeleteImmuRuleParams{ProjectNameOrID: projectName, ImmutableRuleID: ImmutableID})
+	_, err = client.Immutable.DeleteImmuRule(ctx, &immutable.DeleteImmuRuleParams{ProjectNameOrID: projectName, ImmutableRuleID: immutableID})
 	if err != nil {
 		return err
 	}

--- a/pkg/api/user_handler.go
+++ b/pkg/api/user_handler.go
@@ -15,6 +15,7 @@ package api
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/user"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
@@ -140,3 +141,64 @@ func ResetPassword(userId int64, opts reset.PasswordChangeView) error {
 	}
 	return nil
 }
+
+func UpdateUserProfile(userId int64, email, realname, comment string) error {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return err
+	}
+
+	_, err = client.User.UpdateUserProfile(ctx, &user.UpdateUserProfileParams{
+		Profile: &models.UserProfile{
+			Email:    email,
+			Realname: realname,
+			Comment:  comment,
+		},
+		UserID: userId,
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("User profile updated successfully for userId %d\n", userId)
+	return nil
+}
+
+func GetUserByIDOrName(arg string) (*models.UserResp, error) {
+	var opts ListFlags
+	u, err := ListUsers(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	id, idErr := strconv.ParseInt(arg, 10, 64)
+
+	for _, uResp := range u.Payload {
+		if idErr == nil && uResp.UserID == id {
+			return uResp, nil
+		}
+		if uResp.Username == arg {
+			return uResp, nil
+		}
+	}
+
+	return nil, fmt.Errorf("user %q not found", arg)
+}
+
+func GetUserByID(userID int64) (*models.UserResp, error) {
+	var opts ListFlags
+	u, err := ListUsers(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, uResp := range u.Payload {
+		if uResp.UserID == userID {
+			return uResp, nil
+		}
+	}
+
+	return nil, fmt.Errorf("user with ID %d not found", userID)
+}
+
+

--- a/pkg/api/user_handler.go
+++ b/pkg/api/user_handler.go
@@ -142,7 +142,7 @@ func ResetPassword(userId int64, opts reset.PasswordChangeView) error {
 	return nil
 }
 
-func UpdateUserProfile(userId int64, email, realname, comment string) error {
+func UpdateUserProfile(userID int64, email, realname, comment string) error {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {
 		return err
@@ -154,13 +154,13 @@ func UpdateUserProfile(userId int64, email, realname, comment string) error {
 			Realname: realname,
 			Comment:  comment,
 		},
-		UserID: userId,
+		UserID: userID,
 	})
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("User profile updated successfully for userId %d\n", userId)
+	fmt.Printf("User profile updated successfully for userID %d\n", userID)
 	return nil
 }
 

--- a/pkg/api/user_handler.go
+++ b/pkg/api/user_handler.go
@@ -165,37 +165,52 @@ func UpdateUserProfile(userID int64, email, realname, comment string) error {
 }
 
 func GetUserByIDOrName(arg string) (*models.UserResp, error) {
-	var opts ListFlags
-	u, err := ListUsers(opts)
-	if err != nil {
-		return nil, err
-	}
-
+	opts := ListFlags{Page: 1, PageSize: 100}
 	id, idErr := strconv.ParseInt(arg, 10, 64)
 
-	for _, uResp := range u.Payload {
-		if idErr == nil && uResp.UserID == id {
-			return uResp, nil
+	for {
+		u, err := ListUsers(opts)
+		if err != nil {
+			return nil, err
 		}
-		if uResp.Username == arg {
-			return uResp, nil
+
+		for _, uResp := range u.Payload {
+			if idErr == nil && uResp.UserID == id {
+				return uResp, nil
+			}
+			if uResp.Username == arg {
+				return uResp, nil
+			}
 		}
+
+		if len(u.Payload) < int(opts.PageSize) {
+			break
+		}
+		opts.Page++
 	}
 
 	return nil, fmt.Errorf("user %q not found", arg)
 }
 
 func GetUserByID(userID int64) (*models.UserResp, error) {
-	var opts ListFlags
-	u, err := ListUsers(opts)
-	if err != nil {
-		return nil, err
-	}
+	opts := ListFlags{Page: 1, PageSize: 100}
 
-	for _, uResp := range u.Payload {
-		if uResp.UserID == userID {
-			return uResp, nil
+	for {
+		u, err := ListUsers(opts)
+		if err != nil {
+			return nil, err
 		}
+
+		for _, uResp := range u.Payload {
+			if uResp.UserID == userID {
+				return uResp, nil
+			}
+		}
+
+		if len(u.Payload) < int(opts.PageSize) {
+			break
+		}
+		opts.Page++
 	}
 
 	return nil, fmt.Errorf("user with ID %d not found", userID)

--- a/pkg/api/user_handler.go
+++ b/pkg/api/user_handler.go
@@ -164,32 +164,20 @@ func UpdateUserProfile(userID int64, email, realname, comment string) error {
 	return nil
 }
 
+// GetUserByIDOrName retrieves a user by either their ID or their Username.
 func GetUserByIDOrName(arg string) (*models.UserResp, error) {
-	opts := ListFlags{Page: 1, PageSize: 100}
-	id, idErr := strconv.ParseInt(arg, 10, 64)
-
-	for {
-		u, err := ListUsers(opts)
-		if err != nil {
-			return nil, err
+	if id, err := strconv.ParseInt(arg, 10, 64); err == nil {
+		if user, err := GetUserByID(id); err == nil {
+			return user, nil
 		}
-
-		for _, uResp := range u.Payload {
-			if idErr == nil && uResp.UserID == id {
-				return uResp, nil
-			}
-			if uResp.Username == arg {
-				return uResp, nil
-			}
-		}
-
-		if len(u.Payload) < int(opts.PageSize) {
-			break
-		}
-		opts.Page++
 	}
 
-	return nil, fmt.Errorf("user %q not found", arg)
+	id, err := GetUsersIdByName(arg)
+	if err != nil {
+		return nil, fmt.Errorf("user %q not found", arg)
+	}
+
+	return GetUserByID(id)
 }
 
 func GetUserByID(userID int64) (*models.UserResp, error) {
@@ -215,5 +203,3 @@ func GetUserByID(userID int64) (*models.UserResp, error) {
 
 	return nil, fmt.Errorf("user with ID %d not found", userID)
 }
-
-

--- a/pkg/api/user_handler.go
+++ b/pkg/api/user_handler.go
@@ -24,8 +24,12 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/views/user/create"
 )
 
-var contextWithClientFunc = utils.ContextWithClient
-
+var (
+	contextWithClientFunc = utils.ContextWithClient
+	listUsersFunc         = ListUsers
+	getUsersIdByNameFunc  = GetUsersIdByName
+	getUserByIDFunc       = GetUserByID
+)
 func CreateUser(opts create.CreateView) error {
 	ctx, client, err := contextWithClientFunc()
 	if err != nil {
@@ -109,7 +113,7 @@ func ListUsers(opts ...ListFlags) (*user.ListUsersOK, error) {
 func GetUsersIdByName(userName string) (int64, error) {
 	var opts ListFlags
 
-	u, err := ListUsers(opts)
+	u, err := listUsersFunc(opts)
 	if err != nil {
 		return 0, err
 	}
@@ -120,7 +124,7 @@ func GetUsersIdByName(userName string) (int64, error) {
 		}
 	}
 
-	return 0, err
+	return 0, fmt.Errorf("user %q not found", userName)
 }
 
 func ResetPassword(userId int64, opts reset.PasswordChangeView) error {
@@ -144,6 +148,7 @@ func ResetPassword(userId int64, opts reset.PasswordChangeView) error {
 	return nil
 }
 
+// UpdateUserProfile updates the email, realname, and comment of the user profile.
 func UpdateUserProfile(userID int64, email, realname, comment string) error {
 	ctx, client, err := contextWithClientFunc()
 	if err != nil {
@@ -169,24 +174,25 @@ func UpdateUserProfile(userID int64, email, realname, comment string) error {
 // GetUserByIDOrName retrieves a user by either their ID or their Username.
 func GetUserByIDOrName(arg string) (*models.UserResp, error) {
 	if id, err := strconv.ParseInt(arg, 10, 64); err == nil {
-		if user, err := GetUserByID(id); err == nil {
+		if user, err := getUserByIDFunc(id); err == nil {
 			return user, nil
 		}
 	}
 
-	id, err := GetUsersIdByName(arg)
+	id, err := getUsersIdByNameFunc(arg)
 	if err != nil {
 		return nil, fmt.Errorf("user %q not found", arg)
 	}
 
-	return GetUserByID(id)
+	return getUserByIDFunc(id)
 }
 
+// GetUserByID retrieves a user by their user ID.
 func GetUserByID(userID int64) (*models.UserResp, error) {
 	opts := ListFlags{Page: 1, PageSize: 100}
 
 	for {
-		u, err := ListUsers(opts)
+		u, err := listUsersFunc(opts)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/api/user_handler.go
+++ b/pkg/api/user_handler.go
@@ -173,14 +173,22 @@ func UpdateUserProfile(userID int64, email, realname, comment string) error {
 
 // GetUserByIDOrName retrieves a user by either their ID or their Username.
 func GetUserByIDOrName(arg string) (*models.UserResp, error) {
-	if id, err := strconv.ParseInt(arg, 10, 64); err == nil {
-		if user, err := getUserByIDFunc(id); err == nil {
-			return user, nil
+	if id, parseErr := strconv.ParseInt(arg, 10, 64); parseErr == nil {
+		u, err := getUserByIDFunc(id)
+		if err == nil {
+			return u, nil
+		}
+		// Only fall back to username lookup if the ID truly doesn't exist.
+		if err.Error() != fmt.Sprintf("user with ID %d not found", id) {
+			return nil, err
 		}
 	}
 
 	id, err := getUsersIdByNameFunc(arg)
 	if err != nil {
+		return nil, err
+	}
+	if id == 0 {
 		return nil, fmt.Errorf("user %q not found", arg)
 	}
 

--- a/pkg/api/user_handler.go
+++ b/pkg/api/user_handler.go
@@ -14,9 +14,11 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
+	v2client "github.com/goharbor/go-client/pkg/sdk/v2.0/client"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/user"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/utils"
@@ -149,6 +151,11 @@ func ResetPassword(userId int64, opts reset.PasswordChangeView) error {
 	return nil
 }
 
+var updateUserProfileAPIFunc = func(ctx context.Context, client *v2client.HarborAPI, params *user.UpdateUserProfileParams) error {
+	_, err := client.User.UpdateUserProfile(ctx, params)
+	return err
+}
+
 // UpdateUserProfile updates the email, realname, and comment of the user profile.
 func UpdateUserProfile(userID int64, email, realname, comment string) error {
 	ctx, client, err := contextWithClientFunc()
@@ -156,7 +163,7 @@ func UpdateUserProfile(userID int64, email, realname, comment string) error {
 		return err
 	}
 
-	_, err = client.User.UpdateUserProfile(ctx, &user.UpdateUserProfileParams{
+	err = updateUserProfileAPIFunc(ctx, client, &user.UpdateUserProfileParams{
 		Profile: &models.UserProfile{
 			Email:    email,
 			Realname: realname,

--- a/pkg/api/user_handler.go
+++ b/pkg/api/user_handler.go
@@ -24,8 +24,10 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/views/user/create"
 )
 
+var contextWithClientFunc = utils.ContextWithClient
+
 func CreateUser(opts create.CreateView) error {
-	ctx, client, err := utils.ContextWithClient()
+	ctx, client, err := contextWithClientFunc()
 	if err != nil {
 		return err
 	}
@@ -51,7 +53,7 @@ func CreateUser(opts create.CreateView) error {
 }
 
 func DeleteUser(userId int64) error {
-	ctx, client, err := utils.ContextWithClient()
+	ctx, client, err := contextWithClientFunc()
 	if err != nil {
 		return err
 	}
@@ -65,7 +67,7 @@ func DeleteUser(userId int64) error {
 }
 
 func ElevateUser(userId int64) error {
-	ctx, client, err := utils.ContextWithClient()
+	ctx, client, err := contextWithClientFunc()
 	if err != nil {
 		return err
 	}
@@ -82,7 +84,7 @@ func ElevateUser(userId int64) error {
 }
 
 func ListUsers(opts ...ListFlags) (*user.ListUsersOK, error) {
-	ctx, client, err := utils.ContextWithClient()
+	ctx, client, err := contextWithClientFunc()
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +124,7 @@ func GetUsersIdByName(userName string) (int64, error) {
 }
 
 func ResetPassword(userId int64, opts reset.PasswordChangeView) error {
-	ctx, client, err := utils.ContextWithClient()
+	ctx, client, err := contextWithClientFunc()
 	if err != nil {
 		return err
 	}
@@ -143,7 +145,7 @@ func ResetPassword(userId int64, opts reset.PasswordChangeView) error {
 }
 
 func UpdateUserProfile(userID int64, email, realname, comment string) error {
-	ctx, client, err := utils.ContextWithClient()
+	ctx, client, err := contextWithClientFunc()
 	if err != nil {
 		return err
 	}

--- a/pkg/api/user_handler.go
+++ b/pkg/api/user_handler.go
@@ -30,6 +30,7 @@ var (
 	getUsersIdByNameFunc  = GetUsersIdByName
 	getUserByIDFunc       = GetUserByID
 )
+
 func CreateUser(opts create.CreateView) error {
 	ctx, client, err := contextWithClientFunc()
 	if err != nil {

--- a/pkg/api/user_handler_test.go
+++ b/pkg/api/user_handler_test.go
@@ -1,0 +1,38 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpdateUserProfile(t *testing.T) {
+	// Without a valid client context, this should return an error
+	err := UpdateUserProfile(1, "test@example.com", "Test User", "Test Comment")
+	assert.Error(t, err)
+}
+
+func TestGetUserByIDOrName(t *testing.T) {
+	// Without a valid client context, this should return an error
+	_, err := GetUserByIDOrName("admin")
+	assert.Error(t, err)
+}
+
+func TestGetUserByID(t *testing.T) {
+	// Without a valid client context, this should return an error
+	_, err := GetUserByID(1)
+	assert.Error(t, err)
+}

--- a/pkg/api/user_handler_test.go
+++ b/pkg/api/user_handler_test.go
@@ -107,3 +107,38 @@ func TestGetUserByIDOrName_SuccessByName(t *testing.T) {
 	assert.Equal(t, int64(2), u.UserID)
 	assert.Equal(t, "testuser", u.Username)
 }
+
+func TestGetUserByIDOrName_FallbackToNameWhenIDNotFound(t *testing.T) {
+	origGetUsersIdByNameFunc := getUsersIdByNameFunc
+	origGetUserByIDFunc := getUserByIDFunc
+	defer func() {
+		getUsersIdByNameFunc = origGetUsersIdByNameFunc
+		getUserByIDFunc = origGetUserByIDFunc
+	}()
+
+	getUsersIdByNameFunc = func(userName string) (int64, error) {
+		if userName == "2" {
+			return 2, nil
+		}
+		return 0, errors.New("not found")
+	}
+
+	callCount := 0
+	getUserByIDFunc = func(userID int64) (*models.UserResp, error) {
+		callCount++
+		// First call from strconv.ParseInt fails
+		if callCount == 1 {
+			return nil, fmt.Errorf("user with ID %d not found", userID)
+		}
+		// Second call after name lookup fallback succeeds
+		if userID == 2 {
+			return &models.UserResp{UserID: 2, Username: "2"}, nil
+		}
+		return nil, fmt.Errorf("user with ID %d not found", userID)
+	}
+
+	u, err := GetUserByIDOrName("2")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(2), u.UserID)
+	assert.Equal(t, "2", u.Username)
+}

--- a/pkg/api/user_handler_test.go
+++ b/pkg/api/user_handler_test.go
@@ -16,6 +16,7 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	v2client "github.com/goharbor/go-client/pkg/sdk/v2.0/client"

--- a/pkg/api/user_handler_test.go
+++ b/pkg/api/user_handler_test.go
@@ -47,7 +47,7 @@ func TestGetUserByIDOrName(t *testing.T) {
 	// Without a valid client context, this should return an error
 	_, err := GetUserByIDOrName("admin")
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "not found")
+	assert.Contains(t, err.Error(), "mocked error")
 }
 
 func TestGetUserByID(t *testing.T) {

--- a/pkg/api/user_handler_test.go
+++ b/pkg/api/user_handler_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 
 	v2client "github.com/goharbor/go-client/pkg/sdk/v2.0/client"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/user"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -45,7 +47,7 @@ func TestGetUserByIDOrName(t *testing.T) {
 	// Without a valid client context, this should return an error
 	_, err := GetUserByIDOrName("admin")
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "mocked error")
+	assert.Contains(t, err.Error(), "not found")
 }
 
 func TestGetUserByID(t *testing.T) {
@@ -59,4 +61,49 @@ func TestGetUserByID(t *testing.T) {
 	_, err := GetUserByID(1)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "mocked error")
+}
+
+func TestGetUserByID_Success(t *testing.T) {
+	origListUsersFunc := listUsersFunc
+	defer func() { listUsersFunc = origListUsersFunc }()
+	listUsersFunc = func(opts ...ListFlags) (*user.ListUsersOK, error) {
+		return &user.ListUsersOK{
+			Payload: []*models.UserResp{
+				{UserID: 1, Username: "admin"},
+			},
+		}, nil
+	}
+
+	u, err := GetUserByID(1)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), u.UserID)
+	assert.Equal(t, "admin", u.Username)
+}
+
+func TestGetUserByIDOrName_SuccessByName(t *testing.T) {
+	origGetUsersIdByNameFunc := getUsersIdByNameFunc
+	origGetUserByIDFunc := getUserByIDFunc
+	defer func() {
+		getUsersIdByNameFunc = origGetUsersIdByNameFunc
+		getUserByIDFunc = origGetUserByIDFunc
+	}()
+
+	getUsersIdByNameFunc = func(userName string) (int64, error) {
+		if userName == "testuser" {
+			return 2, nil
+		}
+		return 0, errors.New("not found")
+	}
+
+	getUserByIDFunc = func(userID int64) (*models.UserResp, error) {
+		if userID == 2 {
+			return &models.UserResp{UserID: 2, Username: "testuser"}, nil
+		}
+		return nil, errors.New("not found")
+	}
+
+	u, err := GetUserByIDOrName("testuser")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(2), u.UserID)
+	assert.Equal(t, "testuser", u.Username)
 }

--- a/pkg/api/user_handler_test.go
+++ b/pkg/api/user_handler_test.go
@@ -14,25 +14,49 @@
 package api
 
 import (
+	"context"
+	"errors"
 	"testing"
 
+	v2client "github.com/goharbor/go-client/pkg/sdk/v2.0/client"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestUpdateUserProfile(t *testing.T) {
+	origContextWithClient := contextWithClientFunc
+	defer func() { contextWithClientFunc = origContextWithClient }()
+	contextWithClientFunc = func() (context.Context, *v2client.HarborAPI, error) {
+		return nil, nil, errors.New("mocked error")
+	}
+
 	// Without a valid client context, this should return an error
 	err := UpdateUserProfile(1, "test@example.com", "Test User", "Test Comment")
 	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "mocked error")
 }
 
 func TestGetUserByIDOrName(t *testing.T) {
+	origContextWithClient := contextWithClientFunc
+	defer func() { contextWithClientFunc = origContextWithClient }()
+	contextWithClientFunc = func() (context.Context, *v2client.HarborAPI, error) {
+		return nil, nil, errors.New("mocked error")
+	}
+
 	// Without a valid client context, this should return an error
 	_, err := GetUserByIDOrName("admin")
 	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "mocked error")
 }
 
 func TestGetUserByID(t *testing.T) {
+	origContextWithClient := contextWithClientFunc
+	defer func() { contextWithClientFunc = origContextWithClient }()
+	contextWithClientFunc = func() (context.Context, *v2client.HarborAPI, error) {
+		return nil, nil, errors.New("mocked error")
+	}
+
 	// Without a valid client context, this should return an error
 	_, err := GetUserByID(1)
 	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "mocked error")
 }

--- a/pkg/api/user_handler_test.go
+++ b/pkg/api/user_handler_test.go
@@ -38,6 +38,51 @@ func TestUpdateUserProfile(t *testing.T) {
 	assert.Contains(t, err.Error(), "mocked error")
 }
 
+func TestUpdateUserProfile_Success(t *testing.T) {
+	origContextWithClient := contextWithClientFunc
+	origUpdateUserProfileAPI := updateUserProfileAPIFunc
+	defer func() {
+		contextWithClientFunc = origContextWithClient
+		updateUserProfileAPIFunc = origUpdateUserProfileAPI
+	}()
+
+	contextWithClientFunc = func() (context.Context, *v2client.HarborAPI, error) {
+		return context.Background(), &v2client.HarborAPI{}, nil
+	}
+
+	updateUserProfileAPIFunc = func(ctx context.Context, client *v2client.HarborAPI, params *user.UpdateUserProfileParams) error {
+		assert.Equal(t, int64(1), params.UserID)
+		assert.Equal(t, "test@example.com", params.Profile.Email)
+		assert.Equal(t, "Test User", params.Profile.Realname)
+		assert.Equal(t, "Test Comment", params.Profile.Comment)
+		return nil
+	}
+
+	err := UpdateUserProfile(1, "test@example.com", "Test User", "Test Comment")
+	assert.NoError(t, err)
+}
+
+func TestUpdateUserProfile_APIError(t *testing.T) {
+	origContextWithClient := contextWithClientFunc
+	origUpdateUserProfileAPI := updateUserProfileAPIFunc
+	defer func() {
+		contextWithClientFunc = origContextWithClient
+		updateUserProfileAPIFunc = origUpdateUserProfileAPI
+	}()
+
+	contextWithClientFunc = func() (context.Context, *v2client.HarborAPI, error) {
+		return context.Background(), &v2client.HarborAPI{}, nil
+	}
+
+	updateUserProfileAPIFunc = func(ctx context.Context, client *v2client.HarborAPI, params *user.UpdateUserProfileParams) error {
+		return errors.New("api error")
+	}
+
+	err := UpdateUserProfile(1, "test@example.com", "Test User", "Test Comment")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "api error")
+}
+
 func TestGetUserByIDOrName(t *testing.T) {
 	origContextWithClient := contextWithClientFunc
 	defer func() { contextWithClientFunc = origContextWithClient }()
@@ -81,6 +126,45 @@ func TestGetUserByID_Success(t *testing.T) {
 	assert.Equal(t, "admin", u.Username)
 }
 
+func TestGetUserByID_NotFound(t *testing.T) {
+	origListUsersFunc := listUsersFunc
+	defer func() { listUsersFunc = origListUsersFunc }()
+	listUsersFunc = func(opts ...ListFlags) (*user.ListUsersOK, error) {
+		return &user.ListUsersOK{
+			Payload: []*models.UserResp{},
+		}, nil
+	}
+
+	_, err := GetUserByID(999)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "user with ID 999 not found")
+}
+
+func TestGetUserByID_SecondPage(t *testing.T) {
+	origListUsersFunc := listUsersFunc
+	defer func() { listUsersFunc = origListUsersFunc }()
+	listUsersFunc = func(opts ...ListFlags) (*user.ListUsersOK, error) {
+		if opts[0].Page == 1 {
+			// Return 100 dummy users to simulate full page
+			payload := make([]*models.UserResp, 100)
+			for i := 0; i < 100; i++ {
+				payload[i] = &models.UserResp{UserID: int64(i + 10)}
+			}
+			return &user.ListUsersOK{Payload: payload}, nil
+		}
+		return &user.ListUsersOK{
+			Payload: []*models.UserResp{
+				{UserID: 2, Username: "target"},
+			},
+		}, nil
+	}
+
+	u, err := GetUserByID(2)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(2), u.UserID)
+	assert.Equal(t, "target", u.Username)
+}
+
 func TestGetUserByIDOrName_SuccessByName(t *testing.T) {
 	origGetUsersIdByNameFunc := getUsersIdByNameFunc
 	origGetUserByIDFunc := getUserByIDFunc
@@ -107,6 +191,43 @@ func TestGetUserByIDOrName_SuccessByName(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, int64(2), u.UserID)
 	assert.Equal(t, "testuser", u.Username)
+}
+
+func TestGetUserByIDOrName_IDLookupError(t *testing.T) {
+	origGetUserByIDFunc := getUserByIDFunc
+	defer func() { getUserByIDFunc = origGetUserByIDFunc }()
+	getUserByIDFunc = func(userID int64) (*models.UserResp, error) {
+		return nil, errors.New("some API error")
+	}
+
+	_, err := GetUserByIDOrName("123")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "some API error")
+}
+
+func TestGetUserByIDOrName_IDZero(t *testing.T) {
+	origGetUsersIdByNameFunc := getUsersIdByNameFunc
+	defer func() { getUsersIdByNameFunc = origGetUsersIdByNameFunc }()
+	getUsersIdByNameFunc = func(userName string) (int64, error) {
+		return 0, nil
+	}
+
+	_, err := GetUserByIDOrName("notfounduser")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "user \"notfounduser\" not found")
+}
+
+func TestGetUserByIDOrName_SuccessByID(t *testing.T) {
+	origGetUserByIDFunc := getUserByIDFunc
+	defer func() { getUserByIDFunc = origGetUserByIDFunc }()
+	getUserByIDFunc = func(userID int64) (*models.UserResp, error) {
+		return &models.UserResp{UserID: 123, Username: "byid"}, nil
+	}
+
+	u, err := GetUserByIDOrName("123")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(123), u.UserID)
+	assert.Equal(t, "byid", u.Username)
 }
 
 func TestGetUserByIDOrName_FallbackToNameWhenIDNotFound(t *testing.T) {

--- a/pkg/views/user/update/view.go
+++ b/pkg/views/user/update/view.go
@@ -1,0 +1,70 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package update
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/charmbracelet/huh"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	log "github.com/sirupsen/logrus"
+)
+
+type UpdateView struct {
+	Email    string
+	Realname string
+	Comment  string
+}
+
+func UpdateUserView(updateView *UpdateView) {
+	theme := huh.ThemeCharm()
+	err := huh.NewForm(
+		huh.NewGroup(
+			huh.NewInput().
+				Title("Email").
+				Value(&updateView.Email).
+				Validate(func(str string) error {
+					if strings.TrimSpace(str) == "" {
+						return errors.New("email cannot be empty or only spaces")
+					}
+					if isValid := utils.ValidateEmail(str); !isValid {
+						return errors.New("please enter correct email format")
+					}
+					return nil
+				}),
+
+			huh.NewInput().
+				Title("First and Last Name").
+				Value(&updateView.Realname).
+				Validate(func(str string) error {
+					if strings.TrimSpace(str) == "" {
+						return errors.New("real name cannot be empty")
+					}
+					if isValid := utils.ValidateFL(str); !isValid {
+						return errors.New("please enter correct first and last name format, like `Bob Dylan`")
+					}
+					return nil
+				}),
+
+			huh.NewInput().
+				Title("Comment (optional)").
+				Value(&updateView.Comment),
+		),
+	).WithTheme(theme).Run()
+
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/pkg/views/user/update/view.go
+++ b/pkg/views/user/update/view.go
@@ -19,16 +19,17 @@ import (
 
 	"github.com/charmbracelet/huh"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 )
 
+// UpdateView holds the data for the user profile update view.
 type UpdateView struct {
 	Email    string
 	Realname string
 	Comment  string
 }
 
-func UpdateUserView(updateView *UpdateView) {
+// UpdateUserView launches the interactive form to update the user profile.
+func UpdateUserView(updateView *UpdateView) error {
 	theme := huh.ThemeCharm()
 	err := huh.NewForm(
 		huh.NewGroup(
@@ -65,6 +66,7 @@ func UpdateUserView(updateView *UpdateView) {
 	).WithTheme(theme).Run()
 
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
+	return nil
 }

--- a/pkg/views/user/update/view.go
+++ b/pkg/views/user/update/view.go
@@ -28,43 +28,52 @@ type UpdateView struct {
 	Comment  string
 }
 
+var runForm = func(f *huh.Form) error {
+	return f.Run()
+}
+
+func ValidateEmail(str string) error {
+	if strings.TrimSpace(str) == "" {
+		return errors.New("email cannot be empty or only spaces")
+	}
+	if isValid := utils.ValidateEmail(str); !isValid {
+		return errors.New("please enter correct email format")
+	}
+	return nil
+}
+
+func ValidateRealname(str string) error {
+	if strings.TrimSpace(str) == "" {
+		return errors.New("real name cannot be empty")
+	}
+	if isValid := utils.ValidateFL(str); !isValid {
+		return errors.New("please enter correct first and last name format, like `Bob Dylan`")
+	}
+	return nil
+}
+
 // UpdateUserView launches the interactive form to update the user profile.
 func UpdateUserView(updateView *UpdateView) error {
 	theme := huh.ThemeCharm()
-	err := huh.NewForm(
+	form := huh.NewForm(
 		huh.NewGroup(
 			huh.NewInput().
 				Title("Email").
 				Value(&updateView.Email).
-				Validate(func(str string) error {
-					if strings.TrimSpace(str) == "" {
-						return errors.New("email cannot be empty or only spaces")
-					}
-					if isValid := utils.ValidateEmail(str); !isValid {
-						return errors.New("please enter correct email format")
-					}
-					return nil
-				}),
+				Validate(ValidateEmail),
 
 			huh.NewInput().
 				Title("First and Last Name").
 				Value(&updateView.Realname).
-				Validate(func(str string) error {
-					if strings.TrimSpace(str) == "" {
-						return errors.New("real name cannot be empty")
-					}
-					if isValid := utils.ValidateFL(str); !isValid {
-						return errors.New("please enter correct first and last name format, like `Bob Dylan`")
-					}
-					return nil
-				}),
+				Validate(ValidateRealname),
 
 			huh.NewInput().
 				Title("Comment (optional)").
 				Value(&updateView.Comment),
 		),
-	).WithTheme(theme).Run()
+	).WithTheme(theme)
 
+	err := runForm(form)
 	if err != nil {
 		return err
 	}

--- a/pkg/views/user/update/view_test.go
+++ b/pkg/views/user/update/view_test.go
@@ -1,3 +1,16 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package update
 
 import (

--- a/pkg/views/user/update/view_test.go
+++ b/pkg/views/user/update/view_test.go
@@ -1,0 +1,50 @@
+package update
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/charmbracelet/huh"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateEmail(t *testing.T) {
+	assert.Error(t, ValidateEmail(""))
+	assert.Error(t, ValidateEmail("   "))
+	assert.Error(t, ValidateEmail("invalid-email"))
+	assert.NoError(t, ValidateEmail("test@example.com"))
+}
+
+func TestValidateRealname(t *testing.T) {
+	assert.Error(t, ValidateRealname(""))
+	assert.Error(t, ValidateRealname("   "))
+	assert.Error(t, ValidateRealname("Bob")) // Assuming ValidateFL requires First and Last
+	assert.NoError(t, ValidateRealname("Bob Dylan"))
+}
+
+func TestUpdateUserView(t *testing.T) {
+	origRunForm := runForm
+	defer func() { runForm = origRunForm }()
+
+	runForm = func(f *huh.Form) error {
+		return nil // mock successful form execution
+	}
+
+	view := &UpdateView{}
+	err := UpdateUserView(view)
+	assert.NoError(t, err)
+}
+
+func TestUpdateUserView_Error(t *testing.T) {
+	origRunForm := runForm
+	defer func() { runForm = origRunForm }()
+
+	runForm = func(f *huh.Form) error {
+		return errors.New("form error") // mock form error
+	}
+
+	view := &UpdateView{}
+	err := UpdateUserView(view)
+	assert.Error(t, err)
+	assert.Equal(t, "form error", err.Error())
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
The user command group currently supports create, delete, list, elevate, and password subcommands, but lacks an `update` command. In the Harbor REST API, the `PUT /users/{user_id}` endpoint allows administrators to update a user's email, realname, and comment fields.

This PR implements the missing `harbor user update` command to support these user profile modifications.

It features:
1. **Interactive Workflow**: Running `harbor user update` prompts the user to select a user from the visual list (using `huh` and `bubbletea`), prepopulates the form with existing user values (retrieved using the client), and allows interactive updates.
2. **Non-interactive Workflow**: Running `harbor user update <username-or-id> --email "new@example.com" --realname "New Name"` updates only the requested fields without displaying prompts, falling back to existing values for unspecified fields.
3. **Robust ID/Name Resolution**: Accepts both user ID (integer) or username arguments.
4. **Validation and Error Handling**: Validates email format changes and checks for `403` unauthorized responses to provide clean user feedback.
5. **Command Unit Tests**: Added metadata, flags, and command validation tests under `cmd/harbor/root/user/update_test.go`.

**Which issue(s) this PR fixes**:
Fixes #966

**Does this PR introduce a user-facing change?**:
```release-note
Implement `harbor user update` command to modify user profile fields (email, realname, comment) interactively or via flags.


