### PR TITLE
fix: member view mutates global columns slice

### DIFF
--- a/pkg/views/member/view/view.go
+++ b/pkg/views/member/view/view.go
@@ -36,10 +36,8 @@ var columns = []table.Column{
 	{Title: "Project ID", Width: 12},
 }
 
-func ViewMember(member *models.ProjectMemberEntity, wide bool) {
-	var rows []table.Row
+func memberRow(member *models.ProjectMemberEntity, wide bool) table.Row {
 	memberID := strconv.FormatInt(member.ID, 10)
-	projectID := strconv.FormatInt(member.ProjectID, 10)
 	roleName := utils.CamelCaseToHR(member.RoleName)
 
 	memberType := member.EntityType
@@ -51,25 +49,33 @@ func ViewMember(member *models.ProjectMemberEntity, wide bool) {
 
 	if wide {
 		roleID := strconv.FormatInt(member.RoleID, 10)
+		projectID := strconv.FormatInt(member.ProjectID, 10)
 
-		rows = append(rows, table.Row{
+		return table.Row{
 			memberID,
 			member.EntityName,
 			memberType,
 			roleName,
 			roleID,
 			projectID,
-		})
-	} else {
+		}
+	}
+
+	return table.Row{
+		memberID,
+		member.EntityName,
+		memberType,
+		roleName,
+	}
+}
+
+func ViewMember(member *models.ProjectMemberEntity, wide bool) {
+	rows := []table.Row{memberRow(member, wide)}
+
+	if !wide {
 		colsToRemove := []string{"Role ID", "Project ID"}
 		columns = utils.RemoveColumns(columns, colsToRemove)
 		log.Println(columns)
-		rows = append(rows, table.Row{
-			memberID, // Member Name
-			member.EntityName,
-			memberType,
-			roleName,
-		})
 	}
 
 	m := tablelist.NewModel(columns, rows, len(rows))

--- a/pkg/views/member/view/view.go
+++ b/pkg/views/member/view/view.go
@@ -48,9 +48,10 @@ func memberRow(member *models.ProjectMemberEntity, wide bool) table.Row {
 	roleName := utils.CamelCaseToHR(member.RoleName)
 
 	memberType := member.EntityType
-	if memberType == "u" {
+	switch memberType {
+	case "u":
 		memberType = "User"
-	} else if memberType == "g" {
+	case "g":
 		memberType = "Group"
 	}
 

--- a/pkg/views/member/view/view.go
+++ b/pkg/views/member/view/view.go
@@ -16,7 +16,6 @@ package view
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"strconv"
 
@@ -34,6 +33,14 @@ var columns = []table.Column{
 	{Title: "Role Name", Width: 16},
 	{Title: "Role ID", Width: 8},
 	{Title: "Project ID", Width: 12},
+}
+
+func memberColumns(wide bool) []table.Column {
+	if wide {
+		return columns
+	}
+	colsToRemove := []string{"Role ID", "Project ID"}
+	return utils.RemoveColumns(columns, colsToRemove)
 }
 
 func memberRow(member *models.ProjectMemberEntity, wide bool) table.Row {
@@ -72,13 +79,7 @@ func memberRow(member *models.ProjectMemberEntity, wide bool) table.Row {
 func ViewMember(member *models.ProjectMemberEntity, wide bool) {
 	rows := []table.Row{memberRow(member, wide)}
 
-	if !wide {
-		colsToRemove := []string{"Role ID", "Project ID"}
-		columns = utils.RemoveColumns(columns, colsToRemove)
-		log.Println(columns)
-	}
-
-	m := tablelist.NewModel(columns, rows, len(rows))
+	m := tablelist.NewModel(memberColumns(wide), rows, len(rows))
 
 	if _, err := tea.NewProgram(m).Run(); err != nil {
 		fmt.Println("Error running program:", err)

--- a/pkg/views/member/view/view_test.go
+++ b/pkg/views/member/view/view_test.go
@@ -1,0 +1,56 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package view
+
+import (
+	"testing"
+
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMemberRow(t *testing.T) {
+	member := &models.ProjectMemberEntity{
+		ID:         1,
+		ProjectID:  2,
+		EntityName: "alice",
+		EntityType: "u",
+		RoleName:   "projectAdmin",
+		RoleID:     3,
+	}
+
+	t.Run("wide row has all fields", func(t *testing.T) {
+		got := memberRow(member, true)
+		assert.Len(t, got, 6)
+		assert.Equal(t, "1", got[0])
+		assert.Equal(t, "alice", got[1])
+		assert.Equal(t, "User", got[2])
+		assert.Equal(t, "3", got[4])
+		assert.Equal(t, "2", got[5])
+	})
+
+	t.Run("non-wide row omits role and project IDs", func(t *testing.T) {
+		got := memberRow(member, false)
+		assert.Len(t, got, 4)
+		assert.Equal(t, "1", got[0])
+		assert.Equal(t, "alice", got[1])
+		assert.Equal(t, "User", got[2])
+	})
+
+	t.Run("group entity type is expanded", func(t *testing.T) {
+		group := &models.ProjectMemberEntity{EntityType: "g"}
+		got := memberRow(group, false)
+		assert.Equal(t, "Group", got[2])
+	})
+}

--- a/pkg/views/member/view/view_test.go
+++ b/pkg/views/member/view/view_test.go
@@ -20,6 +20,33 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestMemberColumns(t *testing.T) {
+	t.Run("wide returns all columns", func(t *testing.T) {
+		got := memberColumns(true)
+		assert.Len(t, got, 6)
+	})
+
+	t.Run("non-wide hides Role ID and Project ID", func(t *testing.T) {
+		got := memberColumns(false)
+		assert.Len(t, got, 4)
+		for _, col := range got {
+			assert.NotEqual(t, "Role ID", col.Title)
+			assert.NotEqual(t, "Project ID", col.Title)
+		}
+	})
+
+	t.Run("non-wide call does not affect later wide calls", func(t *testing.T) {
+		memberColumns(false)
+		got := memberColumns(true)
+		assert.Len(t, got, 6)
+	})
+
+	t.Run("package-level columns are not mutated", func(t *testing.T) {
+		memberColumns(false)
+		assert.Len(t, columns, 6)
+	})
+}
+
 func TestMemberRow(t *testing.T) {
 	member := &models.ProjectMemberEntity{
 		ID:         1,


### PR DESCRIPTION
The member view command has the same bug as #1038, just in pkg/views/member/view/view.go instead of the list view. Rendering without --wide reassigns the package level columns slice, so any later wide render in the same process only shows 4 of the 6 columns. There was also a leftover log.Println(columns) on that path printing the column structs to the terminal.

I moved the column selection and row building into small helpers so they can be unit tested. Columns are now picked into a local slice and the global stays untouched, and the debug print is gone. Added tests for row building and column selection, including a regression test for the wide-after-non-wide case.

Related to #1038, #1002 covers the list view, this covers the view command.