### PR TITLE
fix(robot): log warning instead of returning error on clipboard copy failure

### DIFF
--- a/cmd/harbor/root/project/robot/refresh.go
+++ b/cmd/harbor/root/project/robot/refresh.go
@@ -112,11 +112,11 @@ Examples:
 				secret = response.Payload.Secret
 				create.CreateRobotSecretView("", secret)
 
-				err = clipboard.WriteAll(response.Payload.Secret)
-				if err != nil {
-					return fmt.Errorf("failed to write the secret to the clipboard: %v", err)
+				if err := clipboard.WriteAll(response.Payload.Secret); err != nil {
+					log.Warnf("failed to write the secret to the clipboard: %v", err)
+				} else {
+					fmt.Println("secret copied to clipboard.")
 				}
-				fmt.Println("secret copied to clipboard.")
 			}
 			return nil
 		},

--- a/cmd/harbor/root/robot/refresh.go
+++ b/cmd/harbor/root/robot/refresh.go
@@ -113,11 +113,11 @@ Examples:
 				secret = response.Payload.Secret
 				create.CreateRobotSecretView("", secret)
 
-				err = clipboard.WriteAll(response.Payload.Secret)
-				if err != nil {
-					return fmt.Errorf("failed to write the secret to the clipboard: %v", err)
+				if err := clipboard.WriteAll(response.Payload.Secret); err != nil {
+					log.Warnf("failed to write the secret to the clipboard: %v", err)
+				} else {
+					fmt.Println("secret copied to clipboard.")
 				}
-				fmt.Println("secret copied to clipboard.")
 			}
 			return err
 		},


### PR DESCRIPTION
## Description
This pull request modifies the robot refresh commands to gracefully handle failures when copying the newly generated secret to the clipboard. Previously, if the system lacked clipboard support or if writing to the clipboard failed, the command would exit with an error, even though the secret was successfully generated on the server.

With this change, the CLI will log a warning when clipboard copying fails but will allow the command to complete successfully and display the secret to the user.

- Fixes 

## Type of Change
Please select the relevant type.

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
- Modified `RefreshSecretCommand` in `cmd/harbor/root/project/robot/refresh.go` to log a warning instead of returning an error on clipboard failure.
- Modified `RefreshSecretCommand` in `cmd/harbor/root/robot/refresh.go` to apply the same non-fatal clipboard warning behavior.
