### PR TITLE
fix(context): remove none from switch usage

### DIFF
--- a/cmd/harbor/root/context/switch.go
+++ b/cmd/harbor/root/context/switch.go
@@ -24,7 +24,7 @@ import (
 
 func SwitchContextCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "switch <none|context>",
+		Use:     "switch <context>",
 		Short:   "Switch to a new context",
 		Example: `harbor context switch harbor-cli@https-demo-goharbor-io`,
 		Args:    cobra.MaximumNArgs(1),

--- a/doc/cli-docs/harbor-context-switch.md
+++ b/doc/cli-docs/harbor-context-switch.md
@@ -9,7 +9,7 @@ weight: 50
 ##### Switch to a new context
 
 ```sh
-harbor context switch <none|context> [flags]
+harbor context switch <context> [flags]
 ```
 
 ### Examples
@@ -35,4 +35,3 @@ harbor context switch harbor-cli@https-demo-goharbor-io
 ### SEE ALSO
 
 * [harbor context](harbor-context.md)	 - Manage locally available contexts
-


### PR DESCRIPTION
## Description

Removes the misleading `none` option from the `harbor context switch` command usage text.

- Fixes #1072

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation update
- [ ] Chore / maintenance

## Changes

- Updated `harbor context switch` usage from `switch <none|context>` to `switch <context>`.
- Updated the corresponding CLI documentation.
- Verified the context command package tests pass.