### PR TITLE
doc: regenerate docs for --log-format flag

### DIFF
--- a/doc/cli-docs/harbor-logout.md
+++ b/doc/cli-docs/harbor-logout.md
@@ -33,6 +33,7 @@ harbor logout [flags]
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -l, --log-format string      Output format for logging. One of: json|text (default "text")
   -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```

--- a/doc/cli-docs/harbor-project-summary.md
+++ b/doc/cli-docs/harbor-project-summary.md
@@ -33,6 +33,7 @@ harbor project summary my-project or harbor project summary 1 --id
 
 ```sh
   -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -l, --log-format string      Output format for logging. One of: json|text (default "text")
   -o, --output-format string   Output format. One of: json|yaml|csv
   -v, --verbose                verbose output
 ```

--- a/doc/man-docs/man1/harbor-logout.1
+++ b/doc/man-docs/man1/harbor-logout.1
@@ -27,6 +27,10 @@ Remove the current credential from the local CLI config.
 	config file (default is $HOME/.config/harbor-cli/config.yaml)
 
 .PP
+\fB-l\fP, \fB--log-format\fP="text"
+	Output format for logging. One of: json|text
+
+.PP
 \fB-o\fP, \fB--output-format\fP=""
 	Output format. One of: json|yaml|csv
 

--- a/doc/man-docs/man1/harbor-project-summary.1
+++ b/doc/man-docs/man1/harbor-project-summary.1
@@ -27,6 +27,10 @@ Get summary of a project by name or ID. If no arguments are provided, it will pr
 	config file (default is $HOME/.config/harbor-cli/config.yaml)
 
 .PP
+\fB-l\fP, \fB--log-format\fP="text"
+	Output format for logging. One of: json|text
+
+.PP
 \fB-o\fP, \fB--output-format\fP=""
 	Output format. One of: json|yaml|csv
 


### PR DESCRIPTION
## Summary
`main`'s doc-drift lint check fails because `harbor-logout` and `harbor-project-summary`
docs were not regenerated after #722 added the global `--log-format` flag.

This regenerates the CLI docs and man pages so they match the current command output.

## Changes
- `doc/cli-docs/harbor-logout.md`
- `doc/cli-docs/harbor-project-summary.md`
- `doc/man-docs/man1/harbor-logout.1`
- `doc/man-docs/man1/harbor-project-summary.1`

## Testing
- `go run doc.go` / `go run ./man-docs/man_doc.go` — no further diff after regeneration
- `golangci-lint run ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)