### PR TITLE
fix(cli): correct Repliation→Replication typo and missing newline

### DIFF
--- a/cmd/harbor/root/configurations/apply.go
+++ b/cmd/harbor/root/configurations/apply.go
@@ -115,7 +115,7 @@ Make sure to run 'harbor config get' first to populate the local config file wit
 				return fmt.Errorf("failed to update Harbor configurations: %v", err)
 			}
 
-			fmt.Printf("harbor configurations updated successfully from %s.", cfgFile)
+			fmt.Printf("harbor configurations updated successfully from %s.\n", cfgFile)
 			return nil
 		},
 	}

--- a/cmd/harbor/root/replication/start.go
+++ b/cmd/harbor/root/replication/start.go
@@ -47,7 +47,7 @@ func StartCommand() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to start replication: %v", utils.ParseHarborErrorMsg(err))
 			}
-			fmt.Printf("Repliation started successfully with ID: %s\n", response.Location)
+			fmt.Printf("Replication started successfully with ID: %s\n", response.Location)
 			return nil
 		},
 	}


### PR DESCRIPTION
## Summary

Fixes #1041 — two minor CLI output issues:

1. **Typo fix**: `Repliation started` → `Replication started` in `cmd/harbor/root/replication/start.go`
2. **Missing newline**: `fmt.Printf` now properly terminates with `\n` in `cmd/harbor/root/configurations/apply.go` (line 118), so the prompt doesn't overwrite the success message

Both are user-facing output fixes matching the issue description exactly.

---
*Submitted via automation*