### PR TITLE
fix(retention): use resolved retention ID when deleting rules

### DIFF
--- a/cmd/harbor/root/tag/retention/delete.go
+++ b/cmd/harbor/root/tag/retention/delete.go
@@ -76,7 +76,7 @@ Examples:
 				}
 			}
 			retentionIndex := prompt.GetRetentionTagRule(retentionID)
-			err = api.DeleteRetention(projectName, int(retentionIndex))
+			err = api.DeleteRetention(retentionID, int(retentionIndex))
 			if err != nil {
 				return fmt.Errorf("%w", err)
 			}

--- a/pkg/api/retention_handler.go
+++ b/pkg/api/retention_handler.go
@@ -121,18 +121,13 @@ func GetRetentionId(projectNameorID string, isName bool) (string, error) {
 	return retentionid, nil
 }
 
-func DeleteRetention(projectName string, ruleIndex int) error {
+func DeleteRetention(retentionID string, ruleIndex int) error {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {
 		return err
 	}
 
-	retentionIDStr, err := GetRetentionId(projectName, true)
-	if err != nil {
-		return err
-	}
-
-	retentionResp, err := ListRetention(retentionIDStr)
+	retentionResp, err := ListRetention(retentionID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

This PR fixes the tag retention deletion flow when a project is specified using `--project-id`.

The CLI already resolves the retention policy ID, but the resolved ID was discarded and `DeleteRetention()` was called with the project name. The API layer then performed another project-name-based lookup.

This change passes the resolved retention ID directly through the deletion flow.

Fixes #1080

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes

- Pass the resolved `retentionID` to `api.DeleteRetention()`.
- Update `DeleteRetention()` to accept the retention ID directly.
- Remove the redundant `GetRetentionId()` lookup from the API deletion path.
- Keep project-name and project-ID deletion flows consistent.