### PR TITLE
fix(cli): validate arg count for artifact tags create/delete to preve…

### DIFF
--- a/cmd/harbor/root/artifact/tags/create.go
+++ b/cmd/harbor/root/artifact/tags/create.go
@@ -28,6 +28,12 @@ func CreateTagsCmd() *cobra.Command {
 		Use:     "create",
 		Short:   "Create a tag of an artifact",
 		Example: `harbor artifact tags create <project>/<repository>/<reference> <tag>`,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 || len(args) == 2 {
+				return nil
+			}
+			return fmt.Errorf("requires either 0 arguments(interactive mode) or 2 arguments(<project>/<repository>/<reference> <tag>), got %d", len(args))
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			var projectName, repoName, reference string

--- a/cmd/harbor/root/artifact/tags/delete.go
+++ b/cmd/harbor/root/artifact/tags/delete.go
@@ -27,6 +27,12 @@ func DeleteTagsCmd() *cobra.Command {
 		Use:     "delete",
 		Short:   "Delete a tag of an artifact",
 		Example: `harbor artifact tags delete <project>/<repository>/<reference> <tag>`,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 || len(args) == 2 {
+				return nil
+			}
+			return fmt.Errorf("requires either 0 arguments (interactive mode) or 2 arguments (<project>/<repository>/<reference> <tag>), got %d", len(args))
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			var projectName, repoName, reference string


### PR DESCRIPTION
## Description
harbor artifact tags create and delete both panic with an "index out of range" error 
when called with exactly one argument. Neither command had an Args validator on the 
cobra.Command, so passing a single arg fell into the non-interactive branch and tried 
to read args[1], which doesn't exist.

- Fixes #1069

## Type of Change
Please select the relevant type.

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
- Added an Args validator to CreateTagsCmd that allows 0 args (interactive mode) or 2 args (non-interactive), rejects anything else with a clean error
- Added the same Args validator to DeleteTagsCmd
- Verified manually: 1 arg → clean error, no panic; 2 args → works as before; 0 args → interactive prompts still work; go build ./... passes