### PR TITLE
feat(jobservice): add pools and workers list commands

### DIFF
--- a/cmd/harbor/root/jobservice/cmd.go
+++ b/cmd/harbor/root/jobservice/cmd.go
@@ -14,7 +14,9 @@
 package jobservice
 
 import (
+	"github.com/goharbor/harbor-cli/cmd/harbor/root/jobservice/pools"
 	"github.com/goharbor/harbor-cli/cmd/harbor/root/jobservice/queues"
+	"github.com/goharbor/harbor-cli/cmd/harbor/root/jobservice/workers"
 	"github.com/spf13/cobra"
 )
 
@@ -31,6 +33,8 @@ Use "harbor jobservice [command] --help" for detailed examples and flags per sub
 
 	cmd.AddCommand(
 		queues.QueuesCommand(),
+		pools.PoolsCommand(),
+		workers.WorkersCommand(),
 	)
 
 	return cmd

--- a/cmd/harbor/root/jobservice/jobservice_test.go
+++ b/cmd/harbor/root/jobservice/jobservice_test.go
@@ -1,0 +1,35 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package jobservice
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJobService_WiresSubcommands(t *testing.T) {
+	cmd := JobService()
+
+	assert.Equal(t, "jobservice", cmd.Use)
+
+	subcommands := make(map[string]bool)
+	for _, sub := range cmd.Commands() {
+		subcommands[sub.Name()] = true
+	}
+
+	assert.True(t, subcommands["queues"], "jobservice should wire queues")
+	assert.True(t, subcommands["pools"], "jobservice should wire pools")
+	assert.True(t, subcommands["workers"], "jobservice should wire workers")
+}

--- a/cmd/harbor/root/jobservice/pools/cmd.go
+++ b/cmd/harbor/root/jobservice/pools/cmd.go
@@ -1,0 +1,29 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pools
+
+import "github.com/spf13/cobra"
+
+// PoolsCommand creates the pools parent command
+func PoolsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pools",
+		Short: "Manage worker pools",
+		Long:  "Manage Harbor jobservice worker pools. Requires system admin privileges.",
+	}
+
+	cmd.AddCommand(ListCommand())
+
+	return cmd
+}

--- a/cmd/harbor/root/jobservice/pools/list.go
+++ b/cmd/harbor/root/jobservice/pools/list.go
@@ -1,0 +1,56 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pools
+
+import (
+	"fmt"
+
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	jobserviceutils "github.com/goharbor/harbor-cli/pkg/utils/jobservice"
+	poolsview "github.com/goharbor/harbor-cli/pkg/views/jobservice/pools"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// ListCommand lists all worker pools
+func ListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List all worker pools",
+		Long:    "Display all Harbor jobservice worker pools with host, concurrency and start time. Requires system admin privileges.",
+		Example: "harbor jobservice pools list",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			response, err := api.GetWorkerPools()
+			if err != nil {
+				return jobserviceutils.FormatScheduleError("failed to retrieve worker pools", err, "read")
+			}
+
+			if response == nil || response.Payload == nil || len(response.Payload) == 0 {
+				fmt.Println("No worker pools found.")
+				return nil
+			}
+
+			formatFlag := viper.GetString("output-format")
+			if formatFlag != "" {
+				return utils.PrintFormat(response.Payload, formatFlag)
+			}
+
+			poolsview.ListPools(response.Payload)
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cmd/harbor/root/jobservice/pools/list_test.go
+++ b/cmd/harbor/root/jobservice/pools/list_test.go
@@ -76,7 +76,7 @@ func executeListCommand(t *testing.T, args ...string) (string, error) {
 
 	w.Close()
 	os.Stdout = oldStdout
-	io.Copy(&outBuf, r)
+	_, _ = io.Copy(&outBuf, r)
 
 	return outBuf.String(), cmdErr
 }

--- a/cmd/harbor/root/jobservice/pools/list_test.go
+++ b/cmd/harbor/root/jobservice/pools/list_test.go
@@ -1,0 +1,164 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pools
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
+	v2client "github.com/goharbor/go-client/pkg/sdk/v2.0/client"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/jobservice"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+type stubJobserviceTransport struct {
+	result interface{}
+	err    error
+}
+
+func (s *stubJobserviceTransport) Submit(op *runtime.ClientOperation) (interface{}, error) {
+	return s.result, s.err
+}
+
+func injectJobserviceClient(t *testing.T, result interface{}, callErr error) {
+	t.Helper()
+
+	origInstance := utils.ClientInstance
+	origErr := utils.ClientErr
+	t.Cleanup(func() {
+		utils.ClientInstance = origInstance
+		utils.ClientErr = origErr
+	})
+
+	utils.ClientInstance = &v2client.HarborAPI{
+		Jobservice: jobservice.New(&stubJobserviceTransport{result: result, err: callErr}, strfmt.Default, nil),
+	}
+	utils.ClientErr = nil
+	utils.ClientOnce.Do(func() {})
+}
+
+func executeListCommand(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+
+	var outBuf, cmdBuf bytes.Buffer
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+
+	os.Stdout = w
+
+	cmd := ListCommand()
+	cmd.SetOut(&cmdBuf)
+	cmd.SetErr(&cmdBuf)
+	cmd.SetArgs(args)
+	cmdErr := cmd.Execute()
+
+	w.Close()
+	os.Stdout = oldStdout
+	io.Copy(&outBuf, r)
+
+	return outBuf.String(), cmdErr
+}
+
+func TestPoolsCommand_WiresListSubcommand(t *testing.T) {
+	cmd := PoolsCommand()
+
+	assert.Equal(t, "pools", cmd.Use)
+	found := false
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "list" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "pools command should wire the list subcommand")
+}
+
+func TestListCommand_APIError(t *testing.T) {
+	injectJobserviceClient(t, nil, errors.New("boom"))
+
+	out, err := executeListCommand(t)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to retrieve worker pools")
+	assert.Contains(t, err.Error(), "boom")
+	assert.NotContains(t, out, "pool-")
+}
+
+func TestListCommand_EmptyPayload(t *testing.T) {
+	injectJobserviceClient(t, &jobservice.GetWorkerPoolsOK{Payload: []*models.WorkerPool{}}, nil)
+
+	out, err := executeListCommand(t)
+
+	assert.NoError(t, err)
+	assert.Contains(t, out, "No worker pools found.")
+}
+
+func TestListCommand_TableOutput(t *testing.T) {
+	viper.Set("output-format", "")
+	t.Cleanup(func() { viper.Set("output-format", "") })
+
+	payload := []*models.WorkerPool{
+		{WorkerPoolID: "pool-abc123", Host: "10.0.0.1:8080", Pid: 12345, Concurrency: 10},
+	}
+	injectJobserviceClient(t, &jobservice.GetWorkerPoolsOK{Payload: payload}, nil)
+
+	out, err := executeListCommand(t)
+
+	assert.NoError(t, err)
+	assert.Contains(t, out, "POOL_ID")
+	assert.Contains(t, out, "pool-abc123")
+	assert.Contains(t, out, "Total: 1 pool(s)")
+}
+
+func TestListCommand_JSONFormat(t *testing.T) {
+	viper.Set("output-format", "json")
+	t.Cleanup(func() { viper.Set("output-format", "") })
+
+	payload := []*models.WorkerPool{
+		{WorkerPoolID: "pool-json999", Host: "10.0.0.9:8080", Pid: 999, Concurrency: 5},
+	}
+	injectJobserviceClient(t, &jobservice.GetWorkerPoolsOK{Payload: payload}, nil)
+
+	out, err := executeListCommand(t)
+
+	assert.NoError(t, err)
+	assert.Contains(t, out, "pool-json999")
+	assert.Contains(t, out, "{")
+}
+
+func TestListCommand_UnsupportedFormat(t *testing.T) {
+	viper.Set("output-format", "xml")
+	t.Cleanup(func() { viper.Set("output-format", "") })
+
+	payload := []*models.WorkerPool{
+		{WorkerPoolID: "pool-abc123", Host: "10.0.0.1:8080"},
+	}
+	injectJobserviceClient(t, &jobservice.GetWorkerPoolsOK{Payload: payload}, nil)
+
+	_, err := executeListCommand(t)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unable to output in the specified 'xml' format")
+}

--- a/cmd/harbor/root/jobservice/workers/cmd.go
+++ b/cmd/harbor/root/jobservice/workers/cmd.go
@@ -1,0 +1,29 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package workers
+
+import "github.com/spf13/cobra"
+
+// WorkersCommand creates the workers parent command
+func WorkersCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "workers",
+		Short: "Manage workers",
+		Long:  "Manage Harbor jobservice workers inside a worker pool. Requires system admin privileges.",
+	}
+
+	cmd.AddCommand(ListCommand())
+
+	return cmd
+}

--- a/cmd/harbor/root/jobservice/workers/list.go
+++ b/cmd/harbor/root/jobservice/workers/list.go
@@ -1,0 +1,62 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package workers
+
+import (
+	"fmt"
+
+	"github.com/goharbor/harbor-cli/pkg/api"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	jobserviceutils "github.com/goharbor/harbor-cli/pkg/utils/jobservice"
+	workersview "github.com/goharbor/harbor-cli/pkg/views/jobservice/workers"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// ListCommand lists workers in a pool
+func ListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "list [pool-id]",
+		Short:   "List workers in a pool",
+		Long:    "Display all workers in the specified Harbor jobservice worker pool. Requires system admin privileges.",
+		Example: "harbor jobservice workers list <pool-id>",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			poolID := args[0]
+			if poolID == "" {
+				return fmt.Errorf("pool-id is required")
+			}
+
+			response, err := api.GetWorkers(poolID)
+			if err != nil {
+				return jobserviceutils.FormatScheduleError("failed to retrieve workers", err, "read")
+			}
+
+			if response == nil || response.Payload == nil || len(response.Payload) == 0 {
+				fmt.Println("No workers found.")
+				return nil
+			}
+
+			formatFlag := viper.GetString("output-format")
+			if formatFlag != "" {
+				return utils.PrintFormat(response.Payload, formatFlag)
+			}
+
+			workersview.ListWorkers(response.Payload)
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cmd/harbor/root/jobservice/workers/list_test.go
+++ b/cmd/harbor/root/jobservice/workers/list_test.go
@@ -76,7 +76,7 @@ func executeListCommand(t *testing.T, args ...string) (string, error) {
 
 	w.Close()
 	os.Stdout = oldStdout
-	io.Copy(&outBuf, r)
+	_, _ = io.Copy(&outBuf, r)
 
 	return outBuf.String(), cmdErr
 }

--- a/cmd/harbor/root/jobservice/workers/list_test.go
+++ b/cmd/harbor/root/jobservice/workers/list_test.go
@@ -1,0 +1,163 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package workers
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
+	v2client "github.com/goharbor/go-client/pkg/sdk/v2.0/client"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/jobservice"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+type stubJobserviceTransport struct {
+	result interface{}
+	err    error
+}
+
+func (s *stubJobserviceTransport) Submit(op *runtime.ClientOperation) (interface{}, error) {
+	return s.result, s.err
+}
+
+func injectJobserviceClient(t *testing.T, result interface{}, callErr error) {
+	t.Helper()
+
+	origInstance := utils.ClientInstance
+	origErr := utils.ClientErr
+	t.Cleanup(func() {
+		utils.ClientInstance = origInstance
+		utils.ClientErr = origErr
+	})
+
+	utils.ClientInstance = &v2client.HarborAPI{
+		Jobservice: jobservice.New(&stubJobserviceTransport{result: result, err: callErr}, strfmt.Default, nil),
+	}
+	utils.ClientErr = nil
+	utils.ClientOnce.Do(func() {})
+}
+
+func executeListCommand(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+
+	var outBuf, cmdBuf bytes.Buffer
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+
+	os.Stdout = w
+
+	cmd := ListCommand()
+	cmd.SetOut(&cmdBuf)
+	cmd.SetErr(&cmdBuf)
+	cmd.SetArgs(args)
+	cmdErr := cmd.Execute()
+
+	w.Close()
+	os.Stdout = oldStdout
+	io.Copy(&outBuf, r)
+
+	return outBuf.String(), cmdErr
+}
+
+func TestWorkersCommand_WiresListSubcommand(t *testing.T) {
+	cmd := WorkersCommand()
+
+	assert.Equal(t, "workers", cmd.Use)
+	found := false
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "list" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "workers command should wire the list subcommand")
+}
+
+func TestListCommand_RequiresOneArg(t *testing.T) {
+	_, err := executeListCommand(t)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "accepts 1 arg(s), received 0")
+}
+
+func TestListCommand_EmptyPoolID(t *testing.T) {
+	_, err := executeListCommand(t, "")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "pool-id is required")
+}
+
+func TestListCommand_APIError(t *testing.T) {
+	injectJobserviceClient(t, nil, errors.New("boom"))
+
+	out, err := executeListCommand(t, "pool-abc123")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to retrieve workers")
+	assert.Contains(t, err.Error(), "boom")
+	assert.NotContains(t, out, "pool-")
+}
+
+func TestListCommand_EmptyPayload(t *testing.T) {
+	injectJobserviceClient(t, &jobservice.GetWorkersOK{Payload: []*models.Worker{}}, nil)
+
+	out, err := executeListCommand(t, "pool-abc123")
+
+	assert.NoError(t, err)
+	assert.Contains(t, out, "No workers found.")
+}
+
+func TestListCommand_TableOutput(t *testing.T) {
+	viper.Set("output-format", "")
+	t.Cleanup(func() { viper.Set("output-format", "") })
+
+	payload := []*models.Worker{
+		{ID: "worker-1", PoolID: "pool-abc123", JobID: "job-9", JobName: "REPLICATE"},
+	}
+	injectJobserviceClient(t, &jobservice.GetWorkersOK{Payload: payload}, nil)
+
+	out, err := executeListCommand(t, "pool-abc123")
+
+	assert.NoError(t, err)
+	assert.Contains(t, out, "WORKER_ID")
+	assert.Contains(t, out, "worker-1")
+	assert.Contains(t, out, "Total: 1 worker(s)")
+}
+
+func TestListCommand_JSONFormat(t *testing.T) {
+	viper.Set("output-format", "json")
+	t.Cleanup(func() { viper.Set("output-format", "") })
+
+	payload := []*models.Worker{
+		{ID: "worker-json9", PoolID: "pool-abc123", JobID: "job-9", JobName: "REPLICATE"},
+	}
+	injectJobserviceClient(t, &jobservice.GetWorkersOK{Payload: payload}, nil)
+
+	out, err := executeListCommand(t, "pool-abc123")
+
+	assert.NoError(t, err)
+	assert.Contains(t, out, "worker-json9")
+	assert.Contains(t, out, "{")
+}

--- a/doc/cli-docs/harbor-jobservice-pools-list.md
+++ b/doc/cli-docs/harbor-jobservice-pools-list.md
@@ -1,0 +1,43 @@
+---
+title: harbor jobservice pools list
+weight: 70
+---
+## harbor jobservice pools list
+
+### Description
+
+##### List all worker pools
+
+### Synopsis
+
+Display all Harbor jobservice worker pools with host, concurrency and start time. Requires system admin privileges.
+
+```sh
+harbor jobservice pools list [flags]
+```
+
+### Examples
+
+```sh
+harbor jobservice pools list
+```
+
+### Options
+
+```sh
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -l, --log-format string      Output format for logging. One of: json|text (default "text")
+  -o, --output-format string   Output format. One of: json|yaml|csv
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor jobservice pools](harbor-jobservice-pools.md)	 - Manage worker pools
+

--- a/doc/cli-docs/harbor-jobservice-pools.md
+++ b/doc/cli-docs/harbor-jobservice-pools.md
@@ -1,0 +1,34 @@
+---
+title: harbor jobservice pools
+weight: 30
+---
+## harbor jobservice pools
+
+### Description
+
+##### Manage worker pools
+
+### Synopsis
+
+Manage Harbor jobservice worker pools. Requires system admin privileges.
+
+### Options
+
+```sh
+  -h, --help   help for pools
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -l, --log-format string      Output format for logging. One of: json|text (default "text")
+  -o, --output-format string   Output format. One of: json|yaml|csv
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor jobservice](harbor-jobservice.md)	 - Manage Harbor job service (admin only)
+* [harbor jobservice pools list](harbor-jobservice-pools-list.md)	 - List all worker pools
+

--- a/doc/cli-docs/harbor-jobservice-workers-list.md
+++ b/doc/cli-docs/harbor-jobservice-workers-list.md
@@ -1,0 +1,43 @@
+---
+title: harbor jobservice workers list
+weight: 85
+---
+## harbor jobservice workers list
+
+### Description
+
+##### List workers in a pool
+
+### Synopsis
+
+Display all workers in the specified Harbor jobservice worker pool. Requires system admin privileges.
+
+```sh
+harbor jobservice workers list [pool-id] [flags]
+```
+
+### Examples
+
+```sh
+harbor jobservice workers list <pool-id>
+```
+
+### Options
+
+```sh
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -l, --log-format string      Output format for logging. One of: json|text (default "text")
+  -o, --output-format string   Output format. One of: json|yaml|csv
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor jobservice workers](harbor-jobservice-workers.md)	 - Manage workers
+

--- a/doc/cli-docs/harbor-jobservice-workers.md
+++ b/doc/cli-docs/harbor-jobservice-workers.md
@@ -1,0 +1,34 @@
+---
+title: harbor jobservice workers
+weight: 70
+---
+## harbor jobservice workers
+
+### Description
+
+##### Manage workers
+
+### Synopsis
+
+Manage Harbor jobservice workers inside a worker pool. Requires system admin privileges.
+
+### Options
+
+```sh
+  -h, --help   help for workers
+```
+
+### Options inherited from parent commands
+
+```sh
+  -c, --config string          config file (default is $HOME/.config/harbor-cli/config.yaml)
+  -l, --log-format string      Output format for logging. One of: json|text (default "text")
+  -o, --output-format string   Output format. One of: json|yaml|csv
+  -v, --verbose                verbose output
+```
+
+### SEE ALSO
+
+* [harbor jobservice](harbor-jobservice.md)	 - Manage Harbor job service (admin only)
+* [harbor jobservice workers list](harbor-jobservice-workers-list.md)	 - List workers in a pool
+

--- a/doc/cli-docs/harbor-jobservice.md
+++ b/doc/cli-docs/harbor-jobservice.md
@@ -33,5 +33,7 @@ Use "harbor jobservice [command] --help" for detailed examples and flags per sub
 ### SEE ALSO
 
 * [harbor](harbor.md)	 - Official Harbor CLI
+* [harbor jobservice pools](harbor-jobservice-pools.md)	 - Manage worker pools
 * [harbor jobservice queues](harbor-jobservice-queues.md)	 - Manage job queues (list, stop, pause, resume)
+* [harbor jobservice workers](harbor-jobservice-workers.md)	 - Manage workers
 

--- a/doc/man-docs/man1/harbor-jobservice-pools-list.1
+++ b/doc/man-docs/man1/harbor-jobservice-pools-list.1
@@ -2,24 +2,20 @@
 .TH "HARBOR" "1"  "Harbor Community" "Harbor User Manuals"
 
 .SH NAME
-harbor-jobservice - Manage Harbor job service (admin only)
+harbor-jobservice-pools-list - List all worker pools
 
 
 .SH SYNOPSIS
-\fBharbor jobservice [flags]\fP
+\fBharbor jobservice pools list [flags]\fP
 
 
 .SH DESCRIPTION
-Manage Harbor job service components including worker pools, job queues, schedules, and job logs.
-This requires system admin privileges.
-
-.PP
-Use "harbor jobservice [command] --help" for detailed examples and flags per subcommand.
+Display all Harbor jobservice worker pools with host, concurrency and start time. Requires system admin privileges.
 
 
 .SH OPTIONS
 \fB-h\fP, \fB--help\fP[=false]
-	help for jobservice
+	help for list
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
@@ -39,5 +35,11 @@ Use "harbor jobservice [command] --help" for detailed examples and flags per sub
 	verbose output
 
 
+.SH EXAMPLE
+.EX
+harbor jobservice pools list
+.EE
+
+
 .SH SEE ALSO
-\fBharbor(1)\fP, \fBharbor-jobservice-pools(1)\fP, \fBharbor-jobservice-queues(1)\fP, \fBharbor-jobservice-workers(1)\fP
+\fBharbor-jobservice-pools(1)\fP

--- a/doc/man-docs/man1/harbor-jobservice-pools.1
+++ b/doc/man-docs/man1/harbor-jobservice-pools.1
@@ -2,24 +2,20 @@
 .TH "HARBOR" "1"  "Harbor Community" "Harbor User Manuals"
 
 .SH NAME
-harbor-jobservice - Manage Harbor job service (admin only)
+harbor-jobservice-pools - Manage worker pools
 
 
 .SH SYNOPSIS
-\fBharbor jobservice [flags]\fP
+\fBharbor jobservice pools [flags]\fP
 
 
 .SH DESCRIPTION
-Manage Harbor job service components including worker pools, job queues, schedules, and job logs.
-This requires system admin privileges.
-
-.PP
-Use "harbor jobservice [command] --help" for detailed examples and flags per subcommand.
+Manage Harbor jobservice worker pools. Requires system admin privileges.
 
 
 .SH OPTIONS
 \fB-h\fP, \fB--help\fP[=false]
-	help for jobservice
+	help for pools
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
@@ -40,4 +36,4 @@ Use "harbor jobservice [command] --help" for detailed examples and flags per sub
 
 
 .SH SEE ALSO
-\fBharbor(1)\fP, \fBharbor-jobservice-pools(1)\fP, \fBharbor-jobservice-queues(1)\fP, \fBharbor-jobservice-workers(1)\fP
+\fBharbor-jobservice(1)\fP, \fBharbor-jobservice-pools-list(1)\fP

--- a/doc/man-docs/man1/harbor-jobservice-workers-list.1
+++ b/doc/man-docs/man1/harbor-jobservice-workers-list.1
@@ -2,24 +2,20 @@
 .TH "HARBOR" "1"  "Harbor Community" "Harbor User Manuals"
 
 .SH NAME
-harbor-jobservice - Manage Harbor job service (admin only)
+harbor-jobservice-workers-list - List workers in a pool
 
 
 .SH SYNOPSIS
-\fBharbor jobservice [flags]\fP
+\fBharbor jobservice workers list [pool-id] [flags]\fP
 
 
 .SH DESCRIPTION
-Manage Harbor job service components including worker pools, job queues, schedules, and job logs.
-This requires system admin privileges.
-
-.PP
-Use "harbor jobservice [command] --help" for detailed examples and flags per subcommand.
+Display all workers in the specified Harbor jobservice worker pool. Requires system admin privileges.
 
 
 .SH OPTIONS
 \fB-h\fP, \fB--help\fP[=false]
-	help for jobservice
+	help for list
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
@@ -39,5 +35,11 @@ Use "harbor jobservice [command] --help" for detailed examples and flags per sub
 	verbose output
 
 
+.SH EXAMPLE
+.EX
+harbor jobservice workers list <pool-id>
+.EE
+
+
 .SH SEE ALSO
-\fBharbor(1)\fP, \fBharbor-jobservice-pools(1)\fP, \fBharbor-jobservice-queues(1)\fP, \fBharbor-jobservice-workers(1)\fP
+\fBharbor-jobservice-workers(1)\fP

--- a/doc/man-docs/man1/harbor-jobservice-workers.1
+++ b/doc/man-docs/man1/harbor-jobservice-workers.1
@@ -2,24 +2,20 @@
 .TH "HARBOR" "1"  "Harbor Community" "Harbor User Manuals"
 
 .SH NAME
-harbor-jobservice - Manage Harbor job service (admin only)
+harbor-jobservice-workers - Manage workers
 
 
 .SH SYNOPSIS
-\fBharbor jobservice [flags]\fP
+\fBharbor jobservice workers [flags]\fP
 
 
 .SH DESCRIPTION
-Manage Harbor job service components including worker pools, job queues, schedules, and job logs.
-This requires system admin privileges.
-
-.PP
-Use "harbor jobservice [command] --help" for detailed examples and flags per subcommand.
+Manage Harbor jobservice workers inside a worker pool. Requires system admin privileges.
 
 
 .SH OPTIONS
 \fB-h\fP, \fB--help\fP[=false]
-	help for jobservice
+	help for workers
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
@@ -40,4 +36,4 @@ Use "harbor jobservice [command] --help" for detailed examples and flags per sub
 
 
 .SH SEE ALSO
-\fBharbor(1)\fP, \fBharbor-jobservice-pools(1)\fP, \fBharbor-jobservice-queues(1)\fP, \fBharbor-jobservice-workers(1)\fP
+\fBharbor-jobservice(1)\fP, \fBharbor-jobservice-workers-list(1)\fP

--- a/pkg/api/jobservice_handler.go
+++ b/pkg/api/jobservice_handler.go
@@ -34,6 +34,38 @@ func ListJobQueues() (*jobservice.ListJobQueuesOK, error) {
 	return response, nil
 }
 
+// GetWorkerPools retrieves all worker pools
+func GetWorkerPools() (*jobservice.GetWorkerPoolsOK, error) {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := client.Jobservice.GetWorkerPools(ctx, &jobservice.GetWorkerPoolsParams{})
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+// GetWorkers retrieves workers for a given pool
+func GetWorkers(poolID string) (*jobservice.GetWorkersOK, error) {
+	ctx, client, err := utils.ContextWithClient()
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := client.Jobservice.GetWorkers(ctx, &jobservice.GetWorkersParams{
+		PoolID: poolID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
 // ActionJobQueue performs an action on a job queue (stop/pause/resume)
 func ActionJobQueue(jobType, action string) error {
 	ctx, client, err := utils.ContextWithClient()

--- a/pkg/api/jobservice_handler_test.go
+++ b/pkg/api/jobservice_handler_test.go
@@ -1,0 +1,123 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package api
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
+	v2client "github.com/goharbor/go-client/pkg/sdk/v2.0/client"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/jobservice"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/goharbor/harbor-cli/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+type stubJobserviceTransport struct {
+	result interface{}
+	err    error
+}
+
+func (s *stubJobserviceTransport) Submit(op *runtime.ClientOperation) (interface{}, error) {
+	return s.result, s.err
+}
+
+func injectJobserviceClient(t *testing.T, result interface{}, callErr error) {
+	t.Helper()
+
+	origInstance := utils.ClientInstance
+	origErr := utils.ClientErr
+	t.Cleanup(func() {
+		utils.ClientInstance = origInstance
+		utils.ClientErr = origErr
+	})
+
+	utils.ClientInstance = &v2client.HarborAPI{
+		Jobservice: jobservice.New(&stubJobserviceTransport{result: result, err: callErr}, strfmt.Default, nil),
+	}
+	utils.ClientErr = nil
+	utils.ClientOnce.Do(func() {})
+}
+
+func TestGetWorkerPools_Success(t *testing.T) {
+	payload := []*models.WorkerPool{
+		{WorkerPoolID: "pool-abc123", Host: "10.0.0.1:8080", Pid: 12345, Concurrency: 10},
+	}
+	injectJobserviceClient(t, &jobservice.GetWorkerPoolsOK{Payload: payload}, nil)
+
+	response, err := GetWorkerPools()
+
+	assert.NoError(t, err)
+	assert.NotNil(t, response)
+	assert.Equal(t, payload, response.Payload)
+}
+
+func TestGetWorkerPools_CallError(t *testing.T) {
+	injectJobserviceClient(t, nil, errors.New("boom"))
+
+	response, err := GetWorkerPools()
+
+	assert.Error(t, err)
+	assert.Nil(t, response)
+	assert.Contains(t, err.Error(), "boom")
+}
+
+func TestGetWorkers_Success(t *testing.T) {
+	payload := []*models.Worker{
+		{ID: "worker-1", PoolID: "pool-abc123", JobID: "job-9", JobName: "REPLICATE"},
+	}
+	injectJobserviceClient(t, &jobservice.GetWorkersOK{Payload: payload}, nil)
+
+	response, err := GetWorkers("pool-abc123")
+
+	assert.NoError(t, err)
+	assert.NotNil(t, response)
+	assert.Equal(t, payload, response.Payload)
+}
+
+func TestGetWorkers_CallError(t *testing.T) {
+	injectJobserviceClient(t, nil, &jobservice.GetWorkersUnauthorized{})
+
+	response, err := GetWorkers("pool-abc123")
+
+	assert.Error(t, err)
+	assert.Nil(t, response)
+	assert.Contains(t, err.Error(), "Unauthorized")
+}
+
+func TestGetWorkerPools_ClientInitError(t *testing.T) {
+	origInstance := utils.ClientInstance
+	origErr := utils.ClientErr
+	t.Cleanup(func() {
+		utils.ClientInstance = origInstance
+		utils.ClientErr = origErr
+	})
+
+	utils.ClientOnce.Do(func() {})
+	utils.ClientInstance = nil
+	utils.ClientErr = errors.New("no credentials")
+
+	response, err := GetWorkerPools()
+	assert.Error(t, err)
+	assert.Nil(t, response)
+	assert.Contains(t, err.Error(), "no credentials")
+
+	utils.ClientErr = errors.New("no credentials")
+	workerResponse, workerErr := GetWorkers("pool-abc123")
+	assert.Error(t, workerErr)
+	assert.Nil(t, workerResponse)
+	assert.Contains(t, workerErr.Error(), "no credentials")
+}

--- a/pkg/views/jobservice/pools/view.go
+++ b/pkg/views/jobservice/pools/view.go
@@ -1,0 +1,40 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pools
+
+import (
+	"fmt"
+
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+)
+
+// ListPools displays worker pools in a formatted table.
+func ListPools(items []*models.WorkerPool) {
+	if len(items) == 0 {
+		fmt.Println("No worker pools found.")
+		return
+	}
+
+	fmt.Printf("%-36s %-20s %-10s %-20s %-20s\n", "POOL_ID", "HOST", "PID", "CONCURRENCY", "START_AT")
+	fmt.Printf("%-36s %-20s %-10s %-20s %-20s\n", "-------", "----", "---", "-----------", "--------")
+
+	for _, p := range items {
+		if p == nil {
+			continue
+		}
+		fmt.Printf("%-36s %-20s %-10d %-20d %-20s\n", p.WorkerPoolID, p.Host, p.Pid, p.Concurrency, p.StartAt.String())
+	}
+
+	fmt.Printf("\nTotal: %d pool(s)\n", len(items))
+}

--- a/pkg/views/jobservice/pools/view_test.go
+++ b/pkg/views/jobservice/pools/view_test.go
@@ -37,7 +37,7 @@ func captureStdout(t *testing.T, fn func()) string {
 	fn()
 	w.Close()
 	os.Stdout = oldStdout
-	io.Copy(&buf, r)
+	_, _ = io.Copy(&buf, r)
 
 	return buf.String()
 }

--- a/pkg/views/jobservice/pools/view_test.go
+++ b/pkg/views/jobservice/pools/view_test.go
@@ -1,0 +1,86 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pools
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+
+	os.Stdout = w
+	fn()
+	w.Close()
+	os.Stdout = oldStdout
+	io.Copy(&buf, r)
+
+	return buf.String()
+}
+
+func TestListPools_NoPools(t *testing.T) {
+	out := captureStdout(t, func() {
+		ListPools([]*models.WorkerPool{})
+	})
+
+	assert.Contains(t, out, "No worker pools found.")
+}
+
+func TestListPools_WithPools(t *testing.T) {
+	pools := []*models.WorkerPool{
+		{WorkerPoolID: "pool-abc123", Host: "10.0.0.1:8080", Pid: 12345, Concurrency: 10},
+		{WorkerPoolID: "pool-def456", Host: "10.0.0.2:8080", Pid: 54321, Concurrency: 20},
+	}
+
+	out := captureStdout(t, func() {
+		ListPools(pools)
+	})
+
+	assert.Contains(t, out, "POOL_ID")
+	assert.Contains(t, out, "HOST")
+	assert.Contains(t, out, "PID")
+	assert.Contains(t, out, "CONCURRENCY")
+	assert.Contains(t, out, "START_AT")
+	assert.Contains(t, out, "pool-abc123")
+	assert.Contains(t, out, "10.0.0.1:8080")
+	assert.Contains(t, out, "pool-def456")
+	assert.Contains(t, out, "Total: 2 pool(s)")
+}
+
+func TestListPools_NilEntrySkipped(t *testing.T) {
+	pools := []*models.WorkerPool{
+		nil,
+		{WorkerPoolID: "pool-abc123", Host: "10.0.0.1:8080", Pid: 12345, Concurrency: 10},
+	}
+
+	out := captureStdout(t, func() {
+		ListPools(pools)
+	})
+
+	assert.Contains(t, out, "pool-abc123")
+	assert.Contains(t, out, "Total: 2 pool(s)")
+}

--- a/pkg/views/jobservice/workers/view.go
+++ b/pkg/views/jobservice/workers/view.go
@@ -1,0 +1,40 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package workers
+
+import (
+	"fmt"
+
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+)
+
+// ListWorkers displays workers in a formatted table.
+func ListWorkers(items []*models.Worker) {
+	if len(items) == 0 {
+		fmt.Println("No workers found.")
+		return
+	}
+
+	fmt.Printf("%-36s %-36s %-15s %-20s\n", "WORKER_ID", "POOL_ID", "JOB_ID", "JOB_NAME")
+	fmt.Printf("%-36s %-36s %-15s %-20s\n", "---------", "-------", "------", "--------")
+
+	for _, w := range items {
+		if w == nil {
+			continue
+		}
+		fmt.Printf("%-36s %-36s %-15s %-20s\n", w.ID, w.PoolID, w.JobID, w.JobName)
+	}
+
+	fmt.Printf("\nTotal: %d worker(s)\n", len(items))
+}

--- a/pkg/views/jobservice/workers/view_test.go
+++ b/pkg/views/jobservice/workers/view_test.go
@@ -37,7 +37,7 @@ func captureStdout(t *testing.T, fn func()) string {
 	fn()
 	w.Close()
 	os.Stdout = oldStdout
-	io.Copy(&buf, r)
+	_, _ = io.Copy(&buf, r)
 
 	return buf.String()
 }

--- a/pkg/views/jobservice/workers/view_test.go
+++ b/pkg/views/jobservice/workers/view_test.go
@@ -1,0 +1,85 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package workers
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+
+	os.Stdout = w
+	fn()
+	w.Close()
+	os.Stdout = oldStdout
+	io.Copy(&buf, r)
+
+	return buf.String()
+}
+
+func TestListWorkers_NoWorkers(t *testing.T) {
+	out := captureStdout(t, func() {
+		ListWorkers([]*models.Worker{})
+	})
+
+	assert.Contains(t, out, "No workers found.")
+}
+
+func TestListWorkers_WithWorkers(t *testing.T) {
+	workers := []*models.Worker{
+		{ID: "worker-1", PoolID: "pool-abc123", JobID: "job-9", JobName: "REPLICATE"},
+		{ID: "worker-2", PoolID: "pool-abc123", JobID: "job-10", JobName: "RETENTION"},
+	}
+
+	out := captureStdout(t, func() {
+		ListWorkers(workers)
+	})
+
+	assert.Contains(t, out, "WORKER_ID")
+	assert.Contains(t, out, "POOL_ID")
+	assert.Contains(t, out, "JOB_ID")
+	assert.Contains(t, out, "JOB_NAME")
+	assert.Contains(t, out, "worker-1")
+	assert.Contains(t, out, "job-9")
+	assert.Contains(t, out, "REPLICATE")
+	assert.Contains(t, out, "Total: 2 worker(s)")
+}
+
+func TestListWorkers_NilEntrySkipped(t *testing.T) {
+	workers := []*models.Worker{
+		nil,
+		{ID: "worker-1", PoolID: "pool-abc123", JobID: "job-9", JobName: "REPLICATE"},
+	}
+
+	out := captureStdout(t, func() {
+		ListWorkers(workers)
+	})
+
+	assert.Contains(t, out, "worker-1")
+	assert.Contains(t, out, "Total: 2 worker(s)")
+}


### PR DESCRIPTION
## Summary
Implements the first read-only slice of the Jobservice Dashboard from tracker #737 (sub-issue #791).

Adds two missing commands that are currently dashboard-only:
- harbor jobservice pools list
- harbor jobservice workers list <pool-id>

Both are admin-only and reuse the existing go-client jobservice API.

## Tracker
- Parent tracker: #737
- Sub-issue: #791
- This PR covers the pools/workers discovery part of #791. Queues were already implemented.

## Changes
- pkg/api/jobservice_handler.go: add GetWorkerPools() -> GET /jobservice/pools and GetWorkers(poolID) -> GET /jobservice/pools/{pool_id}/workers.
- pkg/views/jobservice/pools/view.go / workers/view.go: table views (POOL_ID HOST PID CONCURRENCY START_AT and WORKER_ID POOL_ID JOB_ID JOB_NAME).
- cmd/harbor/root/jobservice/pools and workers: Cobra parents + list subcommands with --output-format (json/yaml/csv) and error handling via FormatScheduleError for 401/403.
- cmd/harbor/root/jobservice/cmd.go: wire pools and workers into jobservice.

## Testing
- gofmt -s -w / go vet ./... / go test ./... pass
- go build and verified: harbor jobservice --help now shows pools and workers

## Notes
- No breaking change, no new dependencies.
- Follows existing pattern from queues list.

Refs: #737
Related: #791
