### PR TITLE
docs(replication): update replication log usage

### DIFF
--- a/cmd/harbor/root/replication/logs.go
+++ b/cmd/harbor/root/replication/logs.go
@@ -28,10 +28,10 @@ func LogsCommand() *cobra.Command {
 	var taskID int64
 	var execID int64
 	cmd := &cobra.Command{
-		Use:   "log [EXECUTION_ID] [TASK_ID]",
+		Use:   "log ",
 		Short: "get replication execution logs by execution and task id",
-		Long:  `Get the logs of a specific replication execution and task by their IDs. If no IDs are provided, it will prompt the user to select them interactively.`,
-		Example: `  harbor replication log -e 12345 -t 67890
+		Long:  `Get the logs of a specific replication execution and task. Use the --execution-id and --task-id flags to specify IDs. If no IDs are provided, the command prompts you interactively.`,
+		Example: ` 
 		  harbor replication log --execution-id 12345 --task-id 67890
 		  harbor replication log --execution-id 12345
   harbor replication log`,

--- a/doc/cli-docs/harbor-replication-log.md
+++ b/doc/cli-docs/harbor-replication-log.md
@@ -13,7 +13,7 @@ weight: 10
 Get the logs of a specific replication execution and task by their IDs. If no IDs are provided, it will prompt the user to select them interactively.
 
 ```sh
-harbor replication log [EXECUTION_ID] [TASK_ID] [flags]
+harbor replication log [flags]
 ```
 
 ### Examples

--- a/doc/man-docs/man1/harbor-replication-log.1
+++ b/doc/man-docs/man1/harbor-replication-log.1
@@ -6,11 +6,11 @@ harbor-replication-log - get replication execution logs by execution and task id
 
 
 .SH SYNOPSIS
-\fBharbor replication log [EXECUTION_ID] [TASK_ID] [flags]\fP
+\fBharbor replication log [flags]\fP
 
 
 .SH DESCRIPTION
-Get the logs of a specific replication execution and task by their IDs. If no IDs are provided, it will prompt the user to select them interactively.
+Get the logs of a specific replication execution and task. Use the --execution-id and --task-id flags to specify IDs. If no IDs are provided, the command prompts you interactively.
 
 
 .SH OPTIONS


### PR DESCRIPTION
## Description

This PR updates the `replication log` command documentation to match the current implementation.

The command currently accepts replication IDs only through the `--execution-id` and `--task-id` flags. The usage text, CLI documentation, and man page previously suggested that positional arguments were supported, which was inconsistent with the actual behavior.

This change updates the documentation to reflect the supported syntax without changing the command's behavior.

- Fixes #939

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation update
- [ ] Chore / maintenance

## Changes

- Updated the `Use` string of the `replication log` command to remove unsupported positional arguments.
- Updated the command description, CLI documentation, and man page to document the supported `--execution-id` and `--task-id` flag-based usage.
- 
