### PR TITLE
fix(project): use positional member name in update command

### DIFF
--- a/cmd/harbor/root/project/member/update.go
+++ b/cmd/harbor/root/project/member/update.go
@@ -16,7 +16,6 @@ package member
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/api"
@@ -43,7 +42,7 @@ func UpdateMemberCommand() *cobra.Command {
 				opts.ProjectNameOrID = args[0]
 			} else if len(args) == 2 {
 				opts.ProjectNameOrID = args[0]
-				opts.ID, _ = strconv.ParseInt(args[1], 0, 64)
+				memberName = args[1]
 			}
 
 			if opts.ProjectNameOrID == "" {


### PR DESCRIPTION
## Description

This PR fixes the `project member update` command so that the second positional argument is treated as the member name, matching the documented command usage.

Fixes #1058

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes

- Use the second positional argument as the member name instead of attempting to parse it as a numeric member ID.
- Preserve the existing `api.GetUsersIdByName()` lookup flow to resolve the member before updating.
- Remove the unused `strconv` import.