### PR TITLE
[feature]: Add interactive command navigation mode for nested Harbor CLI commands

### DIFF
--- a/cmd/harbor/root/cmd.go
+++ b/cmd/harbor/root/cmd.go
@@ -150,6 +150,10 @@ harbor help
 	cmd.GroupID = "core"
 	root.AddCommand(cmd)
 
+	cmd = InteractiveCommand(root)
+	cmd.GroupID = "core"
+	root.AddCommand(cmd)
+
 	// Access
 	cmd = LoginCommand()
 	cmd.GroupID = "access"

--- a/cmd/harbor/root/interactive.go
+++ b/cmd/harbor/root/interactive.go
@@ -14,8 +14,12 @@
 package root
 
 import (
+	"fmt"
+	"strings"
+
 	commandinteractive "github.com/goharbor/harbor-cli/pkg/views/command/interactive"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func InteractiveCommand(root *cobra.Command) *cobra.Command {
@@ -29,10 +33,77 @@ leaf commands, and review the exact command path before running anything manuall
 		Example: `  harbor interactive`,
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			_, err := commandinteractive.Run(root)
-			return err
+			selected, err := commandinteractive.Run(root)
+			if err != nil || selected == nil {
+				return err
+			}
+
+			return executeInteractiveSelection(cmd.Root(), selected)
 		},
 	}
 
 	return cmd
+}
+
+var phase2SupportedCommandPaths = map[string]struct{}{
+	"harbor artifact list":         {},
+	"harbor artifact view":         {},
+	"harbor project list":          {},
+	"harbor project view":          {},
+	"harbor repo list":             {},
+	"harbor repo view":             {},
+	"harbor scanner view":          {},
+	"harbor webhook list":          {},
+	"harbor info":                  {},
+	"harbor version":               {},
+	"harbor vulnerability list":    {},
+	"harbor vulnerability summary": {},
+}
+
+func executeInteractiveSelection(sourceRoot, selected *cobra.Command) error {
+	commandPath := strings.TrimSpace(selected.CommandPath())
+	if !isPhase2SupportedCommandPath(commandPath) {
+		fmt.Printf("Interactive execution is not available yet for %q.\n", commandPath)
+		fmt.Printf("Please run `%s` manually and provide the required arguments or flags.\n", commandPath)
+		return nil
+	}
+
+	execRoot := RootCmd()
+	execRoot.SetArgs(append(changedRootFlags(sourceRoot), commandArgsFromPath(commandPath)...))
+
+	return execRoot.Execute()
+}
+
+func isPhase2SupportedCommandPath(commandPath string) bool {
+	_, ok := phase2SupportedCommandPaths[strings.TrimSpace(commandPath)]
+	return ok
+}
+
+func commandArgsFromPath(commandPath string) []string {
+	parts := strings.Fields(strings.TrimSpace(commandPath))
+	if len(parts) <= 1 {
+		return nil
+	}
+
+	return parts[1:]
+}
+
+func changedRootFlags(root *cobra.Command) []string {
+	if root == nil {
+		return nil
+	}
+
+	var args []string
+	root.PersistentFlags().VisitAll(func(flag *pflag.Flag) {
+		if !flag.Changed {
+			return
+		}
+
+		args = append(args, "--"+flag.Name)
+		if flag.Value.Type() != "bool" {
+			args = append(args, flag.Value.String())
+		}
+	})
+
+	return args
 }

--- a/cmd/harbor/root/interactive.go
+++ b/cmd/harbor/root/interactive.go
@@ -14,7 +14,6 @@
 package root
 
 import (
-	"fmt"
 	"strings"
 
 	commandinteractive "github.com/goharbor/harbor-cli/pkg/views/command/interactive"
@@ -45,38 +44,12 @@ leaf commands, and review the exact command path before running anything manuall
 	return cmd
 }
 
-var phase2SupportedCommandPaths = map[string]struct{}{
-	"harbor artifact list":         {},
-	"harbor artifact view":         {},
-	"harbor project list":          {},
-	"harbor project view":          {},
-	"harbor repo list":             {},
-	"harbor repo view":             {},
-	"harbor scanner view":          {},
-	"harbor webhook list":          {},
-	"harbor info":                  {},
-	"harbor version":               {},
-	"harbor vulnerability list":    {},
-	"harbor vulnerability summary": {},
-}
-
 func executeInteractiveSelection(sourceRoot, selected *cobra.Command) error {
 	commandPath := strings.TrimSpace(selected.CommandPath())
-	if !isPhase2SupportedCommandPath(commandPath) {
-		fmt.Printf("Interactive execution is not available yet for %q.\n", commandPath)
-		fmt.Printf("Please run `%s` manually and provide the required arguments or flags.\n", commandPath)
-		return nil
-	}
-
 	execRoot := RootCmd()
 	execRoot.SetArgs(append(changedRootFlags(sourceRoot), commandArgsFromPath(commandPath)...))
 
 	return execRoot.Execute()
-}
-
-func isPhase2SupportedCommandPath(commandPath string) bool {
-	_, ok := phase2SupportedCommandPaths[strings.TrimSpace(commandPath)]
-	return ok
 }
 
 func commandArgsFromPath(commandPath string) []string {

--- a/cmd/harbor/root/interactive.go
+++ b/cmd/harbor/root/interactive.go
@@ -1,0 +1,38 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package root
+
+import (
+	commandinteractive "github.com/goharbor/harbor-cli/pkg/views/command/interactive"
+	"github.com/spf13/cobra"
+)
+
+func InteractiveCommand(root *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "interactive",
+		Short: "Browse the Harbor command tree interactively",
+		Long: `Browse Harbor commands and subcommands through an interactive menu.
+
+Version 1 focuses on discovery: you can navigate the full command tree, inspect
+leaf commands, and review the exact command path before running anything manually.`,
+		Example: `  harbor interactive`,
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, err := commandinteractive.Run(root)
+			return err
+		},
+	}
+
+	return cmd
+}

--- a/cmd/harbor/root/interactive_test.go
+++ b/cmd/harbor/root/interactive_test.go
@@ -1,0 +1,65 @@
+package root
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestIsPhase2SupportedCommandPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{path: "harbor artifact list", want: true},
+		{path: "harbor project view", want: true},
+		{path: "harbor artifact tags create", want: false},
+		{path: "harbor ldap search", want: false},
+	}
+
+	for _, tt := range tests {
+		got := isPhase2SupportedCommandPath(tt.path)
+		if got != tt.want {
+			t.Fatalf("isPhase2SupportedCommandPath(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestCommandArgsFromPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want []string
+	}{
+		{path: "harbor", want: nil},
+		{path: "harbor info", want: []string{"info"}},
+		{path: "harbor artifact list", want: []string{"artifact", "list"}},
+		{path: " harbor   project   view ", want: []string{"project", "view"}},
+	}
+
+	for _, tt := range tests {
+		got := commandArgsFromPath(tt.path)
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Fatalf("commandArgsFromPath(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestChangedRootFlags(t *testing.T) {
+	root := &cobra.Command{Use: "harbor"}
+	root.PersistentFlags().String("config", "", "config file")
+	root.PersistentFlags().Bool("verbose", false, "verbose output")
+
+	if err := root.PersistentFlags().Set("config", "/tmp/config.yaml"); err != nil {
+		t.Fatalf("failed to set config flag: %v", err)
+	}
+	if err := root.PersistentFlags().Set("verbose", "true"); err != nil {
+		t.Fatalf("failed to set verbose flag: %v", err)
+	}
+
+	got := changedRootFlags(root)
+	want := []string{"--config", "/tmp/config.yaml", "--verbose"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("changedRootFlags() = %v, want %v", got, want)
+	}
+}

--- a/cmd/harbor/root/interactive_test.go
+++ b/cmd/harbor/root/interactive_test.go
@@ -7,25 +7,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func TestIsPhase2SupportedCommandPath(t *testing.T) {
-	tests := []struct {
-		path string
-		want bool
-	}{
-		{path: "harbor artifact list", want: true},
-		{path: "harbor project view", want: true},
-		{path: "harbor artifact tags create", want: false},
-		{path: "harbor ldap search", want: false},
-	}
-
-	for _, tt := range tests {
-		got := isPhase2SupportedCommandPath(tt.path)
-		if got != tt.want {
-			t.Fatalf("isPhase2SupportedCommandPath(%q) = %v, want %v", tt.path, got, tt.want)
-		}
-	}
-}
-
 func TestCommandArgsFromPath(t *testing.T) {
 	tests := []struct {
 		path string

--- a/pkg/views/command/interactive/view.go
+++ b/pkg/views/command/interactive/view.go
@@ -233,7 +233,7 @@ func renderSelectionSummary(cmd *cobra.Command) string {
 	}
 
 	sections = append(sections, "")
-	sections = append(sections, views.YellowStyle.Render("v1 preview: interactive mode currently browses the command tree and shows the selected leaf command."))
+	sections = append(sections, views.YellowStyle.Render("Interactive mode currently browses the command tree and shows the selected leaf command."))
 
 	return "\n" + strings.Join(sections, "\n") + "\n"
 }

--- a/pkg/views/command/interactive/view.go
+++ b/pkg/views/command/interactive/view.go
@@ -1,0 +1,288 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package interactive
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/goharbor/harbor-cli/pkg/views"
+	"github.com/spf13/cobra"
+)
+
+const (
+	defaultListWidth  = 40
+	defaultListHeight = 12
+	minListWidth      = 30
+	minListHeight     = 6
+	verticalChrome    = 8
+)
+
+type commandItem struct {
+	title       string
+	description string
+	command     *cobra.Command
+}
+
+func (i commandItem) Title() string       { return i.title }
+func (i commandItem) Description() string { return i.description }
+func (i commandItem) FilterValue() string { return i.title + " " + i.description }
+
+type stackEntry struct {
+	command *cobra.Command
+	index   int
+}
+
+type Model struct {
+	list     list.Model
+	stack    []stackEntry
+	current  *cobra.Command
+	selected *cobra.Command
+	width    int
+	height   int
+}
+
+type ItemDelegate struct{}
+
+func (d ItemDelegate) Height() int  { return 2 }
+func (d ItemDelegate) Spacing() int { return 0 }
+func (d ItemDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd {
+	return nil
+}
+
+func (d ItemDelegate) Render(w io.Writer, m list.Model, index int, listItem list.Item) {
+	item, ok := listItem.(commandItem)
+	if !ok {
+		return
+	}
+
+	title := item.title
+	description := item.description
+	if description == "" {
+		description = "No description available"
+	}
+
+	titleStyle := views.ItemStyle
+	descriptionStyle := views.GrayStyle.PaddingLeft(4)
+	if index == m.Index() {
+		titleStyle = views.SelectedItemStyle
+		descriptionStyle = views.GrayStyle.PaddingLeft(2)
+		title = "> " + title
+	}
+
+	fmt.Fprint(w, titleStyle.Render(title))
+	fmt.Fprint(w, "\n")
+	fmt.Fprint(w, descriptionStyle.Render(description))
+}
+
+func NewModel(root *cobra.Command) Model {
+	items := commandItems(root)
+	l := list.New(items, ItemDelegate{}, defaultListWidth, defaultListHeight)
+	l.Title = fmt.Sprintf("Interactive Harbor: %s", root.CommandPath())
+	l.SetShowStatusBar(false)
+	l.SetFilteringEnabled(true)
+	l.Styles.Title = views.TitleStyle
+	l.Styles.PaginationStyle = views.PaginationStyle
+	l.Styles.HelpStyle = views.HelpStyle
+	l.AdditionalShortHelpKeys = func() []key.Binding {
+		return nil
+	}
+	l.AdditionalFullHelpKeys = func() []key.Binding {
+		return nil
+	}
+
+	return Model{
+		list:    l,
+		current: root,
+	}
+}
+
+func (m Model) Init() tea.Cmd {
+	return nil
+}
+
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.list.SetSize(dynamicListSize(msg.Width, msg.Height))
+		return m, nil
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "enter":
+			if m.list.FilterState() == list.Filtering {
+				break
+			}
+			selectedItem, ok := m.list.SelectedItem().(commandItem)
+			if !ok {
+				return m, nil
+			}
+			if len(commandItems(selectedItem.command)) == 0 {
+				m.selected = selectedItem.command
+				return m, tea.Quit
+			}
+
+			m.stack = append(m.stack, stackEntry{command: m.current, index: m.list.Index()})
+			m.current = selectedItem.command
+			m.list.SetItems(commandItems(selectedItem.command))
+			m.list.Title = fmt.Sprintf("Interactive Harbor: %s", selectedItem.command.CommandPath())
+			m.list.ResetSelected()
+			m.list.ResetFilter()
+			return m, nil
+		case "esc":
+			if m.list.FilterState() == list.Filtering {
+				break
+			}
+			if len(m.stack) == 0 {
+				return m, tea.Quit
+			}
+			last := m.stack[len(m.stack)-1]
+			m.stack = m.stack[:len(m.stack)-1]
+			m.current = last.command
+			m.list.SetItems(commandItems(last.command))
+			m.list.Title = fmt.Sprintf("Interactive Harbor: %s", last.command.CommandPath())
+			m.list.Select(last.index)
+			m.list.ResetFilter()
+			return m, nil
+		case "q", "ctrl+c":
+			if m.list.FilterState() != list.Filtering {
+				return m, tea.Quit
+			}
+		}
+	}
+
+	var cmd tea.Cmd
+	m.list, cmd = m.list.Update(msg)
+	return m, cmd
+}
+
+func (m Model) View() string {
+	if m.selected != nil {
+		return renderSelectionSummary(m.selected)
+	}
+
+	breadcrumb := views.BlueStyle.Render("Path: " + strings.Join(commandPathSlice(m.current), " > "))
+	hint := views.GrayStyle.Render("Enter: open/select  Esc: back  /: filter  q: quit")
+	body := "\n" + m.list.View() + "\n" + breadcrumb + "\n" + hint + "\n"
+	if m.width == 0 {
+		return body
+	}
+
+	return lipgloss.NewStyle().Width(m.width).Render(body)
+}
+
+func Run(root *cobra.Command) (*cobra.Command, error) {
+	program := tea.NewProgram(NewModel(root), tea.WithAltScreen())
+	finalModel, err := program.Run()
+	if err != nil {
+		return nil, err
+	}
+
+	model, ok := finalModel.(Model)
+	if !ok {
+		return nil, fmt.Errorf("unexpected interactive result")
+	}
+
+	return model.selected, nil
+}
+
+func renderSelectionSummary(cmd *cobra.Command) string {
+	var sections []string
+	sections = append(sections, views.BoldStyle.Render("Selected command"))
+	sections = append(sections, views.GreenStyle.Render(cmd.CommandPath()))
+
+	if cmd.Short != "" {
+		sections = append(sections, "")
+		sections = append(sections, views.BoldStyle.Render("Summary"))
+		sections = append(sections, cmd.Short)
+	}
+
+	if cmd.Long != "" && cmd.Long != cmd.Short {
+		sections = append(sections, "")
+		sections = append(sections, views.BoldStyle.Render("Details"))
+		sections = append(sections, strings.TrimSpace(cmd.Long))
+	}
+
+	if cmd.Example != "" {
+		sections = append(sections, "")
+		sections = append(sections, views.BoldStyle.Render("Examples"))
+		sections = append(sections, strings.TrimSpace(cmd.Example))
+	}
+
+	if cmd.HasAvailableFlags() {
+		sections = append(sections, "")
+		sections = append(sections, views.BoldStyle.Render("Flags"))
+		sections = append(sections, "This command defines flags. Run the command with --help to inspect full flag details.")
+	}
+
+	sections = append(sections, "")
+	sections = append(sections, views.YellowStyle.Render("v1 preview: interactive mode currently browses the command tree and shows the selected leaf command."))
+
+	return "\n" + strings.Join(sections, "\n") + "\n"
+}
+
+func commandItems(cmd *cobra.Command) []list.Item {
+	commands := visibleSubcommands(cmd)
+	items := make([]list.Item, 0, len(commands))
+	for _, sub := range commands {
+		items = append(items, commandItem{
+			title:       sub.Name(),
+			description: sub.Short,
+			command:     sub,
+		})
+	}
+	return items
+}
+
+func visibleSubcommands(cmd *cobra.Command) []*cobra.Command {
+	commands := cmd.Commands()
+	items := make([]*cobra.Command, 0, len(commands))
+	for _, sub := range commands {
+		if !sub.IsAvailableCommand() || sub.Hidden {
+			continue
+		}
+		if sub.Name() == "help" || sub.Name() == "completion" || sub.Name() == "interactive" {
+			continue
+		}
+		items = append(items, sub)
+	}
+	return items
+}
+
+func commandPathSlice(cmd *cobra.Command) []string {
+	if cmd == nil {
+		return nil
+	}
+	return strings.Fields(cmd.CommandPath())
+}
+
+func dynamicListSize(width, height int) (int, int) {
+	listWidth := width
+	if listWidth < minListWidth {
+		listWidth = minListWidth
+	}
+
+	listHeight := height - verticalChrome
+	if listHeight < minListHeight {
+		listHeight = minListHeight
+	}
+
+	return listWidth, listHeight
+}

--- a/pkg/views/command/interactive/view_test.go
+++ b/pkg/views/command/interactive/view_test.go
@@ -1,0 +1,46 @@
+package interactive
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestVisibleSubcommandsSkipsHiddenAndHelperCommands(t *testing.T) {
+	root := &cobra.Command{Use: "harbor"}
+	root.AddCommand(&cobra.Command{Use: "artifact", Short: "Manage artifacts"})
+	root.AddCommand(&cobra.Command{Use: "interactive", Short: "Browse interactively"})
+	root.AddCommand(&cobra.Command{Use: "completion", Short: "Generate completion"})
+	root.AddCommand(&cobra.Command{Use: "secret", Hidden: true})
+	root.SetHelpCommand(&cobra.Command{Use: "help"})
+
+	commands := visibleSubcommands(root)
+	if len(commands) != 1 {
+		t.Fatalf("expected 1 visible subcommand, got %d", len(commands))
+	}
+
+	if commands[0].Name() != "artifact" {
+		t.Fatalf("expected artifact command, got %q", commands[0].Name())
+	}
+}
+
+func TestRenderSelectionSummaryIncludesCommandPath(t *testing.T) {
+	root := &cobra.Command{Use: "harbor"}
+	artifact := &cobra.Command{
+		Use:     "artifact",
+		Short:   "Manage artifacts",
+		Long:    "Manage artifacts in Harbor Repository",
+		Example: "harbor artifact list",
+	}
+	root.AddCommand(artifact)
+
+	summary := renderSelectionSummary(artifact)
+	if !strings.Contains(summary, "harbor artifact") {
+		t.Fatalf("expected command path in summary, got %q", summary)
+	}
+
+	if !strings.Contains(summary, "Manage artifacts") {
+		t.Fatalf("expected summary text in output, got %q", summary)
+	}
+}


### PR DESCRIPTION
## Description
Briefly describe what this pull request does and why the change is needed.

Harbor CLI exposes many top-level commands and many of them contain multiple levels of nested subcommands. Users often need to:

- run `harbor help`
- run `harbor <command> help`
- run `harbor <command> <subcommand> help`
- repeat this process several times until they find the command they need

This creates friction for new users and for infrequent users who know what they want to do, but do not remember the exact path.

So to address this issue

Adding an interactive command navigation mode, for example:
harbor interactive
This mode should let users:
browse top-level Harbor commands
drill down into subcommands step by step
continue until they reach a leaf command
see the selected command path and command description
eventually collect missing arguments interactively and execute the command safely

- Fixes #1055 

## Type of Change
Please select the relevant type.

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
- 
- 

## Demo

https://github.com/user-attachments/assets/ba805840-1db4-481d-87e4-84575e13ea72



