### PR TITLE
feat: add harbor project update command

### DIFF
--- a/cmd/harbor/root/project/cmd.go
+++ b/cmd/harbor/root/project/cmd.go
@@ -27,6 +27,7 @@ func Project() *cobra.Command {
 	}
 	cmd.AddCommand(
 		CreateProjectCommand(),
+		UpdateProjectCommand(),
 		DeleteProjectCommand(),
 		ListProjectCommand(),
 		ViewCommand(),

--- a/cmd/harbor/root/project/update.go
+++ b/cmd/harbor/root/project/update.go
@@ -1,0 +1,242 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package project
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/prompt"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/goharbor/harbor-cli/pkg/views/project/update"
+	"github.com/spf13/cobra"
+)
+
+func UpdateProjectCommand() *cobra.Command {
+	var (
+		isID             bool
+		publicFlag       string
+		autoScanFlag     string
+		preventVulFlag   string
+		reuseSysCVEFlag  string
+		severityFlag     string
+		storageLimitFlag string
+		registryIDFlag   string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "update [project_name]",
+		Short: "Update a project",
+		Long: `Update project settings such as visibility, storage quota, and metadata.
+
+Examples:
+  harbor project update myproject --public true
+  harbor project update myproject --storage-limit -1 --prevent-vul true`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+			var projectNameOrID string
+
+			if len(args) > 0 {
+				projectNameOrID = args[0]
+			} else {
+				projectNameOrID, err = prompt.GetProjectNameFromUser()
+				if err != nil {
+					return fmt.Errorf("failed to get project name: %v", err)
+				}
+				isID = false
+			}
+
+			flags := cmd.Flags()
+			flagsUsed := false
+			storageChanged := false
+
+			if flags.Changed("public") {
+				if err := validateUpdateFlag("public", publicFlag); err != nil {
+					return err
+				}
+				flagsUsed = true
+			}
+			if flags.Changed("auto-scan") {
+				if err := validateUpdateFlag("auto-scan", autoScanFlag); err != nil {
+					return err
+				}
+				flagsUsed = true
+			}
+			if flags.Changed("prevent-vul") {
+				if err := validateUpdateFlag("prevent-vul", preventVulFlag); err != nil {
+					return err
+				}
+				flagsUsed = true
+			}
+			if flags.Changed("reuse-sys-cve") {
+				if err := validateUpdateFlag("reuse-sys-cve", reuseSysCVEFlag); err != nil {
+					return err
+				}
+				flagsUsed = true
+			}
+			if flags.Changed("severity") {
+				if err := validateUpdateFlag("severity", severityFlag); err != nil {
+					return err
+				}
+				flagsUsed = true
+			}
+			if flags.Changed("storage-limit") {
+				if err := utils.ValidateStorageLimit(storageLimitFlag); err != nil {
+					return err
+				}
+				flagsUsed = true
+				storageChanged = true
+			}
+			if flags.Changed("registry-id") {
+				flagsUsed = true
+			}
+
+			resp, err := api.GetProject(projectNameOrID, isID)
+			if err != nil {
+				return fmt.Errorf("failed to get project: %v", utils.ParseHarborErrorMsg(err))
+			}
+
+			projectPayload := resp.Payload
+			metadata := projectPayload.Metadata
+			if metadata == nil {
+				metadata = &models.ProjectMetadata{}
+			}
+
+			updateView := &update.UpdateView{
+				Public:       metadata.Public,
+				StorageLimit: currentStorageLimit(projectPayload.ProjectID),
+				RegistryID:   strconv.FormatInt(projectPayload.RegistryID, 10),
+				AutoScan:     metadata.AutoScan,
+				PreventVul:   metadata.PreventVul,
+				Severity:     metadata.Severity,
+				ReuseSysCVE:  metadata.ReuseSysCVEAllowlist,
+			}
+
+			if flags.Changed("public") {
+				metadata.Public = publicFlag
+				updateView.Public = publicFlag
+			}
+			if flags.Changed("auto-scan") {
+				metadata.AutoScan = &autoScanFlag
+			}
+			if flags.Changed("prevent-vul") {
+				metadata.PreventVul = &preventVulFlag
+			}
+			if flags.Changed("reuse-sys-cve") {
+				metadata.ReuseSysCVEAllowlist = &reuseSysCVEFlag
+			}
+			if flags.Changed("severity") {
+				metadata.Severity = &severityFlag
+			}
+			if flags.Changed("storage-limit") {
+				updateView.StorageLimit = storageLimitFlag
+			}
+			if flags.Changed("registry-id") {
+				updateView.RegistryID = registryIDFlag
+			}
+
+			if !flagsUsed {
+				if err := update.UpdateProjectView(updateView); err != nil {
+					return fmt.Errorf("update cancelled or failed: %v", err)
+				}
+				metadata.Public = updateView.Public
+				metadata.AutoScan = updateView.AutoScan
+				metadata.PreventVul = updateView.PreventVul
+				metadata.Severity = updateView.Severity
+				metadata.ReuseSysCVEAllowlist = updateView.ReuseSysCVE
+				storageChanged = true
+			}
+
+			public := metadata.Public == "true"
+			req := &models.ProjectReq{
+				Public:   &public,
+				Metadata: metadata,
+			}
+
+			if updateView.RegistryID != "" && projectPayload.RegistryID != 0 {
+				registryID, err := strconv.ParseInt(updateView.RegistryID, 10, 64)
+				if err != nil {
+					return fmt.Errorf("invalid registry ID: %v", err)
+				}
+				req.RegistryID = &registryID
+			}
+
+			if err := api.UpdateProject(isID, projectNameOrID, req); err != nil {
+				return fmt.Errorf("failed to update project: %v", utils.ParseHarborErrorMsg(err))
+			}
+
+			if storageChanged {
+				storageLimit, err := strconv.ParseInt(updateView.StorageLimit, 10, 64)
+				if err != nil {
+					return fmt.Errorf("invalid storage limit: %v", err)
+				}
+				quota, err := api.GetQuotaByRef(int64(projectPayload.ProjectID))
+				if err != nil {
+					return fmt.Errorf("failed to get project quota: %v", utils.ParseHarborErrorMsg(err))
+				}
+				if err := api.UpdateQuota(quota.ID, &models.QuotaUpdateReq{
+					Hard: models.ResourceList{"storage": storageLimit},
+				}); err != nil {
+					return fmt.Errorf("failed to update storage quota: %v", utils.ParseHarborErrorMsg(err))
+				}
+			}
+
+			fmt.Printf("Project %s updated successfully\n", projectNameOrID)
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.BoolVar(&isID, "id", false, "Use project ID instead of name")
+	flags.StringVar(&publicFlag, "public", "", "Set project visibility (true/false)")
+	flags.StringVar(&autoScanFlag, "auto-scan", "", "Enable or disable auto scan (true/false)")
+	flags.StringVar(&preventVulFlag, "prevent-vul", "", "Enable or disable vulnerability prevention (true/false)")
+	flags.StringVar(&reuseSysCVEFlag, "reuse-sys-cve", "", "Enable or disable reuse of system CVE allowlist (true/false)")
+	flags.StringVar(&severityFlag, "severity", "", "Set severity level (none, low, medium, high, critical)")
+	flags.StringVar(&storageLimitFlag, "storage-limit", "", "Storage quota of the project in bytes (-1 for unlimited)")
+	flags.StringVar(&registryIDFlag, "registry-id", "", "ID of referenced registry for proxy cache projects")
+
+	return cmd
+}
+
+func currentStorageLimit(projectID int32) string {
+	quota, err := api.GetQuotaByRef(int64(projectID))
+	if err != nil {
+		return "-1"
+	}
+	if val, ok := quota.Hard["storage"]; ok {
+		return strconv.FormatInt(val, 10)
+	}
+	return "-1"
+}
+
+func validateUpdateFlag(flagName, flagValue string) error {
+	allowed := map[string]bool{
+		"none":     true,
+		"low":      true,
+		"medium":   true,
+		"high":     true,
+		"critical": true,
+	}
+	if flagName == "severity" && !allowed[flagValue] {
+		return fmt.Errorf("invalid value for --%s: %s", flagName, flagValue)
+	}
+	if flagName != "severity" && flagValue != "true" && flagValue != "false" {
+		return fmt.Errorf("invalid value for --%s: %s. Expected 'true' or 'false'", flagName, flagValue)
+	}
+	return nil
+}

--- a/cmd/harbor/root/project/update_test.go
+++ b/cmd/harbor/root/project/update_test.go
@@ -1,0 +1,59 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package project
+
+import (
+	"testing"
+
+	"github.com/goharbor/harbor-cli/pkg/testutil"
+)
+
+func TestUpdateProjectCommand_Errors(t *testing.T) {
+	tests := []struct {
+		name        string
+		flags       []string
+		expectError bool
+	}{
+		{
+			name:        "invalid public value",
+			flags:       []string{"myproject", "--public", "maybe"},
+			expectError: true,
+		},
+		{
+			name:        "invalid severity value",
+			flags:       []string{"myproject", "--severity", "extreme"},
+			expectError: true,
+		},
+		{
+			name:        "invalid storage limit",
+			flags:       []string{"myproject", "--storage-limit", "foo"},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := testutil.TestCmd(t, UpdateProjectCommand, tt.flags...)
+
+			if tt.expectError && err == nil {
+				t.Fatalf("expected error but got nil")
+			}
+
+			if !tt.expectError && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/doc/cli-docs/harbor-project-update.md
+++ b/doc/cli-docs/harbor-project-update.md
@@ -1,0 +1,48 @@
+---
+title: harbor project update
+weight: 82
+---
+## harbor project update
+
+### Description
+
+##### Update a project
+
+### Synopsis
+
+Update project settings such as visibility, storage quota, and metadata.
+
+Examples:
+  harbor project update myproject --public true
+  harbor project update myproject --storage-limit -1 --prevent-vul true
+
+```sh
+harbor project update [project_name] [flags]
+```
+
+### Options
+
+```sh
+      --auto-scan string       Enable or disable auto scan (true/false)
+  -h, --help                   help for update
+      --id                     Use project ID instead of name
+      --prevent-vul string     Enable or disable vulnerability prevention (true/false)
+      --public string          Set project visibility (true/false)
+      --registry-id string     ID of referenced registry for proxy cache projects
+      --reuse-sys-cve string   Enable or disable reuse of system CVE allowlist (true/false)
+      --severity string        Set severity level (none, low, medium, high, critical)
+      --storage-limit string   Storage quota of the project in bytes (-1 for unlimited)
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml|csv
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor project](harbor-project.md)	 - Manage projects and assign resources to them
+

--- a/doc/cli-docs/harbor-project.md
+++ b/doc/cli-docs/harbor-project.md
@@ -44,5 +44,6 @@ Manage projects in Harbor
 * [harbor project preheat](harbor-project-preheat.md)	 - Manage project preheat resources
 * [harbor project robot](harbor-project-robot.md)	 - Manage robot accounts
 * [harbor project search](harbor-project-search.md)	 - search project based on their names
+* [harbor project update](harbor-project-update.md)	 - Update a project
 * [harbor project view](harbor-project-view.md)	 - get project by name or id
 

--- a/doc/man-docs/man1/harbor-project-update.1
+++ b/doc/man-docs/man1/harbor-project-update.1
@@ -1,0 +1,72 @@
+.nh
+.TH "HARBOR" "1"  "Harbor Community" "Harbor User Manuals"
+
+.SH NAME
+harbor-project-update - Update a project
+
+
+.SH SYNOPSIS
+\fBharbor project update [project_name] [flags]\fP
+
+
+.SH DESCRIPTION
+Update project settings such as visibility, storage quota, and metadata.
+
+.PP
+Examples:
+  harbor project update myproject --public true
+  harbor project update myproject --storage-limit -1 --prevent-vul true
+
+
+.SH OPTIONS
+\fB--auto-scan\fP=""
+	Enable or disable auto scan (true/false)
+
+.PP
+\fB-h\fP, \fB--help\fP[=false]
+	help for update
+
+.PP
+\fB--id\fP[=false]
+	Use project ID instead of name
+
+.PP
+\fB--prevent-vul\fP=""
+	Enable or disable vulnerability prevention (true/false)
+
+.PP
+\fB--public\fP=""
+	Set project visibility (true/false)
+
+.PP
+\fB--registry-id\fP=""
+	ID of referenced registry for proxy cache projects
+
+.PP
+\fB--reuse-sys-cve\fP=""
+	Enable or disable reuse of system CVE allowlist (true/false)
+
+.PP
+\fB--severity\fP=""
+	Set severity level (none, low, medium, high, critical)
+
+.PP
+\fB--storage-limit\fP=""
+	Storage quota of the project in bytes (-1 for unlimited)
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+\fB-c\fP, \fB--config\fP=""
+	config file (default is $HOME/.config/harbor-cli/config.yaml)
+
+.PP
+\fB-o\fP, \fB--output-format\fP=""
+	Output format. One of: json|yaml|csv
+
+.PP
+\fB-v\fP, \fB--verbose\fP[=false]
+	verbose output
+
+
+.SH SEE ALSO
+\fBharbor-project(1)\fP

--- a/doc/man-docs/man1/harbor-project.1
+++ b/doc/man-docs/man1/harbor-project.1
@@ -38,4 +38,4 @@ Manage projects in Harbor
 
 
 .SH SEE ALSO
-\fBharbor(1)\fP, \fBharbor-project-config(1)\fP, \fBharbor-project-create(1)\fP, \fBharbor-project-delete(1)\fP, \fBharbor-project-list(1)\fP, \fBharbor-project-logs(1)\fP, \fBharbor-project-member(1)\fP, \fBharbor-project-preheat(1)\fP, \fBharbor-project-robot(1)\fP, \fBharbor-project-search(1)\fP, \fBharbor-project-view(1)\fP
+\fBharbor(1)\fP, \fBharbor-project-config(1)\fP, \fBharbor-project-create(1)\fP, \fBharbor-project-delete(1)\fP, \fBharbor-project-list(1)\fP, \fBharbor-project-logs(1)\fP, \fBharbor-project-member(1)\fP, \fBharbor-project-preheat(1)\fP, \fBharbor-project-robot(1)\fP, \fBharbor-project-search(1)\fP, \fBharbor-project-update(1)\fP, \fBharbor-project-view(1)\fP

--- a/pkg/api/project_handler.go
+++ b/pkg/api/project_handler.go
@@ -188,6 +188,21 @@ func SearchProject(query string) (search.SearchOK, error) {
 	return *response, nil
 }
 
+func UpdateProject(useProjectID bool, projectNameOrID string, req *models.ProjectReq) error {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return err
+	}
+
+	useResourceName := !useProjectID
+	_, err = client.Project.UpdateProject(ctx, &project.UpdateProjectParams{
+		ProjectNameOrID: projectNameOrID,
+		XIsResourceName: &useResourceName,
+		Project:         req,
+	})
+	return err
+}
+
 func LogsProject(projectName string, opts ...ListFlags) (*project.GetLogExtsOK, error) {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {

--- a/pkg/views/project/update/view.go
+++ b/pkg/views/project/update/view.go
@@ -1,0 +1,105 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package update
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/charmbracelet/huh"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+)
+
+type UpdateView struct {
+	Public       string
+	StorageLimit string
+	RegistryID   string
+	AutoScan     *string
+	PreventVul   *string
+	Severity     *string
+	ReuseSysCVE  *string
+}
+
+func validateValue(value *string) *string {
+	defaultVal := "false"
+	if value == nil {
+		return &defaultVal
+	}
+	return value
+}
+
+func UpdateProjectView(view *UpdateView) error {
+	theme := huh.ThemeCharm()
+	groups := []*huh.Group{
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("Make Project Public").
+				Options(
+					huh.NewOption("No", "false"),
+					huh.NewOption("Yes", "true"),
+				).
+				Value(&view.Public),
+			huh.NewInput().
+				Title("Storage Limit").
+				Value(&view.StorageLimit).
+				Validate(func(str string) error {
+					if strings.TrimSpace(str) == "" {
+						return errors.New("storage limit cannot be empty")
+					}
+					return utils.ValidateStorageLimit(str)
+				}),
+			huh.NewSelect[string]().
+				Title("Automatically scan images on push").
+				Options(
+					huh.NewOption("No", "false"),
+					huh.NewOption("Yes", "true"),
+				).
+				Value(validateValue(view.AutoScan)),
+			huh.NewSelect[string]().
+				Title("Prevent vulnerable images from running").
+				Options(
+					huh.NewOption("No", "false"),
+					huh.NewOption("Yes", "true"),
+				).
+				Value(validateValue(view.PreventVul)),
+			huh.NewSelect[string]().
+				Title("Vulnerability severity threshold").
+				Options(
+					huh.NewOption("None", "none"),
+					huh.NewOption("Low", "low"),
+					huh.NewOption("Medium", "medium"),
+					huh.NewOption("High", "high"),
+					huh.NewOption("Critical", "critical"),
+				).
+				Value(validateValue(view.Severity)),
+			huh.NewSelect[string]().
+				Title("Reuse system CVE allowlist").
+				Options(
+					huh.NewOption("No", "false"),
+					huh.NewOption("Yes", "true"),
+				).
+				Value(validateValue(view.ReuseSysCVE)),
+		),
+	}
+
+	if view.RegistryID != "" {
+		groups = append(groups, huh.NewGroup(
+			huh.NewInput().
+				Title("Registry ID").
+				Value(&view.RegistryID),
+		))
+	}
+
+	return huh.NewForm(groups...).WithTheme(theme).Run()
+}


### PR DESCRIPTION
Add top-level project update with flags and interactive form for visibility, metadata, storage quota, and proxy cache registry ID.

## Description

Adds `harbor project update [name]` so project settings can be changed from the CLI in one command, matching the WebUI and the existing create/delete/list/view surface.

Without this, users split updates across `harbor project config update` (metadata) and `harbor quota update` (storage). Proxy cache registry ID had no update path after create.

The command supports flags for scripting and an interactive form when no flags are passed. Storage quota updates go through the quota API. Project metadata and visibility go through `UpdateProject` in `pkg/api/project_handler.go`.

- Fixes #1044

## Type of Change
Please select the relevant type.

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes

- Add `harbor project update` command in `cmd/harbor/root/project/update.go`
- Register command in `cmd/harbor/root/project/cmd.go`
- Add `UpdateProject` API wrapper in `pkg/api/project_handler.go`
- Add interactive form in `pkg/views/project/update/view.go`
- Add flag validation tests in `cmd/harbor/root/project/update_test.go`
- Add CLI docs in `doc/cli-docs/harbor-project-update.md` and man page in `doc/man-docs/man1/harbor-project-update.1`
- Link new command from `harbor project` docs

## Test plan

- [x] `go test ./cmd/harbor/root/project/...`
- [x] `go build ./cmd/harbor`
- [ ] Manual test against a live Harbor instance (`harbor project update <name> --public true`)
- [ ] Manual test interactive mode (`harbor project update <name>`)
