### PR TITLE
fix(project): warn when --page is ignored due to --page-size=0

### DIFF
--- a/cmd/harbor/root/project/list.go
+++ b/cmd/harbor/root/project/list.go
@@ -128,6 +128,9 @@ func ListProjectCommand() *cobra.Command {
 func fetchProjects(listFunc func(...api.ListFlags) (project.ListProjectsOK, error), opts api.ListFlags) ([]*models.Project, error) {
 	var allProjects []*models.Project
 	if opts.PageSize == 0 {
+		if opts.Page != 1 {
+			log.Warn("--page is ignored when --page-size is 0 (fetching all pages)")
+		}
 		log.Debug("Page size is 0, will fetch all pages")
 		opts.PageSize = 100
 		opts.Page = 1


### PR DESCRIPTION
Closes #1074

## Problem
When `--page-size=0` (fetch-all mode), the code silently resets `--page` to 1
without informing the user, causing confusing behavior when a user explicitly
passes a `--page` value alongside `--page-size=0`.

## Fix
Added a warning log when `opts.Page != 1` and `opts.PageSize == 0`, informing
the user that `--page` is being ignored.

## Testing
Tested against demo.goharbor.io:
\`harbor project list --page 5 --page-size 0 -v\`

Output now correctly shows:
\`level=warning msg="--page is ignored when --page-size is 0 (fetching all pages)"\`