### PR TITLE
feat(auditlog): implement harbor auditlog list and types commands

### DIFF
--- a/cmd/harbor/root/auditlog/cmd.go
+++ b/cmd/harbor/root/auditlog/cmd.go
@@ -1,0 +1,34 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package auditlog
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func AuditLog() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "auditlog",
+		Short:   "Manage and view audit logs",
+		Long:    "View system-wide audit logs in Harbor",
+		Example: `harbor auditlog list`,
+	}
+
+	cmd.AddCommand(
+		ListAuditLogsCommand(),
+		AuditLogTypesCommand(),
+	)
+
+	return cmd
+}

--- a/cmd/harbor/root/auditlog/list.go
+++ b/cmd/harbor/root/auditlog/list.go
@@ -1,0 +1,87 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package auditlog
+
+import (
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	auditlogView "github.com/goharbor/harbor-cli/pkg/views/auditlog"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func ListAuditLogsCommand() *cobra.Command {
+	var (
+		opts      api.ListFlags
+		username  string
+		operation string
+		resource  string
+		query     string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List audit logs",
+		Long:    "List system-wide audit logs in Harbor",
+		Example: `harbor auditlog list --page 1 --page-size 10 --username admin`,
+		Run: func(cmd *cobra.Command, args []string) {
+			var matchFilters []string
+			if username != "" {
+				matchFilters = append(matchFilters, "username="+username)
+			}
+			if operation != "" {
+				matchFilters = append(matchFilters, "operation="+operation)
+			}
+			if resource != "" {
+				matchFilters = append(matchFilters, "resource="+resource)
+			}
+
+			if len(matchFilters) > 0 {
+				q, err := utils.BuildQueryParam(nil, matchFilters, nil, []string{"username", "operation", "resource"})
+				if err != nil {
+					logrus.Fatalf("failed to build query parameters: %v", err)
+				}
+				opts.Q = q
+			} else if query != "" {
+				opts.Q = query
+			}
+
+			response, err := api.AuditLogs(opts)
+			if err != nil {
+				logrus.Fatalf("failed to fetch audit logs: %v", err)
+			}
+
+			formatFlag := viper.GetString("output-format")
+			if formatFlag != "" {
+				err = utils.PrintFormat(response.Payload, formatFlag)
+				if err != nil {
+					logrus.Fatalf("failed to print format: %v", err)
+				}
+				return
+			}
+
+			auditlogView.RenderAuditLogsExt(response.Payload)
+		},
+	}
+
+	cmd.Flags().Int64VarP(&opts.Page, "page", "", 1, "Page number")
+	cmd.Flags().Int64VarP(&opts.PageSize, "page-size", "", 10, "Size of per page")
+	cmd.Flags().StringVarP(&query, "query", "q", "", "Query string for filtering logs")
+	cmd.Flags().StringVarP(&username, "username", "u", "", "Filter logs by username")
+	cmd.Flags().StringVarP(&operation, "operation", "", "", "Filter logs by operation type (e.g. create, delete, pull)")
+	cmd.Flags().StringVarP(&resource, "resource", "r", "", "Filter logs by target resource")
+
+	return cmd
+}

--- a/cmd/harbor/root/auditlog/list_test.go
+++ b/cmd/harbor/root/auditlog/list_test.go
@@ -1,0 +1,40 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package auditlog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListAuditLogsCommand(t *testing.T) {
+	cmd := ListAuditLogsCommand()
+
+	assert.Equal(t, "list", cmd.Use)
+	assert.Equal(t, "List audit logs", cmd.Short)
+	assert.NotNil(t, cmd.Flags().Lookup("page"))
+	assert.NotNil(t, cmd.Flags().Lookup("page-size"))
+	assert.NotNil(t, cmd.Flags().Lookup("username"))
+	assert.NotNil(t, cmd.Flags().Lookup("operation"))
+	assert.NotNil(t, cmd.Flags().Lookup("resource"))
+	assert.NotNil(t, cmd.Flags().Lookup("query"))
+}
+
+func TestAuditLogTypesCommand(t *testing.T) {
+	cmd := AuditLogTypesCommand()
+
+	assert.Equal(t, "types", cmd.Use)
+	assert.Equal(t, "List audit log event types", cmd.Short)
+}

--- a/cmd/harbor/root/auditlog/types.go
+++ b/cmd/harbor/root/auditlog/types.go
@@ -1,0 +1,54 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package auditlog
+
+import (
+	"fmt"
+
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func AuditLogTypesCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "types",
+		Short:   "List audit log event types",
+		Long:    "List available event types for audit logs in Harbor",
+		Example: `harbor auditlog types`,
+		Run: func(cmd *cobra.Command, args []string) {
+			response, err := api.AuditLogEventTypes()
+			if err != nil {
+				logrus.Fatalf("failed to fetch audit log event types: %v", err)
+			}
+
+			formatFlag := viper.GetString("output-format")
+			if formatFlag != "" {
+				err = utils.PrintFormat(response.Payload, formatFlag)
+				if err != nil {
+					logrus.Fatalf("failed to print format: %v", err)
+				}
+				return
+			}
+
+			for _, eventType := range response.Payload {
+				fmt.Println(eventType)
+			}
+		},
+	}
+
+	return cmd
+}

--- a/cmd/harbor/root/cmd.go
+++ b/cmd/harbor/root/cmd.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/goharbor/harbor-cli/cmd/harbor/root/artifact"
+	"github.com/goharbor/harbor-cli/cmd/harbor/root/auditlog"
 	"github.com/goharbor/harbor-cli/cmd/harbor/root/configurations"
 	"github.com/goharbor/harbor-cli/cmd/harbor/root/context"
 	"github.com/goharbor/harbor-cli/cmd/harbor/root/cve"
@@ -214,6 +215,10 @@ harbor help
 	root.AddCommand(cmd)
 
 	cmd = Logs()
+	cmd.GroupID = "utils"
+	root.AddCommand(cmd)
+
+	cmd = auditlog.AuditLog()
 	cmd.GroupID = "utils"
 	root.AddCommand(cmd)
 

--- a/doc/cli-docs/harbor-auditlog-list.md
+++ b/doc/cli-docs/harbor-auditlog-list.md
@@ -1,0 +1,48 @@
+---
+title: harbor auditlog list
+weight: 10
+---
+## harbor auditlog list
+
+### Description
+
+##### List audit logs
+
+### Synopsis
+
+List system-wide audit logs in Harbor
+
+```sh
+harbor auditlog list [flags]
+```
+
+### Examples
+
+```sh
+harbor auditlog list --page 1 --page-size 10 --username admin
+```
+
+### Options
+
+```sh
+  -h, --help               help for list
+      --operation string   Filter logs by operation type (e.g. create, delete, pull)
+      --page int           Page number (default 1)
+      --page-size int      Size of per page (default 10)
+  -q, --query string       Query string for filtering logs
+  -r, --resource string    Filter logs by target resource
+  -u, --username string    Filter logs by username
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml|csv
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor auditlog](harbor-auditlog.md)	 - Manage and view audit logs
+

--- a/doc/cli-docs/harbor-auditlog-types.md
+++ b/doc/cli-docs/harbor-auditlog-types.md
@@ -1,0 +1,42 @@
+---
+title: harbor auditlog types
+weight: 95
+---
+## harbor auditlog types
+
+### Description
+
+##### List audit log event types
+
+### Synopsis
+
+List available event types for audit logs in Harbor
+
+```sh
+harbor auditlog types [flags]
+```
+
+### Examples
+
+```sh
+harbor auditlog types
+```
+
+### Options
+
+```sh
+  -h, --help   help for types
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml|csv
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor auditlog](harbor-auditlog.md)	 - Manage and view audit logs
+

--- a/doc/cli-docs/harbor-auditlog.md
+++ b/doc/cli-docs/harbor-auditlog.md
@@ -1,0 +1,40 @@
+---
+title: harbor auditlog
+weight: 65
+---
+## harbor auditlog
+
+### Description
+
+##### Manage and view audit logs
+
+### Synopsis
+
+View system-wide audit logs in Harbor
+
+### Examples
+
+```sh
+harbor auditlog list
+```
+
+### Options
+
+```sh
+  -h, --help   help for auditlog
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml|csv
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor](harbor.md)	 - Official Harbor CLI
+* [harbor auditlog list](harbor-auditlog-list.md)	 - List audit logs
+* [harbor auditlog types](harbor-auditlog-types.md)	 - List audit log event types
+

--- a/doc/cli-docs/harbor.md
+++ b/doc/cli-docs/harbor.md
@@ -36,6 +36,7 @@ harbor help
 ### SEE ALSO
 
 * [harbor artifact](harbor-artifact.md)	 - Manage artifacts
+* [harbor auditlog](harbor-auditlog.md)	 - Manage and view audit logs
 * [harbor config](harbor-config.md)	 - Manage system configurations
 * [harbor context](harbor-context.md)	 - Manage locally available contexts
 * [harbor cve-allowlist](harbor-cve-allowlist.md)	 - Manage system CVE allowlist

--- a/pkg/views/auditlog/view.go
+++ b/pkg/views/auditlog/view.go
@@ -1,0 +1,79 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package auditlog
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/goharbor/harbor-cli/pkg/views/base/tablelist"
+)
+
+var columns = []table.Column{
+	{Title: "ID", Width: 8},
+	{Title: "Username", Width: 18},
+	{Title: "Resource", Width: 18},
+	{Title: "Resource Type", Width: 14},
+	{Title: "Operation", Width: 10},
+	{Title: "Timestamp", Width: 20},
+}
+
+func RenderAuditLogs(logs []*models.AuditLog) {
+	var rows []table.Row
+	for _, log := range logs {
+		opTime, _ := utils.FormatCreatedTime(log.OpTime.String())
+		rows = append(rows, table.Row{
+			strconv.FormatInt(log.ID, 10),
+			log.Username,
+			log.Resource,
+			log.ResourceType,
+			log.Operation,
+			opTime,
+		})
+	}
+
+	m := tablelist.NewModel(columns, rows, len(rows))
+
+	if _, err := tea.NewProgram(m).Run(); err != nil {
+		fmt.Println("Error running program:", err)
+		os.Exit(1)
+	}
+}
+
+func RenderAuditLogsExt(logs []*models.AuditLogExt) {
+	var rows []table.Row
+	for _, log := range logs {
+		opTime, _ := utils.FormatCreatedTime(log.OpTime.String())
+		rows = append(rows, table.Row{
+			strconv.FormatInt(log.ID, 10),
+			log.Username,
+			log.Resource,
+			log.ResourceType,
+			log.Operation,
+			opTime,
+		})
+	}
+
+	m := tablelist.NewModel(columns, rows, len(rows))
+
+	if _, err := tea.NewProgram(m).Run(); err != nil {
+		fmt.Println("Error running program:", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## Description
This pull request implements the top-level `harbor auditlog` command group and subcommands to reach WebUI feature parity for audit logging (`❌ Auditlog` in `README.md`).

- Fixes #1060 

## Type of Change
Please select the relevant type.

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation update
- [ ] Chore / maintenance

## Changes
- Created `harbor auditlog` Cobra command group (`cmd/harbor/root/auditlog/cmd.go`) registered under the Utility group.
- Implemented `harbor auditlog list` command with pagination (`--page`, `--page-size`) and filtering flags (`--query`, `--username`, `--operation`, `--resource`).
- Implemented `harbor auditlog types` command to list supported audit log event types (`api.AuditLogEventTypes()`).
- Added table view formatting in `pkg/views/auditlog/view.go` supporting default table views alongside `-o json`, `-o yaml`, `-o csv`.
- Added unit tests in `cmd/harbor/root/auditlog/list_test.go`.
- Regenerated CLI documentation markdown files (`doc/cli-docs/harbor-auditlog*.md`).
