### PR TITLE
fix(config): write file-creation notices to stderr, not stdout

### DIFF
--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -304,7 +304,9 @@ func CreateDataFile(dataFilePath string, initialConfigPath string) error {
 			log.Fatalf("Failed to write data file: %v", err)
 		}
 
-		fmt.Printf("Data file created at %s with configPath: %s\n", dataFilePath, dataFile.ConfigPath)
+		// Informational notice: write to stderr so it never pollutes command
+		// output captured from stdout (e.g. generated shell completion scripts, #1053).
+		fmt.Fprintf(os.Stderr, "Data file created at %s with configPath: %s\n", dataFilePath, dataFile.ConfigPath)
 	} else if err != nil {
 		log.Fatalf("Error checking data file: %v", err)
 	}
@@ -378,7 +380,7 @@ func UpdateDataFile(dataFilePath string, newConfigPath string) error {
 		log.Fatalf("failed to write updated data file: %v", err)
 	}
 
-	fmt.Printf("Data file at %s updated with new configPath: %s\n", dataFilePath, absConfigPath)
+	fmt.Fprintf(os.Stderr, "Data file at %s updated with new configPath: %s\n", dataFilePath, absConfigPath)
 	return nil
 }
 
@@ -405,7 +407,9 @@ func CreateConfigFile(configPath string) error {
 			log.Fatalf("failed to write config file: %v", err)
 		}
 
-		fmt.Printf("Config file created at %s", configPath)
+		// Informational notice: write to stderr so it never pollutes command
+		// output captured from stdout (e.g. generated shell completion scripts, #1053).
+		fmt.Fprintf(os.Stderr, "Config file created at %s\n", configPath)
 	} else if err != nil {
 		log.Fatalf("error checking config file: %v", err)
 	}

--- a/pkg/utils/config_test.go
+++ b/pkg/utils/config_test.go
@@ -14,6 +14,9 @@
 package utils_test
 
 import (
+	"bytes"
+	"io"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -106,4 +109,53 @@ func Test_Config_Flag(t *testing.T) {
 	assert.NotNil(t, currentConfig.CurrentCredentialName, "CurrentCredentialName should not be nil")
 	assert.NotNil(t, currentConfig.Credentials, "Credentials should not be nil")
 	assert.NotNil(t, data.ConfigPath, "ConfigPath should not be nil")
+}
+
+// captureStdoutStderr redirects os.Stdout/os.Stderr while fn runs and returns
+// whatever each stream received.
+func captureStdoutStderr(t *testing.T, fn func()) (stdout string, stderr string) {
+	t.Helper()
+
+	origOut, origErr := os.Stdout, os.Stderr
+	rOut, wOut, err := os.Pipe()
+	assert.NoError(t, err)
+	rErr, wErr, err := os.Pipe()
+	assert.NoError(t, err)
+	os.Stdout, os.Stderr = wOut, wErr
+	defer func() { os.Stdout, os.Stderr = origOut, origErr }()
+
+	fn()
+
+	assert.NoError(t, wOut.Close())
+	assert.NoError(t, wErr.Close())
+
+	var bufOut, bufErr bytes.Buffer
+	_, _ = io.Copy(&bufOut, rOut)
+	_, _ = io.Copy(&bufErr, rErr)
+	return bufOut.String(), bufErr.String()
+}
+
+// Test_CreateFiles_DoNotPolluteStdout is a regression test for #1053: the
+// data/config file auto-creation notices must go to stderr, not stdout.
+// `harbor completion bash` captures stdout into the generated completion
+// script, so a stray "Config file created at ..."/"Data file created at ..."
+// line on stdout ends up sourced by the shell as a command ("command not
+// found: Config"/"command not found: Data").
+func Test_CreateFiles_DoNotPolluteStdout(t *testing.T) {
+	tempDir := t.TempDir()
+	dataPath := filepath.Join(tempDir, ".data", "data.yaml")
+	configPath := filepath.Join(tempDir, ".config", "config.yaml")
+
+	stdout, stderr := captureStdoutStderr(t, func() {
+		assert.NoError(t, utils.CreateConfigFile(configPath))
+		assert.NoError(t, utils.CreateDataFile(dataPath, configPath))
+	})
+
+	assert.NotContains(t, stdout, "Config file created")
+	assert.NotContains(t, stdout, "Data file created")
+	assert.Empty(t, stdout, "file-creation notices must not be written to stdout")
+
+	// The notices are still surfaced to the user, just on stderr.
+	assert.Contains(t, stderr, "Config file created at "+configPath)
+	assert.Contains(t, stderr, "Data file created at "+dataPath)
 }


### PR DESCRIPTION
## Description

On first run, harbor auto-creates its data/config files and prints `Data file created at ...` / `Config file created at ...` notices. These were written to **stdout** via `fmt.Printf`, so any caller that captures stdout gets them mixed into its output.

The most visible symptom is shell completion (#1053): `harbor completion bash` writes the completion script to stdout, and Homebrew stores that output as the completion file. On a fresh install the two notices are prepended to the script — and the config notice even lacked a trailing newline, gluing it directly onto the completion header — so every new shell that sources the file prints:

```
bash: command not found: Data
bash: command not found: Config
```

This PR sends the initialization notices to **stderr** instead, so they no longer taint stdout-captured output, and adds the missing newline. The user still sees the notices; they just go to the correct stream. Explicit user-facing command outputs (e.g. "Added credential ...", "Switched to context ...") are left unchanged.

- Fixes #1053

## Type of Change

- [x] Bug fix

## Changes
- `pkg/utils/config.go`: `CreateDataFile`, `UpdateDataFile`, and `CreateConfigFile` now use `fmt.Fprintf(os.Stderr, ...)` for their informational notices (and the config-created notice gets its missing `\n`).
- `pkg/utils/config_test.go`: new `Test_CreateFiles_DoNotPolluteStdout` capturing stdout/stderr around `CreateConfigFile`/`CreateDataFile`, asserting stdout stays empty while the notices appear on stderr.

## Test Evidence

```
$ go test ./pkg/utils/
ok  	github.com/goharbor/harbor-cli/pkg/utils

$ go vet ./pkg/utils/          # clean
$ gofmt -l pkg/utils/config.go pkg/utils/config_test.go   # clean
$ golangci-lint run ./pkg/utils/
0 issues.
```

The new test fails on `main` (stdout contains `Config file created at .../config.yamlData file created at ...`, exactly the tainted string from the report) and passes with this change.