### PR TITLE
selection: set Aborted when user cancels TUI picker

### DIFF
--- a/pkg/views/base/selection/model.go
+++ b/pkg/views/base/selection/model.go
@@ -83,6 +83,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyMsg:
 		switch keypress := msg.String(); keypress {
+		case "ctrl+c":
+			m.Aborted = true
+			return m, tea.Quit
+		case "q", "esc":
+			if m.List.FilterState() == list.Filtering {
+				break // let the list handle it (esc exits filter mode, q types "q")
+			}
+			m.Aborted = true
+			return m, tea.Quit
 		case "enter":
 			if m.List.FilterState() != list.Filtering {
 				i, ok := m.List.SelectedItem().(Item)


### PR DESCRIPTION
Fixes #947

## Summary

Interactive selection views did not record user cancellation correctly. The shared Bubbletea selection model already had an `Aborted` field, but `Update()` never set it when users pressed `q`, `esc`, or `ctrl+c`.

This PR handles those keys in the base selection model and sets `Aborted = true` before quitting, so callers can distinguish cancellation from an empty selection.

**Scope:** This PR only changes `pkg/views/base/selection/model.go`. Updating all selection wrappers to consume `Aborted` is intentionally left for a follow-up PR, per maintainer feedback on #947.

## Problem

When a command is run without a positional argument, Harbor CLI opens an interactive picker. If the user cancels with `q`, `esc`, or `ctrl+c`, the picker closes but the base model returned with:

- `Aborted = false`
- `Choice = ""`

Callers that check `Aborted` (e.g. project selection) fell through to a misleading `"no project selected"` error. Callers that do not check `Aborted` (e.g. registry selection) could continue with empty values or zero IDs.

## Demo


https://github.com/user-attachments/assets/0ead2916-91d6-4cfd-b7b0-1444f596e08c


<!-- Replace the link above with your uploaded screencast URL -->

**What the screencast shows:**

1. **Before fix:** `harbor project view` → picker opens → press `q` → error: `no project selected`
2. **After fix:** same flow → error: `user aborted project selection`
3. **Filter mode preserved:** press `/` to filter → `esc` exits filter mode without aborting the picker

## Changes

In `pkg/views/base/selection/model.go`:

- Handle `ctrl+c` → set `Aborted = true`, quit
- Handle `q` / `esc` → set `Aborted = true`, quit
- Skip abort when `FilterState() == list.Filtering` so `q` can be typed in the search box and `esc` exits filter mode

## Code path

```text
cmd/harbor/root/project/view.go
  └─ prompt.GetProjectNameFromUser()
       └─ pkg/views/project/select/view.go
            └─ tea.NewProgram(selection.Model).Run()
                 └─ pkg/views/base/selection/model.go   ← fix applied here
                      └─ user presses q / esc / ctrl+c
                      └─ Aborted = true, tea.Quit
            └─ wrapper checks model.Aborted
            └─ returns ErrUserAborted