### PR TITLE
fix: nil,nil return from GetRegistryResponse causes panic in replication policies create

### DIFF
--- a/cmd/harbor/root/replication/policies/create.go
+++ b/cmd/harbor/root/replication/policies/create.go
@@ -66,7 +66,7 @@ func CreateCommand() *cobra.Command {
 			}
 
 			if registry == nil {
-				return fmt.Errorf("Registery with ID %d not found",registryID)
+				return fmt.Errorf("registry with ID %d not found", registryID)
 			}
 
 			policy := ConvertToPolicy(opts, registry)

--- a/cmd/harbor/root/replication/policies/create.go
+++ b/cmd/harbor/root/replication/policies/create.go
@@ -65,6 +65,10 @@ func CreateCommand() *cobra.Command {
 				return fmt.Errorf("failed to get registry with ID %d: %v", registryID, err)
 			}
 
+			if registry == nil {
+				return fmt.Errorf("Registery with ID %d not found",registryID)
+			}
+
 			policy := ConvertToPolicy(opts, registry)
 			response, err := api.CreateReplicationPolicy(&replication.CreateReplicationPolicyParams{
 				Policy: policy,

--- a/pkg/api/registry_handler.go
+++ b/pkg/api/registry_handler.go
@@ -122,7 +122,7 @@ func GetRegistryResponse(registryId int64) (*models.Registry, error) {
 		return nil, err
 	}
 	if response.Payload.ID == 0 {
-		return nil, err
+		return nil, fmt.Errorf("registry with ID %d not found", registryId)
 	}
 
 	return response.GetPayload(), err


### PR DESCRIPTION
## Description

Fixes #1065.

`GetRegistryResponse` was returning `(nil, nil)` when a registry wasn't found, which caused `replication policies create` to panic instead of returning a proper error.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Refactor
* [ ] Documentation update
* [ ] Chore / maintenance

## Changes

* Return an error instead of `(nil, nil)` when the registry doesn't exist.
* Add a nil check in `replication/policies/create.go` to avoid a panic and fail gracefully.
