### PR TITLE
fix: password command documentation

### DIFF
--- a/doc/cli-docs/harbor-user-password.md
+++ b/doc/cli-docs/harbor-user-password.md
@@ -19,7 +19,9 @@ harbor user password [flags]
 ### Options
 
 ```sh
-  -h, --help   help for password
+  -h, --help             help for password
+      --password-stdin   Take the password from stdin
+      --user-id int      User ID for non-interactive mode
 ```
 
 ### Options inherited from parent commands

--- a/doc/man-docs/man1/harbor-user-password.1
+++ b/doc/man-docs/man1/harbor-user-password.1
@@ -17,6 +17,14 @@ Allows admin to reset the password for a specified user or select interactively 
 \fB-h\fP, \fB--help\fP[=false]
 	help for password
 
+.PP
+\fB--password-stdin\fP[=false]
+	Take the password from stdin
+
+.PP
+\fB--user-id\fP=0
+	User ID for non-interactive mode
+
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
 \fB-c\fP, \fB--config\fP=""


### PR DESCRIPTION
## What changed

Regenerated the user password command's Markdown and man-page documentation.

## Why

The `password-stdin` and `user-id` flags were added to the command, but its generated documentation was not committed. The CI documentation check therefore fails before GolangCI-Lint runs.

## Impact

The committed documentation now matches the CLI and the lint workflow can proceed.

## Validation

- `go run doc.go && go run ./man-docs/man_doc.go`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run -v`
- `go test ./...`
