### PR TITLE
fix(project): print correct role ID in update success message

### DIFF
--- a/cmd/harbor/root/project/member/update.go
+++ b/cmd/harbor/root/project/member/update.go
@@ -82,7 +82,7 @@ func UpdateMemberCommand() *cobra.Command {
 				return fmt.Errorf("failed to get members list: %v", err)
 			}
 
-			fmt.Printf("successfully updated user with ID %d with role ID %d for project %s\n", opts.ID, opts.RoleID, opts.ProjectNameOrID)
+			fmt.Printf("successfully updated user with ID %d with role ID %d for project %s\n", opts.ID, roleID, opts.ProjectNameOrID)
 			return nil
 		},
 	}


### PR DESCRIPTION
## Description

This PR fixes the success message printed by the `project member update` command.

Previously, the command attempted to print `opts.RoleID`, which is a `*models.RoleRequest`, using the `%d` formatting verb. As a result, the success message displayed a formatting error instead of the numeric role ID.

Fixes #1063 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes

- Use the existing `roleID` integer when printing the success message.
- Prevent malformed `%!d(*models.RoleRequest=...)` output.
- No functional changes beyond correcting the displayed success message.
