### PR TITLE
feat(replication):Replication policies update from file config

### DIFF
--- a/cmd/harbor/root/replication/policies/update.go
+++ b/cmd/harbor/root/replication/policies/update.go
@@ -19,7 +19,9 @@ import (
 
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/api"
+	config "github.com/goharbor/harbor-cli/pkg/config/replication"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
+	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/replication/policies/create"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -27,6 +29,7 @@ import (
 
 // UpdateCommand returns a command to update existing replication policies
 func UpdateCommand() *cobra.Command {
+	var configFile string
 	cmd := &cobra.Command{
 		Use:   "update [policy-id]",
 		Short: "Update an existing replication policy",
@@ -43,81 +46,108 @@ func UpdateCommand() *cobra.Command {
 				policyID = prompt.GetReplicationPolicyFromUser()
 			}
 
-			existingPolicy, err := api.GetReplicationPolicy(policyID)
-			if err != nil {
-				return fmt.Errorf("failed to get replication policy: %w", err)
-			}
-
-			var existingReplicationMode string
-			if existingPolicy.Payload.SrcRegistry.ID != 0 && existingPolicy.Payload.DestRegistry.ID == 0 {
-				existingReplicationMode = "Pull"
-			} else if existingPolicy.Payload.SrcRegistry.ID == 0 && existingPolicy.Payload.DestRegistry.ID != 0 {
-				existingReplicationMode = "Push"
-			} else {
-				return fmt.Errorf("replication policy with ID %d is neither Pull nor Push", policyID)
-			}
-
-			createView := &create.CreateView{
-				Name:              existingPolicy.Payload.Name,
-				Description:       existingPolicy.Payload.Description,
-				Enabled:           existingPolicy.Payload.Enabled,
-				Override:          existingPolicy.Payload.Override,
-				ReplicateDeletion: existingPolicy.Payload.ReplicateDeletion,
-				ReplicationMode:   existingReplicationMode,
-			}
-
-			if existingPolicy.Payload.CopyByChunk != nil {
-				createView.CopyByChunk = *existingPolicy.Payload.CopyByChunk
-			}
-
-			if existingPolicy.Payload.Speed != nil {
-				if *existingPolicy.Payload.Speed == 0 {
-					speed := int32(-1)
-					existingPolicy.Payload.Speed = &speed
-				}
-				createView.Speed = strconv.FormatInt(int64(*existingPolicy.Payload.Speed), 10)
-			}
-
-			if existingPolicy.Payload.SrcRegistry != nil && existingPolicy.Payload.DestRegistry == nil {
-				createView.ReplicationMode = "Pull"
-			} else if existingPolicy.Payload.SrcRegistry == nil && existingPolicy.Payload.DestRegistry != nil {
-				createView.ReplicationMode = "Push"
-			}
-
-			if existingPolicy.Payload.Trigger != nil {
-				createView.TriggerType = existingPolicy.Payload.Trigger.Type
-
-				if existingPolicy.Payload.Trigger.TriggerSettings != nil {
-					if existingPolicy.Payload.Trigger.Type == "scheduled" {
-						createView.CronString = existingPolicy.Payload.Trigger.TriggerSettings.Cron
-					} else if existingPolicy.Payload.Trigger.Type == "event_based" {
-						createView.ReplicateDeletion = existingPolicy.Payload.ReplicateDeletion
-					}
-				}
-			}
-
-			log.Debugf("Updating replication policy: %s (ID: %d)", existingPolicy.Payload.Name, policyID)
-			create.CreateRPolicyView(createView, true)
-
 			var updatedPolicy *models.ReplicationPolicy
 
-			fmt.Println("Updated policy replicate deletion:", createView.ReplicateDeletion)
-			if createView.ReplicationMode == "Pull" {
-				updatedPolicy = ConvertToPolicy(createView, existingPolicy.Payload.SrcRegistry)
+			if configFile != "" {
+				log.Debugf("Loading replication policy configuration from file: %s", configFile)
+				opts, err := config.LoadConfigFromFile(configFile)
+				if err != nil {
+					return fmt.Errorf("failed to load replication policy configuration: %v", err)
+				}
+
+				registryID, err := api.GetRegistryIdByName(opts.TargetRegistry)
+				if err != nil {
+					return fmt.Errorf("failed to get registry ID for name %s: %v", opts.TargetRegistry, err)
+				}
+				if registryID == 0 {
+					return fmt.Errorf("registry with name %s not found", opts.TargetRegistry)
+				}
+
+				registry, err := api.GetRegistryResponse(registryID)
+				if err != nil {
+					return fmt.Errorf("failed to get registry with ID %d: %v", registryID, err)
+				}
+
+				updatedPolicy = ConvertToPolicy(opts, registry)
 				updatedPolicy.ID = policyID
 			} else {
-				updatedPolicy = ConvertToPolicy(createView, existingPolicy.Payload.DestRegistry)
+				existingPolicy, err := api.GetReplicationPolicy(policyID)
+				if err != nil {
+					return fmt.Errorf("failed to get replication policy: %w", err)
+				}
+
+				var existingReplicationMode string
+				if existingPolicy.Payload.SrcRegistry.ID != 0 && existingPolicy.Payload.DestRegistry.ID == 0 {
+					existingReplicationMode = "Pull"
+				} else if existingPolicy.Payload.SrcRegistry.ID == 0 && existingPolicy.Payload.DestRegistry.ID != 0 {
+					existingReplicationMode = "Push"
+				} else {
+					return fmt.Errorf("replication policy with ID %d is neither Pull nor Push", policyID)
+				}
+
+				createView := &create.CreateView{
+					Name:              existingPolicy.Payload.Name,
+					Description:       existingPolicy.Payload.Description,
+					Enabled:           existingPolicy.Payload.Enabled,
+					Override:          existingPolicy.Payload.Override,
+					ReplicateDeletion: existingPolicy.Payload.ReplicateDeletion,
+					ReplicationMode:   existingReplicationMode,
+				}
+
+				if existingPolicy.Payload.CopyByChunk != nil {
+					createView.CopyByChunk = *existingPolicy.Payload.CopyByChunk
+				}
+
+				if existingPolicy.Payload.Speed != nil {
+					if *existingPolicy.Payload.Speed == 0 {
+						speed := int32(-1)
+						existingPolicy.Payload.Speed = &speed
+					}
+					createView.Speed = strconv.FormatInt(int64(*existingPolicy.Payload.Speed), 10)
+				}
+
+				if existingPolicy.Payload.SrcRegistry != nil && existingPolicy.Payload.DestRegistry == nil {
+					createView.ReplicationMode = "Pull"
+				} else if existingPolicy.Payload.SrcRegistry == nil && existingPolicy.Payload.DestRegistry != nil {
+					createView.ReplicationMode = "Push"
+				}
+
+				if existingPolicy.Payload.Trigger != nil {
+					createView.TriggerType = existingPolicy.Payload.Trigger.Type
+
+					if existingPolicy.Payload.Trigger.TriggerSettings != nil {
+						if existingPolicy.Payload.Trigger.Type == "scheduled" {
+							createView.CronString = existingPolicy.Payload.Trigger.TriggerSettings.Cron
+						} else if existingPolicy.Payload.Trigger.Type == "event_based" {
+							createView.ReplicateDeletion = existingPolicy.Payload.ReplicateDeletion
+						}
+					}
+				}
+
+				log.Debugf("Updating replication policy: %s (ID: %d)", existingPolicy.Payload.Name, policyID)
+				create.CreateRPolicyView(createView, true)
+
+				fmt.Println("Updated policy replicate deletion:", createView.ReplicateDeletion)
+				if createView.ReplicationMode == "Pull" {
+					updatedPolicy = ConvertToPolicy(createView, existingPolicy.Payload.SrcRegistry)
+					updatedPolicy.ID = policyID
+				} else {
+					updatedPolicy = ConvertToPolicy(createView, existingPolicy.Payload.DestRegistry)
+				}
 			}
 
-			_, err = api.UpdateReplicationPolicy(policyID, updatedPolicy)
+			_, err := api.UpdateReplicationPolicy(policyID, updatedPolicy)
 			if err != nil {
-				return fmt.Errorf("failed to update replication policy: %w", err)
+				return fmt.Errorf("failed to update replication policy: %v", utils.ParseHarborErrorMsg(err))
 			}
 
 			fmt.Printf("Successfully updated replication policy: %s (ID: %d)\n", updatedPolicy.Name, policyID)
 			return nil
 		},
 	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&configFile, "policy-config-file", "f", "", "YAML/JSON file with replication policy configuration")
 
 	return cmd
 }

--- a/doc/cli-docs/harbor-replication-policies-update.md
+++ b/doc/cli-docs/harbor-replication-policies-update.md
@@ -15,7 +15,8 @@ harbor replication policies update [policy-id] [flags]
 ### Options
 
 ```sh
-  -h, --help   help for update
+  -h, --help                        help for update
+  -f, --policy-config-file string   YAML/JSON file with replication policy configuration
 ```
 
 ### Options inherited from parent commands

--- a/doc/man-docs/man1/harbor-replication-policies-update.1
+++ b/doc/man-docs/man1/harbor-replication-policies-update.1
@@ -17,6 +17,10 @@ Update an existing replication policy
 \fB-h\fP, \fB--help\fP[=false]
 	help for update
 
+.PP
+\fB-f\fP, \fB--policy-config-file\fP=""
+	YAML/JSON file with replication policy configuration
+
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 \fB-c\fP, \fB--config\fP=""


### PR DESCRIPTION
## Description
Adds a  flag to allow updating replication policies from a YAML/JSON file

- Fixes #1036 

## Type of Change
Please select the relevant type.

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance


