### PR TITLE
fix: typo Repliation→Replication in start.go and missing newline in a…

### DIFF
--- a/cmd/harbor/root/configurations/apply.go
+++ b/cmd/harbor/root/configurations/apply.go
@@ -115,7 +115,7 @@ Make sure to run 'harbor config get' first to populate the local config file wit
 				return fmt.Errorf("failed to update Harbor configurations: %v", err)
 			}
 
-			fmt.Printf("harbor configurations updated successfully from %s.", cfgFile)
+			fmt.Printf("harbor configurations updated successfully from %s.\n", cfgFile)
 			return nil
 		},
 	}

--- a/cmd/harbor/root/replication/start.go
+++ b/cmd/harbor/root/replication/start.go
@@ -47,7 +47,7 @@ func StartCommand() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to start replication: %v", utils.ParseHarborErrorMsg(err))
 			}
-			fmt.Printf("Repliation started successfully with ID: %s\n", response.Location)
+			fmt.Printf("Replication started successfully with ID: %s\n", response.Location)
 			return nil
 		},
 	}


### PR DESCRIPTION
## What this PR fixes

Two minor issues in the codebase:

1. **Typo fix** (`cmd/harbor/root/replication/start.go`):  
   `"Repliation started successfully"` → `"Replication started successfully"`

2. **Missing newline** (`cmd/harbor/root/configurations/apply.go`):  
   Added `\n` to the success message in `fmt.Printf` so the terminal prompt appears on a new line after the command completes.

## Type of change
- [x] Bug fix (non-breaking)
