### PR TITLE
fix(cli): correct spelling typo and missing newline in CLI output

### DIFF
--- a/cmd/harbor/root/configurations/apply.go
+++ b/cmd/harbor/root/configurations/apply.go
@@ -115,7 +115,7 @@ Make sure to run 'harbor config get' first to populate the local config file wit
 				return fmt.Errorf("failed to update Harbor configurations: %v", err)
 			}
 
-			fmt.Printf("harbor configurations updated successfully from %s.", cfgFile)
+			fmt.Printf("harbor configurations updated successfully from %s.\n", cfgFile)
 			return nil
 		},
 	}

--- a/cmd/harbor/root/replication/start.go
+++ b/cmd/harbor/root/replication/start.go
@@ -47,7 +47,7 @@ func StartCommand() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to start replication: %v", utils.ParseHarborErrorMsg(err))
 			}
-			fmt.Printf("Repliation started successfully with ID: %s\n", response.Location)
+			fmt.Printf("Replication started successfully with ID: %s\n", response.Location)
 			return nil
 		},
 	}


### PR DESCRIPTION
## Description
Fixed two minor CLI output bugs in the Harbor CLI: a spelling typo in the replication start command output, and a missing newline in the config apply command's success message which caused the terminal prompt to appear on the same line.
- Fixes #1041

## Type of Change
Please select the relevant type.
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
- Fixed typo "Repliation started" → "Replication started" in `cmd/harbor/root/replication/start.go`
- Added missing newline (`\n`) to success message in `cmd/harbor/root/configurations/apply.go`
- Verified fix by building the CLI with `go build`