### PR TITLE
feat: add declarative configuration management

### DIFF
--- a/cmd/harbor/root/apply.go
+++ b/cmd/harbor/root/apply.go
@@ -1,0 +1,109 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package root
+
+import (
+	"bufio"
+	"fmt"
+	"strings"
+
+	"github.com/goharbor/harbor-cli/pkg/declarative"
+	"github.com/spf13/cobra"
+)
+
+func applyCommand() *cobra.Command {
+	var filename string
+	var dryRun bool
+	var skipConfirmation bool
+	cmd := &cobra.Command{
+		Use:   "apply",
+		Short: "Reconcile Harbor with a declarative configuration",
+		Long: `Compare a versioned configuration document with Harbor and apply the
+required create and update operations. Apply is additive: resources omitted
+from the document are left untouched, and extra live resources are not deleted.`,
+		Example: `  harbor apply -f harbor.yaml --dry-run
+  harbor apply -f harbor.yaml
+  harbor apply -f environments/production
+  harbor apply -f harbor.yaml --yes`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if filename == "" {
+				return fmt.Errorf("configuration file is required")
+			}
+			desired, err := declarative.ReadPath(filename)
+			if err != nil {
+				return err
+			}
+			backend, err := declarative.NewLiveBackend()
+			if err != nil {
+				return err
+			}
+			service := declarative.NewService(backend)
+			plan, err := service.Plan(cmd.Context(), desired)
+			if err != nil {
+				return err
+			}
+			printPlan(cmd, plan)
+			if !plan.HasChanges() {
+				fmt.Fprintln(cmd.OutOrStdout(), "Harbor configuration is already converged.")
+				return nil
+			}
+			if dryRun {
+				fmt.Fprintf(cmd.OutOrStdout(), "Dry run: %d change(s) would be applied.\n", plan.ChangeCount())
+				return nil
+			}
+			if !skipConfirmation {
+				confirmed, err := confirmApply(cmd)
+				if err != nil {
+					return err
+				}
+				if !confirmed {
+					fmt.Fprintln(cmd.OutOrStdout(), "Apply cancelled.")
+					return nil
+				}
+			}
+			if err := service.Apply(cmd.Context(), desired, plan); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Applied %d change(s).\n", plan.ChangeCount())
+			return nil
+		},
+	}
+	flags := cmd.Flags()
+	flags.StringVarP(&filename, "file", "f", "", "YAML/JSON configuration file or directory to apply")
+	flags.BoolVar(&dryRun, "dry-run", false, "Show the reconciliation plan without changing Harbor")
+	flags.BoolVarP(&skipConfirmation, "yes", "y", false, "Apply without an interactive confirmation")
+	return cmd
+}
+
+func printPlan(cmd *cobra.Command, plan declarative.Plan) {
+	fmt.Fprintln(cmd.OutOrStdout(), "Reconciliation plan:")
+	for _, action := range plan.Actions {
+		if action.Operation == declarative.OperationNoop && !verbose {
+			continue
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", action)
+	}
+}
+
+func confirmApply(cmd *cobra.Command) (bool, error) {
+	fmt.Fprint(cmd.OutOrStdout(), "Apply these changes? (y/N): ")
+	answer, err := bufio.NewReader(cmd.InOrStdin()).ReadString('\n')
+	if err != nil {
+		return false, fmt.Errorf("read confirmation: %w", err)
+	}
+	answer = strings.ToLower(strings.TrimSpace(answer))
+	return answer == "y" || answer == "yes", nil
+}

--- a/cmd/harbor/root/apply_test.go
+++ b/cmd/harbor/root/apply_test.go
@@ -1,0 +1,42 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package root
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/goharbor/harbor-cli/pkg/declarative"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrintPlanHidesNoopActionsUnlessVerbose(t *testing.T) {
+	previousVerbose := verbose
+	t.Cleanup(func() { verbose = previousVerbose })
+	verbose = false
+	var output bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&output)
+	plan := declarative.Plan{Actions: []declarative.Action{
+		{Operation: declarative.OperationNoop, Resource: "project", Name: "existing"},
+		{Operation: declarative.OperationCreate, Resource: "project", Name: "new"},
+	}}
+
+	printPlan(cmd, plan)
+
+	assert.NotContains(t, output.String(), "existing")
+	assert.Contains(t, output.String(), "create project new")
+}

--- a/cmd/harbor/root/cmd.go
+++ b/cmd/harbor/root/cmd.go
@@ -176,6 +176,14 @@ harbor help
 	cmd.GroupID = "system"
 	root.AddCommand(cmd)
 
+	cmd = exportCommand()
+	cmd.GroupID = "system"
+	root.AddCommand(cmd)
+
+	cmd = applyCommand()
+	cmd.GroupID = "system"
+	root.AddCommand(cmd)
+
 	cmd = HealthCommand()
 	cmd.GroupID = "system"
 	root.AddCommand(cmd)

--- a/cmd/harbor/root/export.go
+++ b/cmd/harbor/root/export.go
@@ -1,0 +1,75 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package root
+
+import (
+	"fmt"
+
+	"github.com/goharbor/harbor-cli/pkg/declarative"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func exportCommand() *cobra.Command {
+	var filename string
+	cmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export Harbor API-managed configuration",
+		Long: `Export Harbor API-managed configuration as a versioned declarative document.
+
+The export contains system settings, registry endpoints, projects, quotas,
+webhooks, and replication policies. It does not contain credentials, robot
+secrets, users, artifacts, database contents, or Harbor deployment settings.`,
+		Example: `  harbor export -f harbor.yaml
+  harbor export -f harbor.json -o json
+  harbor export -o yaml > harbor.yaml`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			backend, err := declarative.NewLiveBackend()
+			if err != nil {
+				return err
+			}
+			configuration, err := declarative.NewService(backend).Export(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			format, err := exportFormat(filename, viper.GetString("output-format"))
+			if err != nil {
+				return err
+			}
+			if filename == "" || filename == "-" {
+				return declarative.Encode(cmd.OutOrStdout(), configuration, format)
+			}
+			if err := declarative.WriteFile(filename, configuration, format); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.ErrOrStderr(), "Exported Harbor configuration to %s\n", filename)
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&filename, "file", "f", "", "Write configuration to a YAML or JSON file (default: stdout)")
+	return cmd
+}
+
+func exportFormat(filename, requested string) (declarative.Format, error) {
+	if requested != "" {
+		return declarative.ParseFormat(requested)
+	}
+	if filename != "" && filename != "-" {
+		return declarative.FormatForFile(filename)
+	}
+	return declarative.FormatYAML, nil
+}

--- a/doc/cli-docs/harbor-apply.md
+++ b/doc/cli-docs/harbor-apply.md
@@ -1,0 +1,50 @@
+---
+title: harbor apply
+weight: 40
+---
+## harbor apply
+
+### Description
+
+##### Reconcile Harbor with a declarative configuration
+
+### Synopsis
+
+Compare a versioned configuration document with Harbor and apply the
+required create and update operations. Apply is additive: resources omitted
+from the document are left untouched, and extra live resources are not deleted.
+
+```sh
+harbor apply [flags]
+```
+
+### Examples
+
+```sh
+  harbor apply -f harbor.yaml --dry-run
+  harbor apply -f harbor.yaml
+  harbor apply -f environments/production
+  harbor apply -f harbor.yaml --yes
+```
+
+### Options
+
+```sh
+      --dry-run       Show the reconciliation plan without changing Harbor
+  -f, --file string   YAML/JSON configuration file or directory to apply
+  -h, --help          help for apply
+  -y, --yes           Apply without an interactive confirmation
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml|csv
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor](harbor.md)	 - Official Harbor CLI
+

--- a/doc/cli-docs/harbor-export.md
+++ b/doc/cli-docs/harbor-export.md
@@ -1,0 +1,49 @@
+---
+title: harbor export
+weight: 5
+---
+## harbor export
+
+### Description
+
+##### Export Harbor API-managed configuration
+
+### Synopsis
+
+Export Harbor API-managed configuration as a versioned declarative document.
+
+The export contains system settings, registry endpoints, projects, quotas,
+webhooks, and replication policies. It does not contain credentials, robot
+secrets, users, artifacts, database contents, or Harbor deployment settings.
+
+```sh
+harbor export [flags]
+```
+
+### Examples
+
+```sh
+  harbor export -f harbor.yaml
+  harbor export -f harbor.json -o json
+  harbor export -o yaml > harbor.yaml
+```
+
+### Options
+
+```sh
+  -f, --file string   Write configuration to a YAML or JSON file (default: stdout)
+  -h, --help          help for export
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -o, --output-format string   Output format. One of: json|yaml|csv
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor](harbor.md)	 - Official Harbor CLI
+

--- a/doc/cli-docs/harbor.md
+++ b/doc/cli-docs/harbor.md
@@ -35,10 +35,12 @@ harbor help
 
 ### SEE ALSO
 
+* [harbor apply](harbor-apply.md)	 - Reconcile Harbor with a declarative configuration
 * [harbor artifact](harbor-artifact.md)	 - Manage artifacts
 * [harbor config](harbor-config.md)	 - Manage system configurations
 * [harbor context](harbor-context.md)	 - Manage locally available contexts
 * [harbor cve-allowlist](harbor-cve-allowlist.md)	 - Manage system CVE allowlist
+* [harbor export](harbor-export.md)	 - Export Harbor API-managed configuration
 * [harbor health](harbor-health.md)	 - Get the health status of Harbor components
 * [harbor info](harbor-info.md)	 - Display detailed Harbor system, statistics, and CLI environment information
 * [harbor instance](harbor-instance.md)	 - Manage preheat provider instances in Harbor

--- a/examples/declarative/README.md
+++ b/examples/declarative/README.md
@@ -1,0 +1,80 @@
+# Declarative Harbor configuration
+
+The declarative document describes desired Harbor resources rather than Harbor
+API responses. Generated IDs, timestamps, resource usage, health status, and
+credentials are intentionally excluded.
+
+The initial `goharbor.io/v1alpha1` contract supports:
+
+- Harbor system configuration
+- external registry endpoints
+- projects, project metadata, quotas, and webhooks
+- replication policies
+
+Resource names are their portable identities. References such as a project's
+proxy-cache registry and a replication policy's external registry therefore use
+names instead of Harbor-generated IDs.
+
+Export current state:
+
+```sh
+harbor export -f harbor.yaml
+```
+
+Review and apply it:
+
+```sh
+harbor apply -f harbor.yaml --dry-run
+harbor apply -f harbor.yaml
+```
+
+Configurations can also be organized as a directory:
+
+```text
+production/
+├── 00-base.yaml
+├── 10-production.yaml
+└── projects/
+    └── 20-applications.yaml
+```
+
+```sh
+harbor apply -f production --dry-run
+harbor apply -f production
+```
+
+The CLI discovers YAML and JSON files recursively and merges them in
+lexicographic relative-path order. Maps merge by key, resources merge by name,
+and explicitly specified fields in later files override earlier files.
+List-valued fields such as webhook targets, events, and replication filters are
+replaced as a unit, as is the replication trigger. This directly supports a
+reusable base configuration, recommended defaults, required settings, and small
+environment-specific overlays while the resolved document remains a regular
+`HarborConfiguration`.
+
+Apply is additive. It creates missing resources and updates changed managed
+fields, but it never deletes resources omitted from the file.
+
+## Secrets
+
+Exports never contain credentials or webhook authentication headers. A file
+that needs to create or rotate those values can reference environment variables:
+
+```yaml
+spec:
+  registries:
+    - name: private
+      type: harbor
+      url: https://registry.example.com
+      credential:
+        type: basic
+        accessKeyFrom:
+          env: HARBOR_REGISTRY_USERNAME
+        accessSecretFrom:
+          env: HARBOR_REGISTRY_PASSWORD
+```
+
+Existing credentials remain unchanged when `credential` is omitted.
+
+This format is not a database or artifact backup and does not include Harbor
+installation configuration, users, robot secrets, repositories, or artifacts.

--- a/examples/declarative/harbor.yaml
+++ b/examples/declarative/harbor.yaml
@@ -1,0 +1,42 @@
+apiVersion: goharbor.io/v1alpha1
+kind: HarborConfiguration
+spec:
+  system:
+    project_creation_restriction: adminonly
+    self_registration: false
+
+  registries:
+    - name: docker-hub
+      type: docker-hub
+      url: https://hub.docker.com
+      insecure: false
+
+  projects:
+    - name: development
+      public: false
+      metadata:
+        autoScan: true
+        autoSBOMGeneration: true
+        severity: high
+      quota:
+        storage: 536870912000
+      webhooks:
+        - name: deployment
+          enabled: true
+          events:
+            - PUSH_ARTIFACT
+          targets:
+            - notifyType: http
+              endpoint: https://example.com/hooks/harbor
+              payloadFormat: Default
+              verifyRemoteCertificate: true
+
+  replicationPolicies:
+    - name: mirror-production
+      mode: push
+      registry: docker-hub
+      enabled: true
+      override: true
+      trigger:
+        type: scheduled
+        cron: "0 0 * * * *"

--- a/pkg/declarative/codec.go
+++ b/pkg/declarative/codec.go
@@ -1,0 +1,263 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package declarative
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"go.yaml.in/yaml/v4"
+)
+
+// Format identifies a supported declarative document encoding.
+type Format string
+
+const (
+	// FormatYAML encodes a document as YAML.
+	FormatYAML Format = "yaml"
+	// FormatJSON encodes a document as JSON.
+	FormatJSON Format = "json"
+)
+
+// ParseFormat validates a user-supplied output format.
+func ParseFormat(value string) (Format, error) {
+	switch strings.ToLower(value) {
+	case "yaml", "yml":
+		return FormatYAML, nil
+	case "json":
+		return FormatJSON, nil
+	default:
+		return "", fmt.Errorf("unsupported format %q; expected yaml or json", value)
+	}
+}
+
+// FormatForFile infers a document encoding from a filename.
+func FormatForFile(filename string) (Format, error) {
+	switch strings.ToLower(filepath.Ext(filename)) {
+	case ".yaml", ".yml":
+		return FormatYAML, nil
+	case ".json":
+		return FormatJSON, nil
+	default:
+		return "", fmt.Errorf("unsupported file extension %q; expected .yaml, .yml, or .json", filepath.Ext(filename))
+	}
+}
+
+// Decode reads and strictly validates one configuration document.
+func Decode(r io.Reader, format Format) (*Configuration, error) {
+	configuration, err := decode(r, format)
+	if err != nil {
+		return nil, err
+	}
+	if err := configuration.Validate(); err != nil {
+		return nil, err
+	}
+	configuration.Normalize()
+	return configuration, nil
+}
+
+func decode(r io.Reader, format Format) (*Configuration, error) {
+	var configuration Configuration
+	switch format {
+	case FormatYAML:
+		decoder := yaml.NewDecoder(r)
+		decoder.KnownFields(true)
+		if err := decoder.Decode(&configuration); err != nil {
+			return nil, fmt.Errorf("decode YAML configuration: %w", err)
+		}
+		if err := rejectAdditionalDocument(decoder); err != nil {
+			return nil, fmt.Errorf("decode YAML configuration: %w", err)
+		}
+	case FormatJSON:
+		decoder := json.NewDecoder(r)
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&configuration); err != nil {
+			return nil, fmt.Errorf("decode JSON configuration: %w", err)
+		}
+		if err := rejectAdditionalDocument(decoder); err != nil {
+			return nil, fmt.Errorf("decode JSON configuration: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported format %q", format)
+	}
+	return &configuration, nil
+}
+
+func rejectAdditionalDocument(decoder interface{ Decode(any) error }) error {
+	var extra any
+	err := decoder.Decode(&extra)
+	if errors.Is(err, io.EOF) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("decode trailing content: %w", err)
+	}
+	return errors.New("multiple documents in one file are not supported")
+}
+
+// ReadFile loads a configuration, inferring its encoding from the extension.
+func ReadFile(filename string) (*Configuration, error) {
+	format, err := FormatForFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("read configuration: %w", err)
+	}
+	return Decode(bytes.NewReader(data), format)
+}
+
+// ReadPath loads one configuration file or overlays all configuration files in
+// a directory recursively. Directory files are applied in relative-path order.
+func ReadPath(path string) (*Configuration, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("inspect configuration path: %w", err)
+	}
+	if !info.IsDir() {
+		return ReadFile(path)
+	}
+
+	filenames, err := configurationFiles(path)
+	if err != nil {
+		return nil, err
+	}
+	if len(filenames) == 0 {
+		return nil, fmt.Errorf("configuration directory %q contains no YAML or JSON files", path)
+	}
+	configurations := make([]*Configuration, 0, len(filenames))
+	for _, filename := range filenames {
+		configuration, readErr := readFragment(filename)
+		if readErr != nil {
+			return nil, readErr
+		}
+		if validateErr := configuration.validate(false); validateErr != nil {
+			return nil, fmt.Errorf("validate configuration %q: %w", filename, validateErr)
+		}
+		configurations = append(configurations, configuration)
+	}
+	configuration, err := Merge(configurations...)
+	if err != nil {
+		return nil, fmt.Errorf("merge configuration directory %q: %w", path, err)
+	}
+	return configuration, nil
+}
+
+func readFragment(filename string) (*Configuration, error) {
+	format, err := FormatForFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("read configuration %q: %w", filename, err)
+	}
+	configuration, err := decode(bytes.NewReader(data), format)
+	if err != nil {
+		return nil, fmt.Errorf("read configuration %q: %w", filename, err)
+	}
+	return configuration, nil
+}
+
+func configurationFiles(root string) ([]string, error) {
+	var filenames []string
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if path != root && entry.IsDir() && strings.HasPrefix(entry.Name(), ".") {
+			return filepath.SkipDir
+		}
+		if entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			return nil
+		}
+		switch strings.ToLower(filepath.Ext(entry.Name())) {
+		case ".yaml", ".yml", ".json":
+			filenames = append(filenames, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walk configuration directory: %w", err)
+	}
+	slices.Sort(filenames)
+	return filenames, nil
+}
+
+// Encode writes a normalized configuration in the requested encoding.
+func Encode(w io.Writer, configuration *Configuration, format Format) error {
+	if err := configuration.Validate(); err != nil {
+		return err
+	}
+	configuration.Normalize()
+	switch format {
+	case FormatYAML:
+		encoder := yaml.NewEncoder(w)
+		encoder.SetIndent(2)
+		if err := encoder.Encode(configuration); err != nil {
+			return fmt.Errorf("encode YAML configuration: %w", err)
+		}
+		return encoder.Close()
+	case FormatJSON:
+		encoder := json.NewEncoder(w)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(configuration); err != nil {
+			return fmt.Errorf("encode JSON configuration: %w", err)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported format %q", format)
+	}
+}
+
+// WriteFile atomically writes a configuration with owner-only permissions.
+func WriteFile(filename string, configuration *Configuration, format Format) error {
+	var data bytes.Buffer
+	if err := Encode(&data, configuration, format); err != nil {
+		return err
+	}
+
+	directory := filepath.Dir(filename)
+	temporary, err := os.CreateTemp(directory, ".harbor-configuration-*")
+	if err != nil {
+		return fmt.Errorf("create temporary configuration: %w", err)
+	}
+	temporaryName := temporary.Name()
+	defer os.Remove(temporaryName)
+
+	if err := temporary.Chmod(0o600); err != nil {
+		temporary.Close()
+		return fmt.Errorf("secure temporary configuration: %w", err)
+	}
+	if _, err := temporary.Write(data.Bytes()); err != nil {
+		temporary.Close()
+		return fmt.Errorf("write temporary configuration: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close temporary configuration: %w", err)
+	}
+	if err := os.Rename(temporaryName, filename); err != nil {
+		return fmt.Errorf("replace configuration file: %w", err)
+	}
+	return nil
+}

--- a/pkg/declarative/codec_test.go
+++ b/pkg/declarative/codec_test.go
@@ -1,0 +1,83 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package declarative_test
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/goharbor/harbor-cli/pkg/declarative"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestYAMLRoundTrip(t *testing.T) {
+	public := true
+	document := declarative.NewConfiguration()
+	document.Spec.Projects = []declarative.Project{{Name: "zeta"}, {Name: "alpha", Public: &public}}
+
+	var output bytes.Buffer
+	require.NoError(t, declarative.Encode(&output, document, declarative.FormatYAML))
+
+	decoded, err := declarative.Decode(strings.NewReader(output.String()), declarative.FormatYAML)
+	require.NoError(t, err)
+	assert.Equal(t, "alpha", decoded.Spec.Projects[0].Name)
+	assert.Contains(t, output.String(), "apiVersion: goharbor.io/v1alpha1")
+}
+
+func TestDecodeRejectsUnknownFields(t *testing.T) {
+	document := `apiVersion: goharbor.io/v1alpha1
+kind: HarborConfiguration
+spec:
+  unknown: true
+`
+
+	_, err := declarative.Decode(strings.NewReader(document), declarative.FormatYAML)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "field unknown not found")
+}
+
+func TestDecodeRejectsMultipleDocuments(t *testing.T) {
+	document := `apiVersion: goharbor.io/v1alpha1
+kind: HarborConfiguration
+---
+apiVersion: goharbor.io/v1alpha1
+kind: HarborConfiguration
+`
+
+	_, err := declarative.Decode(strings.NewReader(document), declarative.FormatYAML)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "multiple documents")
+}
+
+func TestValidateRejectsDuplicateNames(t *testing.T) {
+	document := declarative.NewConfiguration()
+	document.Spec.Registries = []declarative.Registry{{Name: "docker-hub"}, {Name: "docker-hub"}}
+
+	err := document.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `duplicate registry "docker-hub"`)
+}
+
+func TestExampleConfigurationStaysValid(t *testing.T) {
+	filename := filepath.Join("..", "..", "examples", "declarative", "harbor.yaml")
+
+	document, err := declarative.ReadFile(filename)
+	require.NoError(t, err)
+	assert.Equal(t, declarative.APIVersion, document.APIVersion)
+	assert.NotEmpty(t, document.Spec.Projects)
+}

--- a/pkg/declarative/live.go
+++ b/pkg/declarative/live.go
@@ -1,0 +1,829 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package declarative
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"os"
+	"reflect"
+	"slices"
+	"strconv"
+	"strings"
+
+	v2client "github.com/goharbor/go-client/pkg/sdk/v2.0/client"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/configure"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/project"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/quota"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/registry"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/replication"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/webhook"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+)
+
+const exportPageSize int64 = 100
+
+// LiveBackend reconciles configuration through Harbor's v2 API.
+type LiveBackend struct {
+	client *v2client.HarborAPI
+
+	registries map[string]*models.Registry
+	projects   map[string]*models.Project
+	quotas     map[string]*models.Quota
+	webhooks   map[string]map[string]*models.WebhookPolicy
+	policies   map[string]*models.ReplicationPolicy
+}
+
+// NewLiveBackend creates a backend using the active Harbor CLI context.
+func NewLiveBackend() (*LiveBackend, error) {
+	client, err := utils.GetClient()
+	if err != nil {
+		return nil, err
+	}
+	return &LiveBackend{client: client}, nil
+}
+
+// Snapshot exports all supported API-managed resources and refreshes apply-time indexes.
+func (b *LiveBackend) Snapshot(ctx context.Context) (*Configuration, error) {
+	b.registries = make(map[string]*models.Registry)
+	b.projects = make(map[string]*models.Project)
+	b.quotas = make(map[string]*models.Quota)
+	b.webhooks = make(map[string]map[string]*models.WebhookPolicy)
+	b.policies = make(map[string]*models.ReplicationPolicy)
+
+	document := NewConfiguration()
+	configuration, err := b.client.Configure.GetConfigurations(ctx, &configure.GetConfigurationsParams{})
+	if err != nil {
+		return nil, fmt.Errorf("get system configuration: %w", err)
+	}
+	document.Spec.System = systemConfiguration(configuration.Payload)
+
+	registries, err := b.listRegistries(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range registries {
+		b.registries[item.Name] = item
+		document.Spec.Registries = append(document.Spec.Registries, registryFromModel(item))
+	}
+
+	quotas, err := b.listQuotas(ctx)
+	if err != nil {
+		return nil, err
+	}
+	quotaByProjectID := make(map[int64]*models.Quota, len(quotas))
+	for _, item := range quotas {
+		projectID, ok := quotaProjectID(item.Ref)
+		if ok {
+			quotaByProjectID[projectID] = item
+		}
+	}
+
+	projects, err := b.listProjects(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range projects {
+		b.projects[item.Name] = item
+		projectDocument := projectFromModel(item, b.registries)
+		if projectQuota := quotaByProjectID[int64(item.ProjectID)]; projectQuota != nil {
+			projectDocument.Quota = maps.Clone(projectQuota.Hard)
+			b.quotas[item.Name] = projectQuota
+		}
+
+		webhooks, listErr := b.client.Webhook.ListWebhookPoliciesOfProject(ctx, &webhook.ListWebhookPoliciesOfProjectParams{
+			ProjectNameOrID: item.Name,
+		})
+		if listErr != nil {
+			return nil, fmt.Errorf("list webhooks for project %q: %w", item.Name, listErr)
+		}
+		b.webhooks[item.Name] = make(map[string]*models.WebhookPolicy, len(webhooks.Payload))
+		for _, policy := range webhooks.Payload {
+			b.webhooks[item.Name][policy.Name] = policy
+			projectDocument.Webhooks = append(projectDocument.Webhooks, webhookFromModel(policy))
+		}
+		document.Spec.Projects = append(document.Spec.Projects, projectDocument)
+	}
+
+	policies, err := b.listReplicationPolicies(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range policies {
+		policy, conversionErr := replicationPolicyFromModel(item)
+		if conversionErr != nil {
+			return nil, conversionErr
+		}
+		b.policies[item.Name] = item
+		document.Spec.ReplicationPolicies = append(document.Spec.ReplicationPolicies, policy)
+	}
+
+	document.Normalize()
+	return document, nil
+}
+
+// Apply executes one planned action.
+func (b *LiveBackend) Apply(ctx context.Context, desired *Configuration, action Action) error {
+	switch action.Resource {
+	case resourceRegistry:
+		value, ok := findByName(desired.Spec.Registries, action.Name, func(item Registry) string { return item.Name })
+		if !ok {
+			return fmt.Errorf("registry %q is absent from desired state", action.Name)
+		}
+		return b.applyRegistry(ctx, value, action.Operation)
+	case resourceProject:
+		value, ok := findByName(desired.Spec.Projects, action.Name, func(item Project) string { return item.Name })
+		if !ok {
+			return fmt.Errorf("project %q is absent from desired state", action.Name)
+		}
+		return b.applyProject(ctx, value, action.Operation)
+	case resourceQuota:
+		value, ok := findByName(desired.Spec.Projects, action.Name, func(item Project) string { return item.Name })
+		if !ok {
+			return fmt.Errorf("project %q is absent from desired state", action.Name)
+		}
+		return b.applyQuota(ctx, value)
+	case resourceWebhook:
+		projectValue, ok := findByName(desired.Spec.Projects, action.Project, func(item Project) string { return item.Name })
+		if !ok {
+			return fmt.Errorf("project %q is absent from desired state", action.Project)
+		}
+		value, ok := findByName(projectValue.Webhooks, action.Name, func(item Webhook) string { return item.Name })
+		if !ok {
+			return fmt.Errorf("webhook %q is absent from project %q", action.Name, action.Project)
+		}
+		return b.applyWebhook(ctx, action.Project, value, action.Operation)
+	case resourceReplicationPolicy:
+		value, ok := findByName(desired.Spec.ReplicationPolicies, action.Name, func(item ReplicationPolicy) string { return item.Name })
+		if !ok {
+			return fmt.Errorf("replication policy %q is absent from desired state", action.Name)
+		}
+		return b.applyReplicationPolicy(ctx, value, action.Operation)
+	case resourceSystem:
+		return b.applySystem(ctx, desired.Spec.System)
+	default:
+		return fmt.Errorf("unsupported resource type %q", action.Resource)
+	}
+}
+
+func (b *LiveBackend) listRegistries(ctx context.Context) ([]*models.Registry, error) {
+	var result []*models.Registry
+	for page := int64(1); ; page++ {
+		response, err := b.client.Registry.ListRegistries(ctx, &registry.ListRegistriesParams{Page: &page, PageSize: ptr(exportPageSize)})
+		if err != nil {
+			return nil, fmt.Errorf("list registries: %w", err)
+		}
+		result = append(result, response.Payload...)
+		if len(response.Payload) < int(exportPageSize) {
+			return result, nil
+		}
+	}
+}
+
+func (b *LiveBackend) listProjects(ctx context.Context) ([]*models.Project, error) {
+	var result []*models.Project
+	for page := int64(1); ; page++ {
+		response, err := b.client.Project.ListProjects(ctx, &project.ListProjectsParams{Page: &page, PageSize: ptr(exportPageSize)})
+		if err != nil {
+			return nil, fmt.Errorf("list projects: %w", err)
+		}
+		result = append(result, response.Payload...)
+		if len(response.Payload) < int(exportPageSize) {
+			return result, nil
+		}
+	}
+}
+
+func (b *LiveBackend) listQuotas(ctx context.Context) ([]*models.Quota, error) {
+	var result []*models.Quota
+	for page := int64(1); ; page++ {
+		response, err := b.client.Quota.ListQuotas(ctx, &quota.ListQuotasParams{Page: &page, PageSize: ptr(exportPageSize)})
+		if err != nil {
+			return nil, fmt.Errorf("list quotas: %w", err)
+		}
+		result = append(result, response.Payload...)
+		if len(response.Payload) < int(exportPageSize) {
+			return result, nil
+		}
+	}
+}
+
+func (b *LiveBackend) listReplicationPolicies(ctx context.Context) ([]*models.ReplicationPolicy, error) {
+	var result []*models.ReplicationPolicy
+	for page := int64(1); ; page++ {
+		response, err := b.client.Replication.ListReplicationPolicies(ctx, &replication.ListReplicationPoliciesParams{Page: &page, PageSize: ptr(exportPageSize)})
+		if err != nil {
+			return nil, fmt.Errorf("list replication policies: %w", err)
+		}
+		result = append(result, response.Payload...)
+		if len(response.Payload) < int(exportPageSize) {
+			return result, nil
+		}
+	}
+}
+
+func (b *LiveBackend) applyRegistry(ctx context.Context, desired Registry, operation Operation) error {
+	var credential *models.RegistryCredential
+	if desired.Credential != nil {
+		var err error
+		credential, err = resolveRegistryCredential(desired.Credential)
+		if err != nil {
+			return err
+		}
+	}
+	if operation == OperationCreate {
+		if desired.Type == nil || desired.URL == nil {
+			return fmt.Errorf("creating registry %q requires type and url", desired.Name)
+		}
+		request := &models.Registry{Name: desired.Name, Type: *desired.Type, URL: *desired.URL, Credential: credential}
+		if desired.Description != nil {
+			request.Description = *desired.Description
+		}
+		if desired.Insecure != nil {
+			request.Insecure = *desired.Insecure
+		}
+		if _, err := b.client.Registry.CreateRegistry(ctx, &registry.CreateRegistryParams{Registry: request}); err != nil {
+			return err
+		}
+		return b.refreshRegistry(ctx, desired.Name)
+	}
+
+	current := b.registries[desired.Name]
+	if current == nil {
+		return fmt.Errorf("registry %q not found", desired.Name)
+	}
+	if desired.Type != nil && *desired.Type != current.Type {
+		return fmt.Errorf("registry %q type is immutable (current %q, desired %q)", desired.Name, current.Type, *desired.Type)
+	}
+	request := &models.RegistryUpdate{
+		Name:        &desired.Name,
+		Description: desired.Description,
+		URL:         desired.URL,
+		Insecure:    desired.Insecure,
+	}
+	if desired.Credential != nil {
+		if desired.Credential.Type != nil {
+			request.CredentialType = &credential.Type
+		}
+		if desired.Credential.AccessKeyFrom != nil {
+			request.AccessKey = &credential.AccessKey
+		}
+		if desired.Credential.AccessSecretFrom != nil {
+			request.AccessSecret = &credential.AccessSecret
+		}
+	}
+	_, err := b.client.Registry.UpdateRegistry(ctx, &registry.UpdateRegistryParams{ID: current.ID, Registry: request})
+	return err
+}
+
+func (b *LiveBackend) refreshRegistry(ctx context.Context, name string) error {
+	page := int64(1)
+	response, err := b.client.Registry.ListRegistries(ctx, &registry.ListRegistriesParams{Name: &name, Page: &page, PageSize: ptr(exportPageSize)})
+	if err != nil {
+		return fmt.Errorf("refresh registry %q: %w", name, err)
+	}
+	for _, item := range response.Payload {
+		if item.Name == name {
+			b.registries[name] = item
+			return nil
+		}
+	}
+	return fmt.Errorf("registry %q was created but could not be read back", name)
+}
+
+func (b *LiveBackend) applyProject(ctx context.Context, desired Project, operation Operation) error {
+	request, err := b.projectRequest(desired)
+	if err != nil {
+		return err
+	}
+	if operation == OperationCreate {
+		request.ProjectName = desired.Name
+		if desired.Quota != nil {
+			if storage, ok := desired.Quota["storage"]; ok {
+				request.StorageLimit = &storage
+			}
+		}
+		if _, err := b.client.Project.CreateProject(ctx, &project.CreateProjectParams{Project: request}); err != nil {
+			return err
+		}
+		return b.refreshProject(ctx, desired.Name)
+	}
+
+	resourceName := true
+	_, err = b.client.Project.UpdateProject(ctx, &project.UpdateProjectParams{
+		ProjectNameOrID: desired.Name,
+		XIsResourceName: &resourceName,
+		Project:         request,
+	})
+	return err
+}
+
+func (b *LiveBackend) projectRequest(desired Project) (*models.ProjectReq, error) {
+	request := &models.ProjectReq{Public: desired.Public}
+	current := b.projects[desired.Name]
+	request.Metadata = metadataToModel(desired.Metadata, metadataOf(current))
+	if desired.Public != nil {
+		if request.Metadata == nil {
+			request.Metadata = metadataToModel(&ProjectMetadata{}, metadataOf(current))
+		}
+		request.Metadata.Public = strconv.FormatBool(*desired.Public)
+	}
+	if desired.Registry != nil {
+		registryModel := b.registries[*desired.Registry]
+		if registryModel == nil {
+			return nil, fmt.Errorf("project %q references unknown registry %q", desired.Name, *desired.Registry)
+		}
+		request.RegistryID = &registryModel.ID
+	}
+	return request, nil
+}
+
+func (b *LiveBackend) refreshProject(ctx context.Context, name string) error {
+	resourceName := true
+	response, err := b.client.Project.GetProject(ctx, &project.GetProjectParams{ProjectNameOrID: name, XIsResourceName: &resourceName})
+	if err != nil {
+		return fmt.Errorf("refresh project %q: %w", name, err)
+	}
+	b.projects[name] = response.Payload
+	return nil
+}
+
+func (b *LiveBackend) applyQuota(ctx context.Context, desired Project) error {
+	quotaModel := b.quotas[desired.Name]
+	if quotaModel == nil {
+		if err := b.refreshQuota(ctx, desired.Name); err != nil {
+			return err
+		}
+		quotaModel = b.quotas[desired.Name]
+	}
+	_, err := b.client.Quota.UpdateQuota(ctx, &quota.UpdateQuotaParams{
+		ID:   quotaModel.ID,
+		Hard: &models.QuotaUpdateReq{Hard: maps.Clone(desired.Quota)},
+	})
+	return err
+}
+
+func (b *LiveBackend) refreshQuota(ctx context.Context, projectName string) error {
+	projectModel := b.projects[projectName]
+	if projectModel == nil {
+		if err := b.refreshProject(ctx, projectName); err != nil {
+			return err
+		}
+		projectModel = b.projects[projectName]
+	}
+	quotas, err := b.listQuotas(ctx)
+	if err != nil {
+		return err
+	}
+	for _, item := range quotas {
+		projectID, ok := quotaProjectID(item.Ref)
+		if ok && projectID == int64(projectModel.ProjectID) {
+			b.quotas[projectName] = item
+			return nil
+		}
+	}
+	return fmt.Errorf("quota for project %q not found", projectName)
+}
+
+func (b *LiveBackend) applyWebhook(ctx context.Context, projectName string, desired Webhook, operation Operation) error {
+	current := b.webhooks[projectName][desired.Name]
+	policy, err := webhookToModel(desired, current)
+	if err != nil {
+		return err
+	}
+	if operation == OperationCreate {
+		_, err = b.client.Webhook.CreateWebhookPolicyOfProject(ctx, &webhook.CreateWebhookPolicyOfProjectParams{
+			ProjectNameOrID: projectName,
+			Policy:          policy,
+		})
+		return err
+	}
+	if current == nil {
+		return fmt.Errorf("webhook %q not found in project %q", desired.Name, projectName)
+	}
+	_, err = b.client.Webhook.UpdateWebhookPolicyOfProject(ctx, &webhook.UpdateWebhookPolicyOfProjectParams{
+		ProjectNameOrID: projectName,
+		WebhookPolicyID: current.ID,
+		Policy:          policy,
+	})
+	return err
+}
+
+func (b *LiveBackend) applyReplicationPolicy(ctx context.Context, desired ReplicationPolicy, operation Operation) error {
+	current := b.policies[desired.Name]
+	policy, err := b.replicationPolicyToModel(desired, current)
+	if err != nil {
+		return err
+	}
+	if operation == OperationCreate {
+		_, err = b.client.Replication.CreateReplicationPolicy(ctx, &replication.CreateReplicationPolicyParams{Policy: policy})
+		return err
+	}
+	if current == nil {
+		return fmt.Errorf("replication policy %q not found", desired.Name)
+	}
+	_, err = b.client.Replication.UpdateReplicationPolicy(ctx, &replication.UpdateReplicationPolicyParams{ID: current.ID, Policy: policy})
+	return err
+}
+
+func (b *LiveBackend) replicationPolicyToModel(desired ReplicationPolicy, current *models.ReplicationPolicy) (*models.ReplicationPolicy, error) {
+	policy := &models.ReplicationPolicy{Name: desired.Name}
+	if current != nil {
+		*policy = *current
+	}
+	policy.Name = desired.Name
+	registryModel := b.registries[desired.Registry]
+	if registryModel == nil {
+		return nil, fmt.Errorf("replication policy %q references unknown registry %q", desired.Name, desired.Registry)
+	}
+	if desired.Mode == "pull" {
+		policy.SrcRegistry = registryModel
+		policy.DestRegistry = nil
+	} else {
+		policy.SrcRegistry = nil
+		policy.DestRegistry = registryModel
+	}
+	assign(desired.Description, &policy.Description)
+	assign(desired.Enabled, &policy.Enabled)
+	assign(desired.DestinationNamespace, &policy.DestNamespace)
+	if desired.DestinationReplaceCount != nil {
+		policy.DestNamespaceReplaceCount = desired.DestinationReplaceCount
+	}
+	assign(desired.Override, &policy.Override)
+	if desired.ReplicateDeletion != nil {
+		policy.ReplicateDeletion = *desired.ReplicateDeletion
+		policy.Deletion = *desired.ReplicateDeletion
+	}
+	if desired.CopyByChunk != nil {
+		policy.CopyByChunk = desired.CopyByChunk
+	}
+	if desired.Speed != nil {
+		policy.Speed = desired.Speed
+	}
+	if desired.Filters != nil {
+		policy.Filters = make([]*models.ReplicationFilter, 0, len(desired.Filters))
+		for _, filter := range desired.Filters {
+			policy.Filters = append(policy.Filters, &models.ReplicationFilter{Type: filter.Type, Value: filter.Value, Decoration: filter.Decoration})
+		}
+	}
+	if desired.Trigger != nil {
+		policy.Trigger = &models.ReplicationTrigger{Type: desired.Trigger.Type}
+		if desired.Trigger.Cron != "" {
+			policy.Trigger.TriggerSettings = &models.ReplicationTriggerSettings{Cron: desired.Trigger.Cron}
+		}
+	}
+	return policy, nil
+}
+
+func (b *LiveBackend) applySystem(ctx context.Context, desired map[string]any) error {
+	encoded, err := json.Marshal(desired)
+	if err != nil {
+		return fmt.Errorf("encode system configuration: %w", err)
+	}
+	var configuration models.Configurations
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&configuration); err != nil {
+		return fmt.Errorf("decode system configuration: %w", err)
+	}
+	_, err = b.client.Configure.UpdateConfigurations(ctx, &configure.UpdateConfigurationsParams{Configurations: &configuration})
+	return err
+}
+
+func systemConfiguration(response *models.ConfigurationsResponse) map[string]any {
+	result := make(map[string]any)
+	if response == nil {
+		return result
+	}
+	value := reflect.ValueOf(response).Elem()
+	typeInfo := value.Type()
+	for i := range value.NumField() {
+		field := value.Field(i)
+		if field.Kind() != reflect.Pointer || field.IsNil() {
+			continue
+		}
+		jsonName := strings.Split(typeInfo.Field(i).Tag.Get("json"), ",")[0]
+		if jsonName == "" || jsonName == "-" || isSecretSystemField(jsonName) {
+			continue
+		}
+		item := field.Elem()
+		valueField := item.FieldByName("Value")
+		if valueField.IsValid() && valueField.CanInterface() {
+			result[jsonName] = valueField.Interface()
+		}
+	}
+	return result
+}
+
+func isSecretSystemField(name string) bool {
+	switch name {
+	case "ldap_search_password", "oidc_client_secret", "uaa_client_secret":
+		return true
+	default:
+		return false
+	}
+}
+
+func registryFromModel(value *models.Registry) Registry {
+	return Registry{
+		Name:        value.Name,
+		Type:        ptr(value.Type),
+		URL:         ptr(value.URL),
+		Description: ptr(value.Description),
+		Insecure:    ptr(value.Insecure),
+	}
+}
+
+func projectFromModel(value *models.Project, registries map[string]*models.Registry) Project {
+	result := Project{Name: value.Name, Metadata: metadataFromModel(value.Metadata)}
+	if value.Metadata != nil {
+		result.Public = parseBool(value.Metadata.Public)
+	}
+	if result.Public == nil {
+		result.Public = ptr(false)
+	}
+	if value.RegistryID != 0 {
+		for name, registryModel := range registries {
+			if registryModel.ID == value.RegistryID {
+				result.Registry = &name
+				break
+			}
+		}
+	}
+	return result
+}
+
+func metadataFromModel(value *models.ProjectMetadata) *ProjectMetadata {
+	if value == nil {
+		return nil
+	}
+	return &ProjectMetadata{
+		AutoScan:                 parseBoolPointer(value.AutoScan),
+		AutoSBOMGeneration:       parseBoolPointer(value.AutoSbomGeneration),
+		EnableContentTrust:       parseBoolPointer(value.EnableContentTrust),
+		EnableContentTrustCosign: parseBoolPointer(value.EnableContentTrustCosign),
+		PreventVulnerableImages:  parseBoolPointer(value.PreventVul),
+		ProxySpeedKB:             parseIntPointer(value.ProxySpeedKb),
+		ReuseSystemCVEAllowlist:  parseBoolPointer(value.ReuseSysCVEAllowlist),
+		Severity:                 clonePointer(value.Severity),
+	}
+}
+
+func metadataToModel(desired *ProjectMetadata, current *models.ProjectMetadata) *models.ProjectMetadata {
+	if desired == nil {
+		return nil
+	}
+	result := &models.ProjectMetadata{}
+	if current != nil {
+		*result = *current
+	}
+	assignBoolString(desired.AutoScan, &result.AutoScan)
+	assignBoolString(desired.AutoSBOMGeneration, &result.AutoSbomGeneration)
+	assignBoolString(desired.EnableContentTrust, &result.EnableContentTrust)
+	assignBoolString(desired.EnableContentTrustCosign, &result.EnableContentTrustCosign)
+	assignBoolString(desired.PreventVulnerableImages, &result.PreventVul)
+	assignIntString(desired.ProxySpeedKB, &result.ProxySpeedKb)
+	assignBoolString(desired.ReuseSystemCVEAllowlist, &result.ReuseSysCVEAllowlist)
+	if desired.Severity != nil {
+		result.Severity = desired.Severity
+	}
+	return result
+}
+
+func metadataOf(projectModel *models.Project) *models.ProjectMetadata {
+	if projectModel == nil {
+		return nil
+	}
+	return projectModel.Metadata
+}
+
+func webhookFromModel(value *models.WebhookPolicy) Webhook {
+	result := Webhook{
+		Name:        value.Name,
+		Description: ptr(value.Description),
+		Enabled:     ptr(value.Enabled),
+		Events:      slices.Clone(value.EventTypes),
+	}
+	for _, target := range value.Targets {
+		if target == nil {
+			continue
+		}
+		result.Targets = append(result.Targets, WebhookTarget{
+			NotifyType:              ptr(target.Type),
+			Endpoint:                ptr(target.Address),
+			PayloadFormat:           ptr(string(target.PayloadFormat)),
+			VerifyRemoteCertificate: ptr(!target.SkipCertVerify),
+		})
+	}
+	return result
+}
+
+func webhookToModel(desired Webhook, current *models.WebhookPolicy) (*models.WebhookPolicy, error) {
+	policy := &models.WebhookPolicy{Name: desired.Name, Enabled: true}
+	if current != nil {
+		*policy = *current
+	}
+	policy.Name = desired.Name
+	assign(desired.Description, &policy.Description)
+	assign(desired.Enabled, &policy.Enabled)
+	if desired.Events != nil {
+		policy.EventTypes = slices.Clone(desired.Events)
+	}
+	if desired.Targets == nil {
+		if current == nil {
+			return nil, fmt.Errorf("creating webhook %q requires at least one target", desired.Name)
+		}
+		return policy, nil
+	}
+	if len(desired.Targets) == 0 {
+		return nil, fmt.Errorf("webhook %q requires at least one target", desired.Name)
+	}
+	policy.Targets = make([]*models.WebhookTargetObject, 0, len(desired.Targets))
+	for i, desiredTarget := range desired.Targets {
+		target := &models.WebhookTargetObject{}
+		assign(desiredTarget.NotifyType, &target.Type)
+		assign(desiredTarget.Endpoint, &target.Address)
+		if desiredTarget.PayloadFormat != nil {
+			target.PayloadFormat = models.PayloadFormatType(*desiredTarget.PayloadFormat)
+		}
+		if desiredTarget.VerifyRemoteCertificate != nil {
+			target.SkipCertVerify = !*desiredTarget.VerifyRemoteCertificate
+		}
+		if desiredTarget.AuthHeaderFrom != nil {
+			value, err := resolveSecret(desiredTarget.AuthHeaderFrom)
+			if err != nil {
+				return nil, fmt.Errorf("resolve webhook target %d auth header: %w", i, err)
+			}
+			target.AuthHeader = value
+		}
+		if target.Type == "" || target.Address == "" {
+			return nil, fmt.Errorf("webhook %q target %d requires notifyType and endpoint", desired.Name, i)
+		}
+		policy.Targets = append(policy.Targets, target)
+	}
+	return policy, nil
+}
+
+func replicationPolicyFromModel(value *models.ReplicationPolicy) (ReplicationPolicy, error) {
+	result := ReplicationPolicy{
+		Name:                    value.Name,
+		Description:             ptr(value.Description),
+		Enabled:                 ptr(value.Enabled),
+		DestinationNamespace:    ptr(value.DestNamespace),
+		DestinationReplaceCount: clonePointer(value.DestNamespaceReplaceCount),
+		Override:                ptr(value.Override),
+		ReplicateDeletion:       ptr(value.ReplicateDeletion),
+		CopyByChunk:             clonePointer(value.CopyByChunk),
+		Speed:                   clonePointer(value.Speed),
+	}
+	registryModel := value.DestRegistry
+	result.Mode = "push"
+	if value.SrcRegistry != nil {
+		result.Mode = "pull"
+		registryModel = value.SrcRegistry
+	}
+	if registryModel == nil || registryModel.Name == "" {
+		return ReplicationPolicy{}, fmt.Errorf("replication policy %q has no external registry", value.Name)
+	}
+	result.Registry = registryModel.Name
+	for _, filter := range value.Filters {
+		result.Filters = append(result.Filters, ReplicationFilter{
+			Type:       filter.Type,
+			Value:      fmt.Sprint(filter.Value),
+			Decoration: filter.Decoration,
+		})
+	}
+	if value.Trigger != nil {
+		result.Trigger = &ReplicationTrigger{Type: value.Trigger.Type}
+		if value.Trigger.TriggerSettings != nil {
+			result.Trigger.Cron = value.Trigger.TriggerSettings.Cron
+		}
+	}
+	return result, nil
+}
+
+func resolveRegistryCredential(value *RegistryCredential) (*models.RegistryCredential, error) {
+	result := &models.RegistryCredential{}
+	if value.Type != nil {
+		result.Type = *value.Type
+	}
+	var err error
+	if value.AccessKeyFrom != nil {
+		result.AccessKey, err = resolveSecret(value.AccessKeyFrom)
+		if err != nil {
+			return nil, fmt.Errorf("resolve registry access key: %w", err)
+		}
+	}
+	if value.AccessSecretFrom != nil {
+		result.AccessSecret, err = resolveSecret(value.AccessSecretFrom)
+		if err != nil {
+			return nil, fmt.Errorf("resolve registry access secret: %w", err)
+		}
+	}
+	return result, nil
+}
+
+func resolveSecret(ref *SecretRef) (string, error) {
+	value, ok := os.LookupEnv(ref.Env)
+	if !ok {
+		return "", fmt.Errorf("environment variable %q is not set", ref.Env)
+	}
+	return value, nil
+}
+
+func quotaProjectID(ref any) (int64, bool) {
+	encoded, err := json.Marshal(ref)
+	if err != nil {
+		return 0, false
+	}
+	var value struct {
+		ID int64 `json:"id"`
+	}
+	if json.Unmarshal(encoded, &value) != nil || value.ID == 0 {
+		return 0, false
+	}
+	return value.ID, true
+}
+
+func parseBoolPointer(value *string) *bool {
+	if value == nil {
+		return nil
+	}
+	return parseBool(*value)
+}
+
+func parseBool(value string) *bool {
+	parsed, err := strconv.ParseBool(value)
+	if err != nil {
+		return nil
+	}
+	return &parsed
+}
+
+func parseIntPointer(value *string) *int64 {
+	if value == nil {
+		return nil
+	}
+	parsed, err := strconv.ParseInt(*value, 10, 64)
+	if err != nil {
+		return nil
+	}
+	return &parsed
+}
+
+func assignBoolString(source *bool, destination **string) {
+	if source != nil {
+		value := strconv.FormatBool(*source)
+		*destination = &value
+	}
+}
+
+func assignIntString(source *int64, destination **string) {
+	if source != nil {
+		value := strconv.FormatInt(*source, 10)
+		*destination = &value
+	}
+}
+
+func assign[T any](source *T, destination *T) {
+	if source != nil {
+		*destination = *source
+	}
+}
+
+func clonePointer[T any](value *T) *T {
+	if value == nil {
+		return nil
+	}
+	return ptr(*value)
+}
+
+func findByName[T any](values []T, name string, key func(T) string) (T, bool) {
+	for _, value := range values {
+		if key(value) == name {
+			return value, true
+		}
+	}
+	var zero T
+	return zero, false
+}
+
+func ptr[T any](value T) *T {
+	return &value
+}

--- a/pkg/declarative/live_test.go
+++ b/pkg/declarative/live_test.go
@@ -1,0 +1,126 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package declarative
+
+import (
+	"testing"
+
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExportConversionsOmitSecretsAndObservedState(t *testing.T) {
+	registryModel := &models.Registry{
+		ID:   42,
+		Name: "hub",
+		Type: "docker-hub",
+		URL:  "https://hub.docker.com",
+		Credential: &models.RegistryCredential{
+			AccessKey:    "user",
+			AccessSecret: "secret",
+			Type:         "basic",
+		},
+	}
+	webhookModel := &models.WebhookPolicy{
+		ID:         7,
+		Name:       "notify",
+		Enabled:    true,
+		EventTypes: []string{"PUSH_ARTIFACT"},
+		Targets: []*models.WebhookTargetObject{
+			{Address: "https://example.com", AuthHeader: "secret", SkipCertVerify: true, Type: "http"},
+		},
+	}
+
+	exportedRegistry := registryFromModel(registryModel)
+	exportedWebhook := webhookFromModel(webhookModel)
+
+	assert.Nil(t, exportedRegistry.Credential)
+	require.Len(t, exportedWebhook.Targets, 1)
+	assert.Nil(t, exportedWebhook.Targets[0].AuthHeaderFrom)
+	require.NotNil(t, exportedWebhook.Targets[0].VerifyRemoteCertificate)
+	assert.False(t, *exportedWebhook.Targets[0].VerifyRemoteCertificate)
+}
+
+func TestSystemConfigurationUsesAPINamesAndValues(t *testing.T) {
+	response := &models.ConfigurationsResponse{
+		ReadOnly:                   &models.BoolConfigItem{Value: true},
+		ProjectCreationRestriction: &models.StringConfigItem{Value: "adminonly"},
+	}
+
+	configuration := systemConfiguration(response)
+
+	assert.Equal(t, true, configuration["read_only"])
+	assert.Equal(t, "adminonly", configuration["project_creation_restriction"])
+	assert.NotContains(t, configuration, "ReadOnly")
+}
+
+func TestWebhookSecretReferenceIsResolvedOnlyForApply(t *testing.T) {
+	t.Setenv("HARBOR_WEBHOOK_AUTH", "Bearer token")
+	desired := Webhook{
+		Name: "notify",
+		Targets: []WebhookTarget{{
+			NotifyType:     ptr("http"),
+			Endpoint:       ptr("https://example.com"),
+			AuthHeaderFrom: &SecretRef{Env: "HARBOR_WEBHOOK_AUTH"},
+		}},
+	}
+
+	policy, err := webhookToModel(desired, nil)
+	require.NoError(t, err)
+	require.Len(t, policy.Targets, 1)
+	assert.Equal(t, "Bearer token", policy.Targets[0].AuthHeader)
+}
+
+func TestWebhookConversionPreservesAllTargets(t *testing.T) {
+	model := &models.WebhookPolicy{Targets: []*models.WebhookTargetObject{
+		{Type: "http", Address: "https://one.example.com"},
+		{Type: "http", Address: "https://two.example.com"},
+	}}
+
+	exported := webhookFromModel(model)
+	require.Len(t, exported.Targets, 2)
+
+	roundTrip, err := webhookToModel(exported, nil)
+	require.NoError(t, err)
+	require.Len(t, roundTrip.Targets, 2)
+	assert.Equal(t, "https://one.example.com", roundTrip.Targets[0].Address)
+	assert.Equal(t, "https://two.example.com", roundTrip.Targets[1].Address)
+}
+
+func TestWebhookCreateRequiresTarget(t *testing.T) {
+	_, err := webhookToModel(Webhook{Name: "notify"}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires at least one target")
+}
+
+func TestProjectRequestWritesPublicMetadata(t *testing.T) {
+	backend := &LiveBackend{projects: map[string]*models.Project{
+		"demo": {Metadata: &models.ProjectMetadata{AutoScan: ptr("true")}},
+	}}
+
+	request, err := backend.projectRequest(Project{Name: "demo", Public: ptr(false)})
+	require.NoError(t, err)
+	require.NotNil(t, request.Metadata)
+	assert.Equal(t, "false", request.Metadata.Public)
+	require.NotNil(t, request.Metadata.AutoScan)
+	assert.Equal(t, "true", *request.Metadata.AutoScan)
+}
+
+func TestQuotaProjectIDSupportsDecodedAPIReference(t *testing.T) {
+	id, ok := quotaProjectID(map[string]any{"id": float64(23), "name": "demo"})
+	assert.True(t, ok)
+	assert.Equal(t, int64(23), id)
+}

--- a/pkg/declarative/merge.go
+++ b/pkg/declarative/merge.go
@@ -1,0 +1,181 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package declarative
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"slices"
+)
+
+// Merge overlays configurations from left to right. Maps merge by key, named
+// resources merge by name, and later explicitly specified fields take precedence.
+func Merge(configurations ...*Configuration) (*Configuration, error) {
+	result := NewConfiguration()
+	for _, configuration := range configurations {
+		if err := configuration.validate(false); err != nil {
+			return nil, err
+		}
+		cloned, err := cloneConfiguration(configuration)
+		if err != nil {
+			return nil, err
+		}
+		mergeSpec(&result.Spec, cloned.Spec)
+	}
+	if err := result.Validate(); err != nil {
+		return nil, err
+	}
+	result.Normalize()
+	return result, nil
+}
+
+func cloneConfiguration(configuration *Configuration) (*Configuration, error) {
+	encoded, err := json.Marshal(configuration)
+	if err != nil {
+		return nil, fmt.Errorf("clone configuration: %w", err)
+	}
+	var result Configuration
+	if err := json.Unmarshal(encoded, &result); err != nil {
+		return nil, fmt.Errorf("clone configuration: %w", err)
+	}
+	return &result, nil
+}
+
+func mergeSpec(destination *Spec, source Spec) {
+	destination.System = mergeMap(destination.System, source.System)
+	destination.Registries = mergeNamed(destination.Registries, source.Registries, func(value Registry) string { return value.Name }, mergeRegistry)
+	destination.Projects = mergeNamed(destination.Projects, source.Projects, func(value Project) string { return value.Name }, mergeProject)
+	destination.ReplicationPolicies = mergeNamed(
+		destination.ReplicationPolicies,
+		source.ReplicationPolicies,
+		func(value ReplicationPolicy) string { return value.Name },
+		mergeReplicationPolicy,
+	)
+}
+
+func mergeNamed[T any](destination, source []T, name func(T) string, merge func(T, T) T) []T {
+	indexes := make(map[string]int, len(destination))
+	for i, value := range destination {
+		indexes[name(value)] = i
+	}
+	for _, value := range source {
+		index, exists := indexes[name(value)]
+		if !exists {
+			indexes[name(value)] = len(destination)
+			destination = append(destination, value)
+			continue
+		}
+		destination[index] = merge(destination[index], value)
+	}
+	return destination
+}
+
+func mergeRegistry(base, overlay Registry) Registry {
+	base.Type = prefer(overlay.Type, base.Type)
+	base.URL = prefer(overlay.URL, base.URL)
+	base.Description = prefer(overlay.Description, base.Description)
+	base.Insecure = prefer(overlay.Insecure, base.Insecure)
+	if overlay.Credential != nil {
+		if base.Credential == nil {
+			base.Credential = &RegistryCredential{}
+		}
+		base.Credential.Type = prefer(overlay.Credential.Type, base.Credential.Type)
+		base.Credential.AccessKeyFrom = prefer(overlay.Credential.AccessKeyFrom, base.Credential.AccessKeyFrom)
+		base.Credential.AccessSecretFrom = prefer(overlay.Credential.AccessSecretFrom, base.Credential.AccessSecretFrom)
+	}
+	return base
+}
+
+func mergeProject(base, overlay Project) Project {
+	base.Public = prefer(overlay.Public, base.Public)
+	base.Registry = prefer(overlay.Registry, base.Registry)
+	base.Metadata = mergeProjectMetadata(base.Metadata, overlay.Metadata)
+	base.Quota = mergeMap(base.Quota, overlay.Quota)
+	base.Webhooks = mergeNamed(base.Webhooks, overlay.Webhooks, func(value Webhook) string { return value.Name }, mergeWebhook)
+	return base
+}
+
+func mergeProjectMetadata(base, overlay *ProjectMetadata) *ProjectMetadata {
+	if overlay == nil {
+		return base
+	}
+	if base == nil {
+		base = &ProjectMetadata{}
+	}
+	base.AutoScan = prefer(overlay.AutoScan, base.AutoScan)
+	base.AutoSBOMGeneration = prefer(overlay.AutoSBOMGeneration, base.AutoSBOMGeneration)
+	base.EnableContentTrust = prefer(overlay.EnableContentTrust, base.EnableContentTrust)
+	base.EnableContentTrustCosign = prefer(overlay.EnableContentTrustCosign, base.EnableContentTrustCosign)
+	base.PreventVulnerableImages = prefer(overlay.PreventVulnerableImages, base.PreventVulnerableImages)
+	base.ProxySpeedKB = prefer(overlay.ProxySpeedKB, base.ProxySpeedKB)
+	base.ReuseSystemCVEAllowlist = prefer(overlay.ReuseSystemCVEAllowlist, base.ReuseSystemCVEAllowlist)
+	base.Severity = prefer(overlay.Severity, base.Severity)
+	return base
+}
+
+func mergeWebhook(base, overlay Webhook) Webhook {
+	base.Description = prefer(overlay.Description, base.Description)
+	base.Enabled = prefer(overlay.Enabled, base.Enabled)
+	if overlay.Events != nil {
+		base.Events = slices.Clone(overlay.Events)
+	}
+	if overlay.Targets != nil {
+		base.Targets = slices.Clone(overlay.Targets)
+	}
+	return base
+}
+
+func mergeReplicationPolicy(base, overlay ReplicationPolicy) ReplicationPolicy {
+	base.Description = prefer(overlay.Description, base.Description)
+	base.Enabled = prefer(overlay.Enabled, base.Enabled)
+	if overlay.Mode != "" {
+		base.Mode = overlay.Mode
+	}
+	if overlay.Registry != "" {
+		base.Registry = overlay.Registry
+	}
+	base.DestinationNamespace = prefer(overlay.DestinationNamespace, base.DestinationNamespace)
+	base.DestinationReplaceCount = prefer(overlay.DestinationReplaceCount, base.DestinationReplaceCount)
+	base.Override = prefer(overlay.Override, base.Override)
+	base.ReplicateDeletion = prefer(overlay.ReplicateDeletion, base.ReplicateDeletion)
+	base.CopyByChunk = prefer(overlay.CopyByChunk, base.CopyByChunk)
+	base.Speed = prefer(overlay.Speed, base.Speed)
+	if overlay.Filters != nil {
+		base.Filters = slices.Clone(overlay.Filters)
+	}
+	if overlay.Trigger != nil {
+		base.Trigger = overlay.Trigger
+	}
+	return base
+}
+
+func mergeMap[M ~map[K]V, K comparable, V any](destination, source M) M {
+	if source == nil {
+		return destination
+	}
+	if destination == nil {
+		return maps.Clone(source)
+	}
+	maps.Copy(destination, source)
+	return destination
+}
+
+func prefer[T any](preferred, fallback *T) *T {
+	if preferred != nil {
+		return preferred
+	}
+	return fallback
+}

--- a/pkg/declarative/merge_test.go
+++ b/pkg/declarative/merge_test.go
@@ -1,0 +1,130 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package declarative_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/goharbor/harbor-cli/pkg/declarative"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeOverlaysNamedResourcesAndSpecifiedFields(t *testing.T) {
+	autoScan := true
+	enabled := true
+	base := declarative.NewConfiguration()
+	base.Spec.System = map[string]any{"read_only": false, "self_registration": true}
+	base.Spec.Projects = []declarative.Project{{
+		Name:     "application",
+		Metadata: &declarative.ProjectMetadata{AutoScan: &autoScan},
+		Quota:    map[string]int64{"storage": 100, "count": -1},
+	}}
+	base.Spec.ReplicationPolicies = []declarative.ReplicationPolicy{{
+		Name: "mirror", Mode: "push", Registry: "hub",
+		Trigger: &declarative.ReplicationTrigger{Type: "scheduled", Cron: "0 0 * * * *"},
+	}}
+
+	overlay := declarative.NewConfiguration()
+	overlay.Spec.System = map[string]any{"read_only": true}
+	overlay.Spec.Projects = []declarative.Project{{
+		Name:     "application",
+		Metadata: &declarative.ProjectMetadata{Severity: ptr("critical")},
+		Quota:    map[string]int64{"storage": 500},
+	}}
+	overlay.Spec.ReplicationPolicies = []declarative.ReplicationPolicy{{
+		Name: "mirror", Enabled: &enabled,
+		Trigger: &declarative.ReplicationTrigger{Type: "manual"},
+	}}
+
+	merged, err := declarative.Merge(base, overlay)
+	require.NoError(t, err)
+
+	assert.Equal(t, true, merged.Spec.System["read_only"])
+	assert.Equal(t, true, merged.Spec.System["self_registration"])
+	require.Len(t, merged.Spec.Projects, 1)
+	assert.Equal(t, int64(500), merged.Spec.Projects[0].Quota["storage"])
+	assert.Equal(t, int64(-1), merged.Spec.Projects[0].Quota["count"])
+	assert.Equal(t, &autoScan, merged.Spec.Projects[0].Metadata.AutoScan)
+	assert.Equal(t, "critical", *merged.Spec.Projects[0].Metadata.Severity)
+	require.Len(t, merged.Spec.ReplicationPolicies, 1)
+	assert.Equal(t, "push", merged.Spec.ReplicationPolicies[0].Mode)
+	assert.Equal(t, "hub", merged.Spec.ReplicationPolicies[0].Registry)
+	assert.Equal(t, &enabled, merged.Spec.ReplicationPolicies[0].Enabled)
+	assert.Equal(t, "manual", merged.Spec.ReplicationPolicies[0].Trigger.Type)
+	assert.Empty(t, merged.Spec.ReplicationPolicies[0].Trigger.Cron)
+	assert.Equal(t, int64(100), base.Spec.Projects[0].Quota["storage"], "merge must not mutate its inputs")
+}
+
+func TestReadPathRecursivelyAppliesFilesInLexicalOrder(t *testing.T) {
+	directory := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(directory, "projects"), 0o755))
+	require.NoError(t, os.Mkdir(filepath.Join(directory, ".ignored"), 0o755))
+	writeTestFile(t, filepath.Join(directory, "00-base.yaml"), `apiVersion: goharbor.io/v1alpha1
+kind: HarborConfiguration
+spec:
+  projects:
+    - name: application
+      public: false
+      quota:
+        storage: 100
+  replicationPolicies:
+    - name: mirror
+      mode: push
+      registry: hub
+`)
+	writeTestFile(t, filepath.Join(directory, "10-production.yaml"), `apiVersion: goharbor.io/v1alpha1
+kind: HarborConfiguration
+spec:
+  projects:
+    - name: application
+      quota:
+        storage: 500
+  replicationPolicies:
+    - name: mirror
+      enabled: true
+`)
+	writeTestFile(t, filepath.Join(directory, "projects", "20-metadata.json"), `{
+  "apiVersion": "goharbor.io/v1alpha1",
+  "kind": "HarborConfiguration",
+  "spec": {"projects": [{"name": "application", "metadata": {"severity": "critical"}}]}
+}`)
+	writeTestFile(t, filepath.Join(directory, "README.md"), "not configuration")
+	writeTestFile(t, filepath.Join(directory, ".ignored", "invalid.yaml"), "not: a configuration")
+
+	configuration, err := declarative.ReadPath(directory)
+	require.NoError(t, err)
+
+	require.Len(t, configuration.Spec.Projects, 1)
+	project := configuration.Spec.Projects[0]
+	assert.Equal(t, int64(500), project.Quota["storage"])
+	assert.Equal(t, "critical", *project.Metadata.Severity)
+	require.Len(t, configuration.Spec.ReplicationPolicies, 1)
+	assert.Equal(t, "push", configuration.Spec.ReplicationPolicies[0].Mode)
+	assert.True(t, *configuration.Spec.ReplicationPolicies[0].Enabled)
+}
+
+func TestReadPathRejectsEmptyDirectory(t *testing.T) {
+	_, err := declarative.ReadPath(t.TempDir())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "contains no YAML or JSON files")
+}
+
+func writeTestFile(t *testing.T, filename, contents string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filename, []byte(contents), 0o600))
+}

--- a/pkg/declarative/plan.go
+++ b/pkg/declarative/plan.go
@@ -1,0 +1,285 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package declarative
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"slices"
+)
+
+// Operation is the reconciliation operation for a resource.
+type Operation string
+
+const (
+	// OperationCreate creates a missing resource.
+	OperationCreate Operation = "create"
+	// OperationUpdate updates a resource whose managed fields differ.
+	OperationUpdate Operation = "update"
+	// OperationNoop leaves an already-converged resource unchanged.
+	OperationNoop Operation = "no-op"
+)
+
+const (
+	resourceSystem            = "system configuration"
+	resourceRegistry          = "registry"
+	resourceProject           = "project"
+	resourceQuota             = "quota"
+	resourceWebhook           = "webhook"
+	resourceReplicationPolicy = "replication policy"
+)
+
+// Action is one ordered reconciliation step.
+type Action struct {
+	Operation Operation
+	Resource  string
+	Name      string
+	Project   string
+}
+
+// String returns a human-readable plan line.
+func (a Action) String() string {
+	identity := a.Name
+	if a.Project != "" {
+		identity = a.Project + "/" + a.Name
+	}
+	if identity == "" {
+		return fmt.Sprintf("%s %s", a.Operation, a.Resource)
+	}
+	return fmt.Sprintf("%s %s %s", a.Operation, a.Resource, identity)
+}
+
+// Plan is an ordered set of reconciliation actions.
+type Plan struct {
+	Actions []Action
+}
+
+// HasChanges reports whether applying the plan would mutate Harbor.
+func (p Plan) HasChanges() bool {
+	return slices.ContainsFunc(p.Actions, func(action Action) bool { return action.Operation != OperationNoop })
+}
+
+// ChangeCount returns the number of mutating actions.
+func (p Plan) ChangeCount() int {
+	count := 0
+	for _, action := range p.Actions {
+		if action.Operation != OperationNoop {
+			count++
+		}
+	}
+	return count
+}
+
+// BuildPlan compares desired fields with current state and orders dependent actions.
+func BuildPlan(desired, current *Configuration) (Plan, error) {
+	if err := desired.Validate(); err != nil {
+		return Plan{}, err
+	}
+	if current == nil {
+		current = NewConfiguration()
+	}
+
+	registries := indexBy(current.Spec.Registries, func(value Registry) string { return value.Name })
+	projects := indexBy(current.Spec.Projects, func(value Project) string { return value.Name })
+	policies := indexBy(current.Spec.ReplicationPolicies, func(value ReplicationPolicy) string { return value.Name })
+
+	var plan Plan
+	for _, wanted := range desired.Spec.Registries {
+		actual, exists := registries[wanted.Name]
+		operation := OperationCreate
+		if exists {
+			operation = OperationNoop
+			if !registryMatches(wanted, actual) {
+				operation = OperationUpdate
+			}
+		}
+		plan.Actions = append(plan.Actions, Action{Operation: operation, Resource: resourceRegistry, Name: wanted.Name})
+	}
+
+	for _, wanted := range desired.Spec.Projects {
+		actual, exists := projects[wanted.Name]
+		operation := OperationCreate
+		if exists {
+			operation = OperationNoop
+			if !projectMatches(wanted, actual) {
+				operation = OperationUpdate
+			}
+		}
+		plan.Actions = append(plan.Actions, Action{Operation: operation, Resource: resourceProject, Name: wanted.Name})
+	}
+
+	for _, wanted := range desired.Spec.Projects {
+		actual, projectExists := projects[wanted.Name]
+		if wanted.Quota != nil {
+			operation := OperationUpdate
+			if projectExists && mapSubsetMatches(wanted.Quota, actual.Quota) {
+				operation = OperationNoop
+			}
+			plan.Actions = append(plan.Actions, Action{Operation: operation, Resource: resourceQuota, Name: wanted.Name})
+		}
+
+		actualWebhooks := indexBy(actual.Webhooks, func(value Webhook) string { return value.Name })
+		for _, webhook := range wanted.Webhooks {
+			currentWebhook, exists := actualWebhooks[webhook.Name]
+			operation := OperationCreate
+			if projectExists && exists {
+				operation = OperationNoop
+				if !webhookMatches(webhook, currentWebhook) {
+					operation = OperationUpdate
+				}
+			}
+			plan.Actions = append(plan.Actions, Action{
+				Operation: operation,
+				Resource:  resourceWebhook,
+				Name:      webhook.Name,
+				Project:   wanted.Name,
+			})
+		}
+	}
+
+	for _, wanted := range desired.Spec.ReplicationPolicies {
+		actual, exists := policies[wanted.Name]
+		operation := OperationCreate
+		if exists {
+			operation = OperationNoop
+			if !replicationPolicyMatches(wanted, actual) {
+				operation = OperationUpdate
+			}
+		}
+		plan.Actions = append(plan.Actions, Action{Operation: operation, Resource: resourceReplicationPolicy, Name: wanted.Name})
+	}
+
+	if len(desired.Spec.System) > 0 {
+		operation := OperationNoop
+		if !mapSubsetMatches(desired.Spec.System, current.Spec.System) {
+			operation = OperationUpdate
+		}
+		plan.Actions = append(plan.Actions, Action{Operation: operation, Resource: resourceSystem})
+	}
+	return plan, nil
+}
+
+func indexBy[T any](values []T, key func(T) string) map[string]T {
+	result := make(map[string]T, len(values))
+	for _, value := range values {
+		result[key(value)] = value
+	}
+	return result
+}
+
+func registryMatches(desired, current Registry) bool {
+	return optionalMatches(desired.Type, current.Type) &&
+		optionalMatches(desired.URL, current.URL) &&
+		optionalMatches(desired.Description, current.Description) &&
+		optionalMatches(desired.Insecure, current.Insecure) &&
+		desired.Credential == nil
+}
+
+func projectMatches(desired, current Project) bool {
+	return optionalMatches(desired.Public, current.Public) &&
+		optionalMatches(desired.Registry, current.Registry) &&
+		metadataMatches(desired.Metadata, current.Metadata)
+}
+
+func metadataMatches(desired, current *ProjectMetadata) bool {
+	if desired == nil {
+		return true
+	}
+	if current == nil {
+		return false
+	}
+	return optionalMatches(desired.AutoScan, current.AutoScan) &&
+		optionalMatches(desired.AutoSBOMGeneration, current.AutoSBOMGeneration) &&
+		optionalMatches(desired.EnableContentTrust, current.EnableContentTrust) &&
+		optionalMatches(desired.EnableContentTrustCosign, current.EnableContentTrustCosign) &&
+		optionalMatches(desired.PreventVulnerableImages, current.PreventVulnerableImages) &&
+		optionalMatches(desired.ProxySpeedKB, current.ProxySpeedKB) &&
+		optionalMatches(desired.ReuseSystemCVEAllowlist, current.ReuseSystemCVEAllowlist) &&
+		optionalMatches(desired.Severity, current.Severity)
+}
+
+func webhookMatches(desired, current Webhook) bool {
+	return optionalMatches(desired.Description, current.Description) &&
+		optionalMatches(desired.Enabled, current.Enabled) &&
+		sliceMatches(desired.Events, current.Events) &&
+		webhookTargetsMatch(desired.Targets, current.Targets)
+}
+
+func webhookTargetsMatch(desired, current []WebhookTarget) bool {
+	if desired == nil {
+		return true
+	}
+	if len(desired) != len(current) {
+		return false
+	}
+	for i := range desired {
+		wanted, actual := desired[i], current[i]
+		if !optionalMatches(wanted.NotifyType, actual.NotifyType) ||
+			!optionalMatches(wanted.Endpoint, actual.Endpoint) ||
+			!optionalMatches(wanted.PayloadFormat, actual.PayloadFormat) ||
+			!optionalMatches(wanted.VerifyRemoteCertificate, actual.VerifyRemoteCertificate) ||
+			wanted.AuthHeaderFrom != nil {
+			return false
+		}
+	}
+	return true
+}
+
+func replicationPolicyMatches(desired, current ReplicationPolicy) bool {
+	return desired.Mode == current.Mode && desired.Registry == current.Registry &&
+		optionalMatches(desired.Description, current.Description) &&
+		optionalMatches(desired.Enabled, current.Enabled) &&
+		optionalMatches(desired.DestinationNamespace, current.DestinationNamespace) &&
+		optionalMatches(desired.DestinationReplaceCount, current.DestinationReplaceCount) &&
+		optionalMatches(desired.Override, current.Override) &&
+		optionalMatches(desired.ReplicateDeletion, current.ReplicateDeletion) &&
+		optionalMatches(desired.CopyByChunk, current.CopyByChunk) &&
+		optionalMatches(desired.Speed, current.Speed) &&
+		sliceMatches(desired.Filters, current.Filters) &&
+		optionalMatches(desired.Trigger, current.Trigger)
+}
+
+func optionalMatches[T comparable](desired, current *T) bool {
+	return desired == nil || current != nil && *desired == *current
+}
+
+func sliceMatches[T comparable](desired, current []T) bool {
+	return desired == nil || slices.Equal(desired, current)
+}
+
+func mapSubsetMatches[K comparable, V any](desired, current map[K]V) bool {
+	for key, wanted := range desired {
+		actual, exists := current[key]
+		if !exists || !jsonEquivalent(wanted, actual) {
+			return false
+		}
+	}
+	return true
+}
+
+func jsonEquivalent(left, right any) bool {
+	leftJSON, leftErr := json.Marshal(left)
+	rightJSON, rightErr := json.Marshal(right)
+	if leftErr != nil || rightErr != nil {
+		return reflect.DeepEqual(left, right)
+	}
+	var normalizedLeft any
+	var normalizedRight any
+	if json.Unmarshal(leftJSON, &normalizedLeft) != nil || json.Unmarshal(rightJSON, &normalizedRight) != nil {
+		return reflect.DeepEqual(left, right)
+	}
+	return reflect.DeepEqual(normalizedLeft, normalizedRight)
+}

--- a/pkg/declarative/plan_test.go
+++ b/pkg/declarative/plan_test.go
@@ -1,0 +1,81 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package declarative_test
+
+import (
+	"testing"
+
+	"github.com/goharbor/harbor-cli/pkg/declarative"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildPlanOrdersDependenciesAndIgnoresUnmanagedFields(t *testing.T) {
+	public := false
+	registryType := "docker-hub"
+	desired := declarative.NewConfiguration()
+	desired.Spec.Registries = []declarative.Registry{{Name: "hub", Type: &registryType}}
+	desired.Spec.Projects = []declarative.Project{
+		{
+			Name:   "demo",
+			Public: &public,
+			Quota:  map[string]int64{"storage": 100},
+			Webhooks: []declarative.Webhook{
+				{Name: "notify"},
+			},
+		},
+	}
+	desired.Spec.ReplicationPolicies = []declarative.ReplicationPolicy{{Name: "mirror", Mode: "push", Registry: "hub"}}
+	desired.Spec.System = map[string]any{"read_only": false}
+
+	current := declarative.NewConfiguration()
+	current.Spec.Registries = []declarative.Registry{{Name: "hub", Type: &registryType, URL: ptr("https://hub.docker.com")}}
+	current.Spec.Projects = []declarative.Project{{Name: "demo", Public: &public, Quota: map[string]int64{"storage": 50}}}
+
+	plan, err := declarative.BuildPlan(desired, current)
+	require.NoError(t, err)
+
+	operations := make([]string, 0, len(plan.Actions))
+	for _, action := range plan.Actions {
+		operations = append(operations, action.String())
+	}
+	assert.Equal(t, []string{
+		"no-op registry hub",
+		"no-op project demo",
+		"update quota demo",
+		"create webhook demo/notify",
+		"create replication policy mirror",
+		"update system configuration",
+	}, operations)
+	assert.Equal(t, 4, plan.ChangeCount())
+}
+
+func TestBuildPlanIsNoopAfterConvergence(t *testing.T) {
+	enabled := true
+	document := declarative.NewConfiguration()
+	document.Spec.ReplicationPolicies = []declarative.ReplicationPolicy{
+		{Name: "mirror", Mode: "pull", Registry: "source", Enabled: &enabled},
+	}
+
+	plan, err := declarative.BuildPlan(document, document)
+	require.NoError(t, err)
+	require.Len(t, plan.Actions, 1)
+	assert.Equal(t, declarative.OperationNoop, plan.Actions[0].Operation)
+	assert.False(t, plan.HasChanges())
+}
+
+func ptr[T any](value T) *T {
+	return &value
+}

--- a/pkg/declarative/service.go
+++ b/pkg/declarative/service.go
@@ -1,0 +1,75 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package declarative
+
+import (
+	"context"
+	"fmt"
+)
+
+// Backend reads and mutates Harbor resources for declarative reconciliation.
+type Backend interface {
+	Snapshot(context.Context) (*Configuration, error)
+	Apply(context.Context, *Configuration, Action) error
+}
+
+// Service exports, plans, and applies declarative Harbor configuration.
+type Service struct {
+	backend Backend
+}
+
+// NewService creates a declarative configuration service.
+func NewService(backend Backend) *Service {
+	return &Service{backend: backend}
+}
+
+// Export returns normalized current state.
+func (s *Service) Export(ctx context.Context) (*Configuration, error) {
+	configuration, err := s.backend.Snapshot(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("export Harbor configuration: %w", err)
+	}
+	configuration.Normalize()
+	if err := configuration.Validate(); err != nil {
+		return nil, fmt.Errorf("validate exported configuration: %w", err)
+	}
+	return configuration, nil
+}
+
+// Plan compares a desired document with current Harbor state.
+func (s *Service) Plan(ctx context.Context, desired *Configuration) (Plan, error) {
+	current, err := s.backend.Snapshot(ctx)
+	if err != nil {
+		return Plan{}, fmt.Errorf("read current Harbor configuration: %w", err)
+	}
+	plan, err := BuildPlan(desired, current)
+	if err != nil {
+		return Plan{}, fmt.Errorf("build reconciliation plan: %w", err)
+	}
+	return plan, nil
+}
+
+// Apply executes the mutating steps of an existing plan in dependency order.
+func (s *Service) Apply(ctx context.Context, desired *Configuration, plan Plan) error {
+	for _, action := range plan.Actions {
+		if action.Operation == OperationNoop {
+			continue
+		}
+		if err := s.backend.Apply(ctx, desired, action); err != nil {
+			return fmt.Errorf("%s: %w", action, err)
+		}
+	}
+	return nil
+}

--- a/pkg/declarative/service_test.go
+++ b/pkg/declarative/service_test.go
@@ -1,0 +1,52 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package declarative_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/goharbor/harbor-cli/pkg/declarative"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingBackend struct {
+	snapshot *declarative.Configuration
+	actions  []declarative.Action
+}
+
+func (b *recordingBackend) Snapshot(context.Context) (*declarative.Configuration, error) {
+	return b.snapshot, nil
+}
+
+func (b *recordingBackend) Apply(_ context.Context, _ *declarative.Configuration, action declarative.Action) error {
+	b.actions = append(b.actions, action)
+	return nil
+}
+
+func TestServiceApplySkipsNoopActions(t *testing.T) {
+	backend := &recordingBackend{snapshot: declarative.NewConfiguration()}
+	service := declarative.NewService(backend)
+	desired := declarative.NewConfiguration()
+	plan := declarative.Plan{Actions: []declarative.Action{
+		{Operation: declarative.OperationNoop, Resource: "project", Name: "existing"},
+		{Operation: declarative.OperationCreate, Resource: "project", Name: "new"},
+	}}
+
+	require.NoError(t, service.Apply(context.Background(), desired, plan))
+	require.Len(t, backend.actions, 1)
+	assert.Equal(t, "new", backend.actions[0].Name)
+}

--- a/pkg/declarative/types.go
+++ b/pkg/declarative/types.go
@@ -1,0 +1,261 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package declarative exports and reconciles Harbor API-managed configuration.
+package declarative
+
+import (
+	"cmp"
+	"fmt"
+	"slices"
+	"strings"
+)
+
+const (
+	// APIVersion is the version of the declarative configuration schema.
+	APIVersion = "goharbor.io/v1alpha1"
+	// Kind identifies a complete Harbor configuration document.
+	Kind = "HarborConfiguration"
+)
+
+// Configuration is the portable desired state of Harbor API-managed resources.
+type Configuration struct {
+	APIVersion string `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string `json:"kind" yaml:"kind"`
+	Spec       Spec   `json:"spec" yaml:"spec"`
+}
+
+// Spec contains the resources managed by a Configuration.
+type Spec struct {
+	System              map[string]any      `json:"system,omitempty" yaml:"system,omitempty"`
+	Registries          []Registry          `json:"registries,omitempty" yaml:"registries,omitempty"`
+	Projects            []Project           `json:"projects,omitempty" yaml:"projects,omitempty"`
+	ReplicationPolicies []ReplicationPolicy `json:"replicationPolicies,omitempty" yaml:"replicationPolicies,omitempty"`
+}
+
+// SecretRef resolves a secret from the process environment at apply time.
+type SecretRef struct {
+	Env string `json:"env" yaml:"env"`
+}
+
+// Registry describes an external registry endpoint. Export never includes credentials.
+type Registry struct {
+	Name        string              `json:"name" yaml:"name"`
+	Type        *string             `json:"type,omitempty" yaml:"type,omitempty"`
+	URL         *string             `json:"url,omitempty" yaml:"url,omitempty"`
+	Description *string             `json:"description,omitempty" yaml:"description,omitempty"`
+	Insecure    *bool               `json:"insecure,omitempty" yaml:"insecure,omitempty"`
+	Credential  *RegistryCredential `json:"credential,omitempty" yaml:"credential,omitempty"`
+}
+
+// RegistryCredential references external registry credentials without storing secret values.
+type RegistryCredential struct {
+	Type             *string    `json:"type,omitempty" yaml:"type,omitempty"`
+	AccessKeyFrom    *SecretRef `json:"accessKeyFrom,omitempty" yaml:"accessKeyFrom,omitempty"`
+	AccessSecretFrom *SecretRef `json:"accessSecretFrom,omitempty" yaml:"accessSecretFrom,omitempty"`
+}
+
+// Project describes a Harbor project and its project-scoped configuration.
+type Project struct {
+	Name     string           `json:"name" yaml:"name"`
+	Public   *bool            `json:"public,omitempty" yaml:"public,omitempty"`
+	Registry *string          `json:"registry,omitempty" yaml:"registry,omitempty"`
+	Metadata *ProjectMetadata `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	Quota    map[string]int64 `json:"quota,omitempty" yaml:"quota,omitempty"`
+	Webhooks []Webhook        `json:"webhooks,omitempty" yaml:"webhooks,omitempty"`
+}
+
+// ProjectMetadata contains mutable project settings.
+type ProjectMetadata struct {
+	AutoScan                 *bool   `json:"autoScan,omitempty" yaml:"autoScan,omitempty"`
+	AutoSBOMGeneration       *bool   `json:"autoSBOMGeneration,omitempty" yaml:"autoSBOMGeneration,omitempty"`
+	EnableContentTrust       *bool   `json:"enableContentTrust,omitempty" yaml:"enableContentTrust,omitempty"`
+	EnableContentTrustCosign *bool   `json:"enableContentTrustCosign,omitempty" yaml:"enableContentTrustCosign,omitempty"`
+	PreventVulnerableImages  *bool   `json:"preventVulnerableImages,omitempty" yaml:"preventVulnerableImages,omitempty"`
+	ProxySpeedKB             *int64  `json:"proxySpeedKB,omitempty" yaml:"proxySpeedKB,omitempty"`
+	ReuseSystemCVEAllowlist  *bool   `json:"reuseSystemCVEAllowlist,omitempty" yaml:"reuseSystemCVEAllowlist,omitempty"`
+	Severity                 *string `json:"severity,omitempty" yaml:"severity,omitempty"`
+}
+
+// Webhook describes a project webhook policy.
+type Webhook struct {
+	Name        string          `json:"name" yaml:"name"`
+	Description *string         `json:"description,omitempty" yaml:"description,omitempty"`
+	Enabled     *bool           `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	Events      []string        `json:"events,omitempty" yaml:"events,omitempty"`
+	Targets     []WebhookTarget `json:"targets,omitempty" yaml:"targets,omitempty"`
+}
+
+// WebhookTarget describes one destination of a webhook policy.
+type WebhookTarget struct {
+	NotifyType              *string    `json:"notifyType,omitempty" yaml:"notifyType,omitempty"`
+	Endpoint                *string    `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
+	PayloadFormat           *string    `json:"payloadFormat,omitempty" yaml:"payloadFormat,omitempty"`
+	VerifyRemoteCertificate *bool      `json:"verifyRemoteCertificate,omitempty" yaml:"verifyRemoteCertificate,omitempty"`
+	AuthHeaderFrom          *SecretRef `json:"authHeaderFrom,omitempty" yaml:"authHeaderFrom,omitempty"`
+}
+
+// ReplicationPolicy describes a Harbor replication policy using registry names instead of IDs.
+type ReplicationPolicy struct {
+	Name                    string              `json:"name" yaml:"name"`
+	Description             *string             `json:"description,omitempty" yaml:"description,omitempty"`
+	Enabled                 *bool               `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	Mode                    string              `json:"mode,omitempty" yaml:"mode,omitempty"`
+	Registry                string              `json:"registry,omitempty" yaml:"registry,omitempty"`
+	DestinationNamespace    *string             `json:"destinationNamespace,omitempty" yaml:"destinationNamespace,omitempty"`
+	DestinationReplaceCount *int8               `json:"destinationNamespaceReplaceCount,omitempty" yaml:"destinationNamespaceReplaceCount,omitempty"`
+	Override                *bool               `json:"override,omitempty" yaml:"override,omitempty"`
+	ReplicateDeletion       *bool               `json:"replicateDeletion,omitempty" yaml:"replicateDeletion,omitempty"`
+	CopyByChunk             *bool               `json:"copyByChunk,omitempty" yaml:"copyByChunk,omitempty"`
+	Speed                   *int32              `json:"speed,omitempty" yaml:"speed,omitempty"`
+	Filters                 []ReplicationFilter `json:"filters,omitempty" yaml:"filters,omitempty"`
+	Trigger                 *ReplicationTrigger `json:"trigger,omitempty" yaml:"trigger,omitempty"`
+}
+
+// ReplicationFilter limits resources selected by a replication policy.
+type ReplicationFilter struct {
+	Type       string `json:"type" yaml:"type"`
+	Value      string `json:"value,omitempty" yaml:"value,omitempty"`
+	Decoration string `json:"decoration,omitempty" yaml:"decoration,omitempty"`
+}
+
+// ReplicationTrigger describes when a replication policy runs.
+type ReplicationTrigger struct {
+	Type string `json:"type,omitempty" yaml:"type,omitempty"`
+	Cron string `json:"cron,omitempty" yaml:"cron,omitempty"`
+}
+
+// NewConfiguration returns an empty document using the current schema version.
+func NewConfiguration() *Configuration {
+	return &Configuration{APIVersion: APIVersion, Kind: Kind}
+}
+
+// Validate checks schema identity, resource identity, and local references.
+func (c *Configuration) Validate() error {
+	return c.validate(true)
+}
+
+func (c *Configuration) validate(requireComplete bool) error {
+	if c == nil {
+		return fmt.Errorf("configuration is empty")
+	}
+	if c.APIVersion != APIVersion {
+		return fmt.Errorf("unsupported apiVersion %q; expected %q", c.APIVersion, APIVersion)
+	}
+	if c.Kind != Kind {
+		return fmt.Errorf("unsupported kind %q; expected %q", c.Kind, Kind)
+	}
+	if err := validateNames("registry", c.Spec.Registries, func(value Registry) string { return value.Name }); err != nil {
+		return err
+	}
+	if err := validateNames("project", c.Spec.Projects, func(value Project) string { return value.Name }); err != nil {
+		return err
+	}
+	if err := validateNames("replication policy", c.Spec.ReplicationPolicies, func(value ReplicationPolicy) string { return value.Name }); err != nil {
+		return err
+	}
+
+	for _, registry := range c.Spec.Registries {
+		if registry.Credential == nil {
+			continue
+		}
+		for _, ref := range []*SecretRef{registry.Credential.AccessKeyFrom, registry.Credential.AccessSecretFrom} {
+			if ref != nil && strings.TrimSpace(ref.Env) == "" {
+				return fmt.Errorf("registry %q has an empty credential environment reference", registry.Name)
+			}
+		}
+	}
+	for _, project := range c.Spec.Projects {
+		if err := validateNames("webhook in project "+project.Name, project.Webhooks, func(value Webhook) string { return value.Name }); err != nil {
+			return err
+		}
+		for _, webhook := range project.Webhooks {
+			for i, target := range webhook.Targets {
+				if requireComplete && (target.NotifyType == nil || strings.TrimSpace(*target.NotifyType) == "") {
+					return fmt.Errorf("webhook %q in project %q target at index %d has no notifyType", webhook.Name, project.Name, i)
+				}
+				if requireComplete && (target.Endpoint == nil || strings.TrimSpace(*target.Endpoint) == "") {
+					return fmt.Errorf("webhook %q in project %q target at index %d has no endpoint", webhook.Name, project.Name, i)
+				}
+				if target.AuthHeaderFrom != nil && strings.TrimSpace(target.AuthHeaderFrom.Env) == "" {
+					return fmt.Errorf("webhook %q in project %q target at index %d has an empty auth-header environment reference", webhook.Name, project.Name, i)
+				}
+			}
+		}
+	}
+	for _, policy := range c.Spec.ReplicationPolicies {
+		if policy.Mode != "" && policy.Mode != "push" && policy.Mode != "pull" {
+			return fmt.Errorf("replication policy %q mode must be push or pull", policy.Name)
+		}
+		if requireComplete && policy.Mode == "" {
+			return fmt.Errorf("replication policy %q must define a mode", policy.Name)
+		}
+		if requireComplete && strings.TrimSpace(policy.Registry) == "" {
+			return fmt.Errorf("replication policy %q must reference a registry", policy.Name)
+		}
+		for i, filter := range policy.Filters {
+			if strings.TrimSpace(filter.Type) == "" {
+				return fmt.Errorf("replication policy %q filter at index %d has no type", policy.Name, i)
+			}
+		}
+		if requireComplete && policy.Trigger != nil && strings.TrimSpace(policy.Trigger.Type) == "" {
+			return fmt.Errorf("replication policy %q trigger has no type", policy.Name)
+		}
+	}
+	return nil
+}
+
+func validateNames[T any](kind string, values []T, name func(T) string) error {
+	seen := make(map[string]struct{}, len(values))
+	for i, item := range values {
+		value := strings.TrimSpace(name(item))
+		if value == "" {
+			return fmt.Errorf("%s at index %d has no name", kind, i)
+		}
+		if _, ok := seen[value]; ok {
+			return fmt.Errorf("duplicate %s %q", kind, value)
+		}
+		seen[value] = struct{}{}
+	}
+	return nil
+}
+
+// Normalize sorts resources so repeated exports produce stable output.
+func (c *Configuration) Normalize() {
+	if c == nil {
+		return
+	}
+	slices.SortFunc(c.Spec.Registries, func(a, b Registry) int { return cmp.Compare(a.Name, b.Name) })
+	slices.SortFunc(c.Spec.Projects, func(a, b Project) int { return cmp.Compare(a.Name, b.Name) })
+	for i := range c.Spec.Projects {
+		project := &c.Spec.Projects[i]
+		slices.SortFunc(project.Webhooks, func(a, b Webhook) int { return cmp.Compare(a.Name, b.Name) })
+		for j := range project.Webhooks {
+			slices.Sort(project.Webhooks[j].Events)
+		}
+	}
+	slices.SortFunc(c.Spec.ReplicationPolicies, func(a, b ReplicationPolicy) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+	for i := range c.Spec.ReplicationPolicies {
+		policy := &c.Spec.ReplicationPolicies[i]
+		slices.SortFunc(policy.Filters, func(a, b ReplicationFilter) int {
+			return cmp.Or(
+				cmp.Compare(a.Type, b.Type),
+				cmp.Compare(a.Value, b.Value),
+				cmp.Compare(a.Decoration, b.Decoration),
+			)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add a versioned `HarborConfiguration` domain model with strict YAML/JSON encoding
- add `harbor export` for portable, secret-free API-managed configuration
- add additive `harbor apply -f <file-or-directory>` with dry-run, confirmation, and create/update/no-op planning
- support deterministic base/default/environment overlays for system settings, registries, projects, quotas, webhooks, and replication policies
- preserve name-based references and resolve write-only secrets from environment variables

## Why

Harbor configuration currently requires imperative CLI/UI operations or custom API scripts. This provides a stable desired-state format that can be stored in Git, reused across environments, and later consumed by a controller/operator.

Closes #1034.

The complete contract, ownership rules, failure semantics, and future authentication-dependent resource decisions are documented in #1077.

## Behavior

- apply is additive; omitted and extra live resources are not deleted
- omitted fields are unmanaged; explicitly supplied fields are reconciled
- directory inputs are recursive and merge in lexical relative-path order
- maps merge by key and named resources merge by name
- list-valued fields and replication triggers replace as atomic values
- exports redact credentials and webhook authentication headers
- invalid, immutable, or unsupported transitions fail with scoped errors

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race ./pkg/declarative ./cmd/harbor/root`
- `golangci-lint run ./...` (`0 issues`)
- CLI help smoke tests for `harbor apply` and `harbor export`

A live Harbor endpoint was not available for API-level end-to-end verification.
