### PR TITLE
Refactor/slog

### DIFF
--- a/cmd/harbor/root/artifact/delete.go
+++ b/cmd/harbor/root/artifact/delete.go
@@ -41,7 +41,10 @@ func DeleteArtifactCommand() *cobra.Command {
 				if err != nil {
 					slog.Error(fmt.Sprintf("failed to get project name: %v", utils.ParseHarborErrorMsg(err)))
 				}
-				repoName = prompt.GetRepoNameFromUser(projectName)
+				repoName, err = prompt.GetRepoNameFromUser(projectName)
+				if err != nil {
+					return fmt.Errorf("failed to get repository name: %v", utils.ParseHarborErrorMsg(err))
+				}
 				reference = prompt.GetReferenceFromUser(repoName, projectName)
 			}
 			err = api.DeleteArtifact(projectName, repoName, reference)

--- a/cmd/harbor/root/artifact/delete.go
+++ b/cmd/harbor/root/artifact/delete.go
@@ -15,7 +15,6 @@ package artifact
 
 import (
 	"fmt"
-	"log/slog"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
@@ -39,7 +38,7 @@ func DeleteArtifactCommand() *cobra.Command {
 			} else {
 				projectName, err = prompt.GetProjectNameFromUser()
 				if err != nil {
-					slog.Error(fmt.Sprintf("failed to get project name: %v", utils.ParseHarborErrorMsg(err)))
+					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
 				}
 				repoName, err = prompt.GetRepoNameFromUser(projectName)
 				if err != nil {

--- a/cmd/harbor/root/artifact/delete.go
+++ b/cmd/harbor/root/artifact/delete.go
@@ -15,11 +15,11 @@ package artifact
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -39,7 +39,7 @@ func DeleteArtifactCommand() *cobra.Command {
 			} else {
 				projectName, err = prompt.GetProjectNameFromUser()
 				if err != nil {
-					log.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
+					slog.Error(fmt.Sprintf("failed to get project name: %v", utils.ParseHarborErrorMsg(err)))
 				}
 				repoName = prompt.GetRepoNameFromUser(projectName)
 				reference = prompt.GetReferenceFromUser(repoName, projectName)

--- a/cmd/harbor/root/artifact/label/add.go
+++ b/cmd/harbor/root/artifact/label/add.go
@@ -61,7 +61,10 @@ Examples:
 				if err != nil {
 					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
 				}
-				repoName = prompt.GetRepoNameFromUser(projectName)
+				repoName, err = prompt.GetRepoNameFromUser(projectName)
+				if err != nil {
+					return fmt.Errorf("failed to get repository name: %v", utils.ParseHarborErrorMsg(err))
+				}
 				reference = prompt.GetReferenceFromUser(repoName, projectName)
 			}
 			if isProject {

--- a/cmd/harbor/root/artifact/label/delete.go
+++ b/cmd/harbor/root/artifact/label/delete.go
@@ -62,7 +62,10 @@ Examples:
 				if err != nil {
 					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
 				}
-				repoName = prompt.GetRepoNameFromUser(projectName)
+				repoName, err = prompt.GetRepoNameFromUser(projectName)
+				if err != nil {
+					return fmt.Errorf("failed to get repository name: %v", utils.ParseHarborErrorMsg(err))
+				}
 				reference = prompt.GetReferenceFromUser(repoName, projectName)
 			}
 			if isProject {

--- a/cmd/harbor/root/artifact/label/list.go
+++ b/cmd/harbor/root/artifact/label/list.go
@@ -62,7 +62,10 @@ Supports output formatting such as JSON or YAML using the --output (-o) flag.`,
 				if err != nil {
 					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
 				}
-				repoName = prompt.GetRepoNameFromUser(projectName)
+				repoName, err = prompt.GetRepoNameFromUser(projectName)
+				if err != nil {
+					return fmt.Errorf("failed to get repository name: %v", utils.ParseHarborErrorMsg(err))
+				}
 				reference = prompt.GetReferenceFromUser(repoName, projectName)
 			}
 

--- a/cmd/harbor/root/artifact/list.go
+++ b/cmd/harbor/root/artifact/list.go
@@ -60,7 +60,10 @@ Supports pagination, search queries, and sorting using flags.`,
 				if err != nil {
 					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
 				}
-				repoName = prompt.GetRepoNameFromUser(projectName)
+				repoName, err = prompt.GetRepoNameFromUser(projectName)
+				if err != nil {
+					return fmt.Errorf("failed to get repository name: %v", utils.ParseHarborErrorMsg(err))
+				}
 			}
 
 			artifacts, err = api.ListArtifact(projectName, repoName, opts)

--- a/cmd/harbor/root/artifact/scan/scan.go
+++ b/cmd/harbor/root/artifact/scan/scan.go
@@ -44,7 +44,10 @@ func parseArgs(args []string) (string, string, string, error) {
 		if err != nil {
 			return "", "", "", err
 		}
-		repoName := prompt.GetRepoNameFromUser(projectName)
+		repoName, err := prompt.GetRepoNameFromUser(projectName)
+		if err != nil {
+			return "", "", "", err
+		}
 		reference := prompt.GetReferenceFromUser(repoName, projectName)
 
 		return projectName, repoName, reference, nil

--- a/cmd/harbor/root/artifact/tags/create.go
+++ b/cmd/harbor/root/artifact/tags/create.go
@@ -46,9 +46,14 @@ func CreateTagsCmd() *cobra.Command {
 					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
 				}
 
-				repoName = prompt.GetRepoNameFromUser(projectName)
+				repoName, err = prompt.GetRepoNameFromUser(projectName)
+				if err != nil {
+					return fmt.Errorf("failed to get repository name: %v", utils.ParseHarborErrorMsg(err))
+				}
 				reference = prompt.GetReferenceFromUser(repoName, projectName)
-				create.CreateTagView(&tagName)
+				if err := create.CreateTagView(&tagName); err != nil {
+					return err
+				}
 			}
 			err = api.CreateTag(projectName, repoName, reference, tagName)
 			if err != nil {

--- a/cmd/harbor/root/artifact/tags/delete.go
+++ b/cmd/harbor/root/artifact/tags/delete.go
@@ -44,7 +44,10 @@ func DeleteTagsCmd() *cobra.Command {
 					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
 				}
 
-				repoName = prompt.GetRepoNameFromUser(projectName)
+				repoName, err = prompt.GetRepoNameFromUser(projectName)
+				if err != nil {
+					return fmt.Errorf("failed to get repository name: %v", utils.ParseHarborErrorMsg(err))
+				}
 				reference = prompt.GetReferenceFromUser(repoName, projectName)
 				tagName = prompt.GetTagFromUser(repoName, projectName, reference)
 			}

--- a/cmd/harbor/root/artifact/tags/list.go
+++ b/cmd/harbor/root/artifact/tags/list.go
@@ -47,7 +47,10 @@ func ListTagsCmd() *cobra.Command {
 					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
 				}
 
-				repoName = prompt.GetRepoNameFromUser(projectName)
+				repoName, err = prompt.GetRepoNameFromUser(projectName)
+				if err != nil {
+					return fmt.Errorf("failed to get repository name: %v", utils.ParseHarborErrorMsg(err))
+				}
 				if repoName == "" {
 					return fmt.Errorf("invalid repository name provided")
 				}

--- a/cmd/harbor/root/artifact/view.go
+++ b/cmd/harbor/root/artifact/view.go
@@ -46,7 +46,10 @@ func ViewArtifactCommmand() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
 				}
-				repoName = prompt.GetRepoNameFromUser(projectName)
+				repoName, err = prompt.GetRepoNameFromUser(projectName)
+				if err != nil {
+					return fmt.Errorf("failed to get repository name: %v", utils.ParseHarborErrorMsg(err))
+				}
 				reference = prompt.GetReferenceFromUser(repoName, projectName)
 			}
 

--- a/cmd/harbor/root/cmd.go
+++ b/cmd/harbor/root/cmd.go
@@ -76,7 +76,9 @@ harbor help
 			// Determine if --config was explicitly set
 			userSpecifiedConfig := cmd.Flags().Changed("config")
 			// Initialize configuration
-			utils.InitConfig(cfgFile, userSpecifiedConfig)
+			if err := utils.InitConfig(cfgFile, userSpecifiedConfig); err != nil {
+				return err
+			}
 
 			// Logging Flags
 			arr := make([]any, 0) // slog requires any since the slog.Debug takes in (string, ...any)

--- a/cmd/harbor/root/cmd.go
+++ b/cmd/harbor/root/cmd.go
@@ -66,17 +66,17 @@ harbor
 harbor help
 `,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			// Determine if --config was explicitly set
-			userSpecifiedConfig := cmd.Flags().Changed("config")
-			// Initialize configuration
-			utils.InitConfig(cfgFile, userSpecifiedConfig)
-
 			if logFormat != "json" && logFormat != "text" {
 				return fmt.Errorf("invalid log-format: %s, log-format can be one of: json|text", logFormat)
 			}
 
-			// Sets up logging
+			// Sets up logging before anything else logs
 			logger.Setup(verbose, logFormat)
+
+			// Determine if --config was explicitly set
+			userSpecifiedConfig := cmd.Flags().Changed("config")
+			// Initialize configuration
+			utils.InitConfig(cfgFile, userSpecifiedConfig)
 
 			// Logging Flags
 			arr := make([]any, 0) // slog requires any since the slog.Debug takes in (string, ...any)

--- a/cmd/harbor/root/context/delete.go
+++ b/cmd/harbor/root/context/delete.go
@@ -111,7 +111,7 @@ If you specify --name, that credential (rather than the "current" one) will be u
 
 			// 5. Confirm to the user (no error here)
 			canonicalPath := strings.Join(actualSegments, ".")
-			slog.Info(fmt.Sprintf("Successfully cleared %s", canonicalPath))
+			fmt.Printf("Successfully cleared %s\n", canonicalPath)
 
 			return nil
 		},

--- a/cmd/harbor/root/context/delete.go
+++ b/cmd/harbor/root/context/delete.go
@@ -15,11 +15,11 @@ package context
 
 import (
 	"fmt"
+	"log/slog"
 	"reflect"
 	"strings"
 
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -81,9 +81,9 @@ If you specify --name, that credential (rather than the "current" one) will be u
 				}
 
 				if found {
-					logrus.Debugf("Removed credential '%s' and cleared CurrentCredentialName", currentName)
+					slog.Debug(fmt.Sprintf("Removed credential '%s' and cleared CurrentCredentialName", currentName))
 				} else {
-					logrus.Debugf("No credential named '%s' found; cleared CurrentCredentialName anyway", currentName)
+					slog.Debug(fmt.Sprintf("No credential named '%s' found; cleared CurrentCredentialName anyway", currentName))
 				}
 
 				return nil
@@ -111,7 +111,7 @@ If you specify --name, that credential (rather than the "current" one) will be u
 
 			// 5. Confirm to the user (no error here)
 			canonicalPath := strings.Join(actualSegments, ".")
-			logrus.Infof("Successfully cleared %s", canonicalPath)
+			slog.Info(fmt.Sprintf("Successfully cleared %s", canonicalPath))
 
 			return nil
 		},

--- a/cmd/harbor/root/context/update.go
+++ b/cmd/harbor/root/context/update.go
@@ -15,12 +15,12 @@ package context
 
 import (
 	"fmt"
+	"log/slog"
 	"reflect"
 	"strconv"
 	"strings"
 
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -67,7 +67,7 @@ If you specify --name, that credential (rather than the "current" one) will be u
 				return fmt.Errorf("failed to save updated config: %w", err)
 			}
 
-			// 5. Confirm to the user (logrus.Info is fine here; no error)
+			// 5. Confirm to the user (slog.Info is fine here; no error)
 			canonicalPath := strings.Join(actualSegments, ".")
 			fmt.Printf("Successfully updated %s to '%s'\n", canonicalPath, newValue)
 			return nil
@@ -250,7 +250,7 @@ func encryptPassword(plaintext string) (string, error) {
 	// Make sure a key exists
 	if err := utils.GenerateEncryptionKey(); err != nil {
 		// It's okay if the key already exists; that might not be a fatal error for you
-		logrus.Debugf("Encryption key might already exist: %v", err)
+		slog.Debug("Encryption key might already exist", "error", err)
 	}
 
 	key, err := utils.GetEncryptionKey()

--- a/cmd/harbor/root/cve/add.go
+++ b/cmd/harbor/root/cve/add.go
@@ -57,6 +57,8 @@ func updatecveView(updateView *update.UpdateView) error {
 		updateView = &update.UpdateView{}
 	}
 
-	update.UpdateCveView(updateView)
+	if err := update.UpdateCveView(updateView); err != nil {
+		return err
+	}
 	return api.UpdateSystemCve(*updateView)
 }

--- a/cmd/harbor/root/info.go
+++ b/cmd/harbor/root/info.go
@@ -15,12 +15,12 @@ package root
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/goharbor/harbor-cli/cmd/harbor/internal/version"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/info/list"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -75,7 +75,7 @@ The output can be formatted as table (default), JSON, or YAML using the '--outpu
 			if FormatFlag != "" {
 				err = utils.PrintFormat(systemInfo, FormatFlag)
 				if err != nil {
-					log.Error(err)
+					slog.Error(err.Error())
 				}
 			} else {
 				list.ListInfo(&systemInfo)

--- a/cmd/harbor/root/info.go
+++ b/cmd/harbor/root/info.go
@@ -15,7 +15,6 @@ package root
 
 import (
 	"fmt"
-	"log/slog"
 
 	"github.com/goharbor/harbor-cli/cmd/harbor/internal/version"
 	"github.com/goharbor/harbor-cli/pkg/api"
@@ -75,7 +74,7 @@ The output can be formatted as table (default), JSON, or YAML using the '--outpu
 			if FormatFlag != "" {
 				err = utils.PrintFormat(systemInfo, FormatFlag)
 				if err != nil {
-					slog.Error(err.Error())
+					return err
 				}
 			} else {
 				list.ListInfo(&systemInfo)

--- a/cmd/harbor/root/instance/ping.go
+++ b/cmd/harbor/root/instance/ping.go
@@ -15,11 +15,11 @@ package instance
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -45,17 +45,17 @@ an instance from a list of available instances.`,
 			}
 
 			if len(args) > 0 {
-				log.Debugf("Instance name provided: %s", args[0])
+				slog.Debug(fmt.Sprintf("Instance name provided: %s", args[0]))
 				instanceName = args[0]
 			} else {
-				log.Debug("No instance name provided, prompting user")
+				slog.Debug("No instance name provided, prompting user")
 				instanceName, err = prompt.GetInstanceNameFromUser()
 				if err != nil {
 					return fmt.Errorf("failed to get instance name: %v", utils.ParseHarborErrorMsg(err))
 				}
 			}
 
-			log.Debugf("Pinging instance: %s", instanceName)
+			slog.Debug(fmt.Sprintf("Pinging instance: %s", instanceName))
 			response, err := api.PingInstance(instanceName, useInstanceID)
 			if err != nil {
 				if utils.ParseHarborErrorCode(err) == "404" {

--- a/cmd/harbor/root/instance/view.go
+++ b/cmd/harbor/root/instance/view.go
@@ -15,13 +15,13 @@ package instance
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/preheat"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/instance/view"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -47,17 +47,17 @@ an instance from a list of available instances.`,
 			}
 
 			if len(args) > 0 {
-				log.Debugf("Instance name provided: %s", args[0])
+				slog.Debug(fmt.Sprintf("Instance name provided: %s", args[0]))
 				instanceName = args[0]
 			} else {
-				log.Debug("No instance name provided, prompting user")
+				slog.Debug("No instance name provided, prompting user")
 				instanceName, err = prompt.GetInstanceNameFromUser()
 				if err != nil {
 					return fmt.Errorf("failed to get instance name: %v", utils.ParseHarborErrorMsg(err))
 				}
 			}
 
-			log.Debugf("Fetching instance: %s", instanceName)
+			slog.Debug(fmt.Sprintf("Fetching instance: %s", instanceName))
 			instance, err = api.GetInstance(instanceName, isID)
 			if err != nil {
 				if utils.ParseHarborErrorCode(err) == "404" {

--- a/cmd/harbor/root/labels/create.go
+++ b/cmd/harbor/root/labels/create.go
@@ -80,7 +80,9 @@ func createLabelView(createView *create.CreateView, flags *pflag.FlagSet) error 
 		createView = &create.CreateView{}
 	}
 
-	create.CreateLabelView(createView)
+	if err := create.CreateLabelView(createView); err != nil {
+		return err
+	}
 
 	if createView.Scope == "p" && !flags.Changed("project") {
 		projectID, err := prompt.GetProjectIDFromUser()

--- a/cmd/harbor/root/labels/list.go
+++ b/cmd/harbor/root/labels/list.go
@@ -15,11 +15,12 @@ package labels
 
 import (
 	"fmt"
+	"log/slog"
+	"os"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/label/list"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -80,14 +81,15 @@ func ListLabelCommand() *cobra.Command {
 
 			label, err := api.ListLabel(opts)
 			if err != nil {
-				log.Fatalf("failed to get label list: %v", err)
+				slog.Error("failed to get label list", "error", err)
+				os.Exit(1)
 			}
 
 			formatFlag := viper.GetString("output-format")
 			if formatFlag != "" {
 				err = utils.PrintFormat(label, formatFlag)
 				if err != nil {
-					log.Error(err)
+					slog.Error(err.Error())
 				}
 			} else {
 				list.ListLabels(label.Payload)

--- a/cmd/harbor/root/labels/list.go
+++ b/cmd/harbor/root/labels/list.go
@@ -16,7 +16,6 @@ package labels
 import (
 	"fmt"
 	"log/slog"
-	"os"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
@@ -81,8 +80,7 @@ func ListLabelCommand() *cobra.Command {
 
 			label, err := api.ListLabel(opts)
 			if err != nil {
-				slog.Error("failed to get label list", "error", err)
-				os.Exit(1)
+				return fmt.Errorf("failed to get label list: %v", err)
 			}
 
 			formatFlag := viper.GetString("output-format")

--- a/cmd/harbor/root/labels/list.go
+++ b/cmd/harbor/root/labels/list.go
@@ -15,7 +15,6 @@ package labels
 
 import (
 	"fmt"
-	"log/slog"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
@@ -87,7 +86,7 @@ func ListLabelCommand() *cobra.Command {
 			if formatFlag != "" {
 				err = utils.PrintFormat(label, formatFlag)
 				if err != nil {
-					slog.Error(err.Error())
+					return err
 				}
 			} else {
 				list.ListLabels(label.Payload)

--- a/cmd/harbor/root/labels/update.go
+++ b/cmd/harbor/root/labels/update.go
@@ -94,7 +94,9 @@ func UpdateLableCommand() *cobra.Command {
 				updateView.Scope = opts.Scope
 			}
 
-			update.UpdateLabelView(updateView)
+			if err := update.UpdateLabelView(updateView); err != nil {
+				return err
+			}
 			err = api.UpdateLabel(updateView, labelId)
 			if err != nil {
 				return fmt.Errorf("failed to update label: %v", err)

--- a/cmd/harbor/root/login.go
+++ b/cmd/harbor/root/login.go
@@ -121,7 +121,9 @@ func CreateLoginView(loginView *login.LoginView) error {
 			Name:     "",
 		}
 	}
-	login.CreateView(loginView)
+	if err := login.CreateView(loginView); err != nil {
+		return err
+	}
 
 	return RunLogin(*loginView)
 }
@@ -185,8 +187,7 @@ func RunLogin(opts login.LoginView) error {
 			} else {
 				slog.Warn("Credentials already exist in the config file but the password is different. Updating the password.")
 				if err = utils.UpdateCredentialsInConfigFile(cred, configPath); err != nil {
-					slog.Error("failed to update the credential", "error", err)
-					os.Exit(1)
+					return fmt.Errorf("failed to update the credential: %v", err)
 				}
 				fmt.Printf("Login successful for %s at %s\n", opts.Username, opts.Server)
 				return nil
@@ -194,8 +195,7 @@ func RunLogin(opts login.LoginView) error {
 		} else {
 			slog.Warn("Credentials already exist in the config file but more than one field was different. Updating the credentials.")
 			if err = utils.UpdateCredentialsInConfigFile(cred, configPath); err != nil {
-				slog.Error("failed to update the credential", "error", err)
-				os.Exit(1)
+				return fmt.Errorf("failed to update the credential: %v", err)
 			}
 			fmt.Printf("Login successful for %s at %s\n", opts.Username, opts.Server)
 			return nil

--- a/cmd/harbor/root/login.go
+++ b/cmd/harbor/root/login.go
@@ -16,6 +16,7 @@ package root
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 
@@ -26,7 +27,6 @@ import (
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/user"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/login"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -174,26 +174,28 @@ func RunLogin(opts login.LoginView) error {
 		return fmt.Errorf("failed to get current harbor data: %s", err)
 	}
 	configPath := harborData.ConfigPath
-	log.Debugf("Checking if credentials already exist in the config file...")
+	slog.Debug("Checking if credentials already exist in the config file...")
 	existingCred, err := utils.GetCredentials(opts.Name)
 	if err == nil {
 		if existingCred.Username == opts.Username && existingCred.ServerAddress == opts.Server {
 			if existingCred.Password == encryptedPassword {
-				log.Warn("Credentials already exist in the config file. They were not added again.")
+				slog.Warn("Credentials already exist in the config file. They were not added again.")
 				fmt.Printf("Login successful for %s at %s\n", opts.Username, opts.Server)
 				return nil
 			} else {
-				log.Warn("Credentials already exist in the config file but the password is different. Updating the password.")
+				slog.Warn("Credentials already exist in the config file but the password is different. Updating the password.")
 				if err = utils.UpdateCredentialsInConfigFile(cred, configPath); err != nil {
-					log.Fatalf("failed to update the credential: %s", err)
+					slog.Error("failed to update the credential", "error", err)
+					os.Exit(1)
 				}
 				fmt.Printf("Login successful for %s at %s\n", opts.Username, opts.Server)
 				return nil
 			}
 		} else {
-			log.Warn("Credentials already exist in the config file but more than one field was different. Updating the credentials.")
+			slog.Warn("Credentials already exist in the config file but more than one field was different. Updating the credentials.")
 			if err = utils.UpdateCredentialsInConfigFile(cred, configPath); err != nil {
-				log.Fatalf("failed to update the credential: %s", err)
+				slog.Error("failed to update the credential", "error", err)
+				os.Exit(1)
 			}
 			fmt.Printf("Login successful for %s at %s\n", opts.Username, opts.Server)
 			return nil
@@ -203,7 +205,7 @@ func RunLogin(opts login.LoginView) error {
 	if err = utils.AddCredentialsToConfigFile(cred, configPath); err != nil {
 		return fmt.Errorf("failed to store the credential: %s", err)
 	}
-	log.Debugf("Credentials successfully added to the config file.")
+	slog.Debug("Credentials successfully added to the config file.")
 	fmt.Printf("Login successful for %s at %s\n", opts.Username, opts.Server)
 	return nil
 }

--- a/cmd/harbor/root/logs.go
+++ b/cmd/harbor/root/logs.go
@@ -15,6 +15,7 @@ package root
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 	"time"
@@ -23,12 +24,11 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	list "github.com/goharbor/harbor-cli/pkg/views/logs"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
-var logsLogger = log.New()
+var logsLogger = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
 func Logs() *cobra.Command {
 	var opts api.ListFlags
@@ -84,7 +84,7 @@ harbor-cli logs --output-format json`,
 
 			formatFlag := viper.GetString("output-format")
 			if formatFlag != "" {
-				log.WithField("output_format", formatFlag).Debug("Output format selected")
+				slog.Debug("Output format selected", "output_format", formatFlag)
 				err = utils.PrintFormat(logs.Payload, formatFlag)
 				if err != nil {
 					return err
@@ -117,20 +117,12 @@ harbor-cli logs --output-format json`,
 func followLogs(opts api.ListFlags, interval time.Duration) {
 	var lastLogTime *time.Time
 
-	logsLogger.SetFormatter(&log.TextFormatter{
-		FullTimestamp:   true,
-		TimestampFormat: "2006-01-02 15:04:05",
-		DisableColors:   false,
-	})
-	logsLogger.SetLevel(log.InfoLevel)
-	logsLogger.SetOutput(os.Stdout)
-
 	fmt.Println("Following Harbor audit logs... (Press Ctrl+C to stop)")
 
 	for {
 		logs, err := api.AuditLogs(opts)
 		if err != nil {
-			log.Errorf("failed to retrieve audit logs: %v", err)
+			slog.Error("failed to retrieve audit logs", "error", err)
 			time.Sleep(interval)
 			continue
 		}
@@ -178,15 +170,13 @@ func printLogsAsStream(logs []*models.AuditLogExt) {
 			resource,
 			resultIcon)
 
-		entry := logsLogger.WithTime(logTime)
-
 		switch level {
 		case "error":
-			entry.Error(message)
+			logsLogger.Error(message, "time", logTime)
 		case "info":
-			entry.Info(message)
+			logsLogger.Info(message, "time", logTime)
 		default:
-			entry.Debug(message)
+			logsLogger.Debug(message, "time", logTime)
 		}
 	}
 }

--- a/cmd/harbor/root/password.go
+++ b/cmd/harbor/root/password.go
@@ -31,7 +31,9 @@ func PasswordCommand() *cobra.Command {
 		Short: "Change your password",
 		Args:  cobra.MinimumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			change.ChangePasswordView(&opts)
+			if err := change.ChangePasswordView(&opts); err != nil {
+				return err
+			}
 
 			err := UpdatePassword(&opts)
 			if err != nil {

--- a/cmd/harbor/root/project/config/update.go
+++ b/cmd/harbor/root/project/config/update.go
@@ -129,7 +129,9 @@ Supported flag values:
 				flagsUsed = true
 			}
 			if !flagsUsed {
-				update.UpdateProjectMetadataView(conf)
+				if err := update.UpdateProjectMetadataView(conf); err != nil {
+					return err
+				}
 			}
 
 			err = api.UpdateConfig(isID, projectIDOrName, *conf)

--- a/cmd/harbor/root/project/create.go
+++ b/cmd/harbor/root/project/create.go
@@ -15,11 +15,11 @@ package project
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/project/create"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -47,11 +47,11 @@ func CreateProjectCommand() *cobra.Command {
 			}
 
 			if opts.ProjectName != "" && opts.StorageLimit != "" {
-				log.Debug("Attempting to create project using flags...")
+				slog.Debug("Attempting to create project using flags...")
 				err = api.CreateProject(opts)
 				ProjectName = opts.ProjectName
 			} else {
-				log.Debug("Switching to interactive view...")
+				slog.Debug("Switching to interactive view...")
 				createView := &create.CreateView{
 					ProjectName:  opts.ProjectName,
 					Public:       opts.Public,

--- a/cmd/harbor/root/project/delete.go
+++ b/cmd/harbor/root/project/delete.go
@@ -15,13 +15,13 @@ package project
 
 import (
 	"fmt"
+	"log/slog"
 	"strconv"
 	"sync"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -53,7 +53,7 @@ func DeleteProjectCommand() *cobra.Command {
 			}
 
 			if projectID != "" {
-				log.Debugf("Deleting project with ID: %s", projectID)
+				slog.Debug(fmt.Sprintf("Deleting project with ID: %s", projectID))
 				wg.Add(1)
 				go func(id string) {
 					defer wg.Done()
@@ -69,14 +69,14 @@ func DeleteProjectCommand() *cobra.Command {
 				}(projectID)
 			} else if len(args) > 0 {
 				// Delete by project name from args
-				log.Debugf("Deleting %d projects from args...", len(args))
+				slog.Debug(fmt.Sprintf("Deleting %d projects from args...", len(args)))
 				for _, projectName := range args {
 					pn := projectName
-					log.Debugf("Initiating delete for project: %s", pn)
+					slog.Debug(fmt.Sprintf("Initiating delete for project: %s", pn))
 					wg.Add(1)
 					go func(projectName string) {
 						defer wg.Done()
-						log.Debugf("Deleting project '%s' with force=%v", projectName, forceDelete)
+						slog.Debug(fmt.Sprintf("Deleting project '%s' with force=%v", projectName, forceDelete))
 						if err := api.DeleteProject(projectName, forceDelete, false); err != nil {
 							mu.Lock()
 							failedDeletes[projectName] = utils.ParseHarborErrorMsg(err)
@@ -90,13 +90,13 @@ func DeleteProjectCommand() *cobra.Command {
 				}
 			} else {
 				// If no arguments provided, prompt user for project name
-				log.Debug("No arguments provided. Prompting user for project name.")
+				slog.Debug("No arguments provided. Prompting user for project name.")
 				projectName, err := prompt.GetProjectNameFromUser()
 				if err != nil {
 					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
 				}
-				log.Debugf("User input project: %s", projectName)
-				log.Debugf("Deleting project '%s' with force=%v", projectName, forceDelete)
+				slog.Debug(fmt.Sprintf("User input project: %s", projectName))
+				slog.Debug(fmt.Sprintf("Deleting project '%s' with force=%v", projectName, forceDelete))
 				if err := api.DeleteProject(projectName, forceDelete, false); err != nil {
 					return fmt.Errorf("failed to delete project: %v", utils.ParseHarborErrorMsg(err))
 				}
@@ -121,7 +121,7 @@ func DeleteProjectCommand() *cobra.Command {
 				return fmt.Errorf("failed to delete %d project(s)", len(failedDeletes))
 			}
 
-			log.Debug("All requested projects deleted successfully.")
+			slog.Debug("All requested projects deleted successfully.")
 			return nil
 		},
 	}

--- a/cmd/harbor/root/project/list.go
+++ b/cmd/harbor/root/project/list.go
@@ -15,13 +15,13 @@ package project
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/project"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	list "github.com/goharbor/harbor-cli/pkg/views/project/list"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -43,7 +43,7 @@ func ListProjectCommand() *cobra.Command {
 		Short: "List projects",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			log.Debug("Starting project list command")
+			slog.Debug("Starting project list command")
 			if err := utils.ValidatePagination(opts.Page, opts.PageSize); err != nil {
 				return err
 			}
@@ -54,15 +54,15 @@ func ListProjectCommand() *cobra.Command {
 
 			var listFunc func(...api.ListFlags) (project.ListProjectsOK, error)
 			if private {
-				log.Debug("Using private project list function")
+				slog.Debug("Using private project list function")
 				opts.Public = false
 				listFunc = api.ListProject
 			} else if public {
-				log.Debug("Using public project list function")
+				slog.Debug("Using public project list function")
 				opts.Public = true
 				listFunc = api.ListProject
 			} else {
-				log.Debug("Using list all projects function")
+				slog.Debug("Using list all projects function")
 				listFunc = api.ListAllProjects
 			}
 
@@ -77,26 +77,26 @@ func ListProjectCommand() *cobra.Command {
 				opts.Q = q
 			}
 
-			log.Debug("Fetching projects...")
+			slog.Debug("Fetching projects...")
 			allProjects, err = fetchProjects(listFunc, opts)
 			if err != nil {
 				return fmt.Errorf("failed to get projects list: %v", utils.ParseHarborErrorMsg(err))
 			}
 
-			log.WithField("count", len(allProjects)).Debug("Number of projects fetched")
+			slog.Debug("Number of projects fetched", "count", len(allProjects))
 			if len(allProjects) == 0 {
 				fmt.Println("No projects found")
 				return nil
 			}
 			formatFlag := viper.GetString("output-format")
 			if formatFlag != "" {
-				log.WithField("output_format", formatFlag).Debug("Output format selected")
+				slog.Debug("Output format selected", "output_format", formatFlag)
 				err = utils.PrintFormat(allProjects, formatFlag)
 				if err != nil {
 					return err
 				}
 			} else {
-				log.Debug("Listing projects using default view")
+				slog.Debug("Listing projects using default view")
 				list.ListProjects(allProjects)
 			}
 			return nil
@@ -120,36 +120,30 @@ func ListProjectCommand() *cobra.Command {
 func fetchProjects(listFunc func(...api.ListFlags) (project.ListProjectsOK, error), opts api.ListFlags) ([]*models.Project, error) {
 	var allProjects []*models.Project
 	if opts.PageSize == 0 {
-		log.Debug("Page size is 0, will fetch all pages")
+		slog.Debug("Page size is 0, will fetch all pages")
 		opts.PageSize = 100
 		opts.Page = 1
 
 		for {
-			log.WithFields(log.Fields{
-				"page":      opts.Page,
-				"page_size": opts.PageSize,
-			}).Debug("Fetching next page of projects")
+			slog.Debug("Fetching next page of projects", "page", opts.Page, "page_size", opts.PageSize)
 
 			projects, err := listFunc(opts)
 			if err != nil {
 				return nil, err
 			}
 
-			log.WithField("fetched_count", len(projects.Payload)).Debug("Fetched projects from current page")
+			slog.Debug("Fetched projects from current page", "fetched_count", len(projects.Payload))
 			allProjects = append(allProjects, projects.Payload...)
 
 			if len(projects.Payload) < int(opts.PageSize) {
-				log.Debug("Last page reached, stopping pagination")
+				slog.Debug("Last page reached, stopping pagination")
 				break
 			}
 
 			opts.Page++
 		}
 	} else {
-		log.WithFields(log.Fields{
-			"page":      opts.Page,
-			"page_size": opts.PageSize,
-		}).Debug("Fetching projects with user-defined pagination")
+		slog.Debug("Fetching projects with user-defined pagination", "page", opts.Page, "page_size", opts.PageSize)
 
 		projects, err := listFunc(opts)
 		if err != nil {

--- a/cmd/harbor/root/project/logs.go
+++ b/cmd/harbor/root/project/logs.go
@@ -15,13 +15,13 @@ package project
 
 import (
 	"fmt"
+	"log/slog"
 
 	proj "github.com/goharbor/go-client/pkg/sdk/v2.0/client/project"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	auditLog "github.com/goharbor/harbor-cli/pkg/views/project/logs"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -42,26 +42,26 @@ func LogsProjectCommmand() *cobra.Command {
 				return fmt.Errorf("page size should be less than or equal to 100")
 			}
 
-			log.Debug("Starting execution of 'logs' command")
+			slog.Debug("Starting execution of 'logs' command")
 			var err error
 			var resp *proj.GetLogExtsOK
 			var projectName string
 
 			if len(args) > 0 {
 				projectName = args[0]
-				log.Debugf("Project name provided as argument: %s", projectName)
+				slog.Debug(fmt.Sprintf("Project name provided as argument: %s", projectName))
 			} else {
-				log.Debug("No project name argument provided, prompting user...")
+				slog.Debug("No project name argument provided, prompting user...")
 				projectName, err = prompt.GetProjectNameFromUser()
 				if err != nil {
 					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
 				}
-				log.Debugf("Project name received from prompt: %s", projectName)
+				slog.Debug(fmt.Sprintf("Project name received from prompt: %s", projectName))
 			}
 			if opts.Page < 1 {
 				return fmt.Errorf("page number must be greater than or equal to 1")
 			}
-			log.Debugf("Checking if project '%s' exists...", projectName)
+			slog.Debug(fmt.Sprintf("Checking if project '%s' exists...", projectName))
 			_, err = api.GetProject(projectName, false)
 			if err != nil {
 				if utils.ParseHarborErrorCode(err) == "404" {
@@ -70,7 +70,7 @@ func LogsProjectCommmand() *cobra.Command {
 				return fmt.Errorf("failed to verify project: %v", utils.ParseHarborErrorMsg(err))
 			}
 
-			log.Debugf("Fetching logs for project: %s", projectName)
+			slog.Debug(fmt.Sprintf("Fetching logs for project: %s", projectName))
 			resp, err = api.LogsProject(projectName, opts)
 			if err != nil {
 				return fmt.Errorf("failed to get project logs: %v", utils.ParseHarborErrorMsg(err))
@@ -78,13 +78,13 @@ func LogsProjectCommmand() *cobra.Command {
 
 			formatFlag := viper.GetString("output-format")
 			if formatFlag != "" {
-				log.WithField("output_format", formatFlag).Debug("Output format selected")
+				slog.Debug("Output format selected", "output_format", formatFlag)
 				err = utils.PrintFormat(resp.Payload, formatFlag)
 				if err != nil {
 					return err
 				}
 			} else {
-				log.Debug("Listing project logs using default view")
+				slog.Debug("Listing project logs using default view")
 				auditLog.LogsProject(resp.Payload)
 			}
 			return nil

--- a/cmd/harbor/root/project/member/create.go
+++ b/cmd/harbor/root/project/member/create.go
@@ -16,7 +16,6 @@ package member
 
 import (
 	"fmt"
-	"log/slog"
 
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 
@@ -89,7 +88,7 @@ func CreateMemberCommand() *cobra.Command {
 			}
 
 			if err != nil {
-				slog.Error("failed to create user", "error", err)
+				return fmt.Errorf("failed to create user: %v", err)
 			}
 
 			fmt.Printf("successfully added user %s to project %s\n", createView.MemberUser.Username, opts.ProjectName)

--- a/cmd/harbor/root/project/member/create.go
+++ b/cmd/harbor/root/project/member/create.go
@@ -16,9 +16,9 @@ package member
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
-	"github.com/sirupsen/logrus"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
@@ -89,7 +89,7 @@ func CreateMemberCommand() *cobra.Command {
 			}
 
 			if err != nil {
-				logrus.Errorf("failed to create user: %v", err)
+				slog.Error("failed to create user", "error", err)
 			}
 
 			fmt.Printf("successfully added user %s to project %s\n", createView.MemberUser.Username, opts.ProjectName)

--- a/cmd/harbor/root/project/preheat/execution/list.go
+++ b/cmd/harbor/root/project/preheat/execution/list.go
@@ -15,12 +15,12 @@ package execution
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/preheat/execution/list"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -51,10 +51,10 @@ func ListExecutionCommand() *cobra.Command {
 			}
 
 			if len(args) >= 1 {
-				log.Debugf("Project name provided: %s", args[0])
+				slog.Debug(fmt.Sprintf("Project name provided: %s", args[0]))
 				projectName = args[0]
 			} else {
-				log.Debug("No project name provided, prompting user")
+				slog.Debug("No project name provided, prompting user")
 				projectName, err = prompt.GetProjectNameFromUser()
 				if err != nil {
 					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
@@ -70,17 +70,17 @@ func ListExecutionCommand() *cobra.Command {
 			}
 
 			if len(args) >= 2 {
-				log.Debugf("Policy name provided: %s", args[1])
+				slog.Debug(fmt.Sprintf("Policy name provided: %s", args[1]))
 				policyName = args[1]
 			} else {
-				log.Debug("No policy name provided, prompting user")
+				slog.Debug("No policy name provided, prompting user")
 				policyName, err = prompt.GetPreheatPolicyNameFromUser(projectName)
 				if err != nil {
 					return fmt.Errorf("failed to get policy name: %v", utils.ParseHarborErrorMsg(err))
 				}
 			}
 
-			log.Debug("Fetching preheat policy executions...")
+			slog.Debug("Fetching preheat policy executions...")
 			resp, err := api.ListPreheatExecutions(projectName, policyName, opts)
 			if err != nil {
 				if utils.ParseHarborErrorCode(err) == "404" {

--- a/cmd/harbor/root/project/preheat/execution/stop.go
+++ b/cmd/harbor/root/project/preheat/execution/stop.go
@@ -15,12 +15,12 @@ package execution
 
 import (
 	"fmt"
+	"log/slog"
 	"strconv"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -43,10 +43,10 @@ func StopExecutionCommand() *cobra.Command {
 			}
 
 			if len(args) >= 1 {
-				log.Debugf("Project name provided: %s", args[0])
+				slog.Debug(fmt.Sprintf("Project name provided: %s", args[0]))
 				projectName = args[0]
 			} else {
-				log.Debug("No project name provided, prompting user")
+				slog.Debug("No project name provided, prompting user")
 				projectName, err = prompt.GetProjectNameFromUser()
 				if err != nil {
 					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
@@ -61,10 +61,10 @@ func StopExecutionCommand() *cobra.Command {
 			}
 
 			if len(args) >= 2 {
-				log.Debugf("Policy name provided: %s", args[1])
+				slog.Debug(fmt.Sprintf("Policy name provided: %s", args[1]))
 				policyName = args[1]
 			} else {
-				log.Debug("No policy name provided, prompting user")
+				slog.Debug("No policy name provided, prompting user")
 				policyName, err = prompt.GetPreheatPolicyNameFromUser(projectName)
 				if err != nil {
 					return fmt.Errorf("failed to get policy name: %v", utils.ParseHarborErrorMsg(err))
@@ -72,20 +72,20 @@ func StopExecutionCommand() *cobra.Command {
 			}
 
 			if len(args) >= 3 {
-				log.Debugf("Execution ID provided: %s", args[2])
+				slog.Debug(fmt.Sprintf("Execution ID provided: %s", args[2]))
 				executionID, err = strconv.ParseInt(args[2], 10, 64)
 				if err != nil {
 					return fmt.Errorf("invalid execution ID %q: %v", args[2], err)
 				}
 			} else {
-				log.Debug("No execution ID provided, prompting user")
+				slog.Debug("No execution ID provided, prompting user")
 				executionID, err = prompt.GetPreheatPolicyExecIDFromUser(projectName, policyName)
 				if err != nil {
 					return fmt.Errorf("failed to get execution id: %v", utils.ParseHarborErrorMsg(err))
 				}
 			}
 
-			log.Debug("Stopping preheat execution...")
+			slog.Debug("Stopping preheat execution...")
 			err = api.StopPreheatExecution(projectName, policyName, executionID)
 			if err != nil {
 				if utils.ParseHarborErrorCode(err) == "404" {

--- a/cmd/harbor/root/project/preheat/execution/view.go
+++ b/cmd/harbor/root/project/preheat/execution/view.go
@@ -15,13 +15,13 @@ package execution
 
 import (
 	"fmt"
+	"log/slog"
 	"strconv"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/preheat/execution/view"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -45,10 +45,10 @@ func ViewExecutionCommand() *cobra.Command {
 			}
 
 			if len(args) >= 1 {
-				log.Debugf("Project name provided: %s", args[0])
+				slog.Debug(fmt.Sprintf("Project name provided: %s", args[0]))
 				projectName = args[0]
 			} else {
-				log.Debug("No project name provided, prompting user")
+				slog.Debug("No project name provided, prompting user")
 				projectName, err = prompt.GetProjectNameFromUser()
 				if err != nil {
 					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
@@ -63,10 +63,10 @@ func ViewExecutionCommand() *cobra.Command {
 			}
 
 			if len(args) >= 2 {
-				log.Debugf("Policy name provided: %s", args[1])
+				slog.Debug(fmt.Sprintf("Policy name provided: %s", args[1]))
 				policyName = args[1]
 			} else {
-				log.Debug("No policy name provided, prompting user")
+				slog.Debug("No policy name provided, prompting user")
 				policyName, err = prompt.GetPreheatPolicyNameFromUser(projectName)
 				if err != nil {
 					return fmt.Errorf("failed to get policy name: %v", utils.ParseHarborErrorMsg(err))
@@ -74,20 +74,20 @@ func ViewExecutionCommand() *cobra.Command {
 			}
 
 			if len(args) >= 3 {
-				log.Debugf("Execution ID provided: %s", args[2])
+				slog.Debug(fmt.Sprintf("Execution ID provided: %s", args[2]))
 				executionID, err = strconv.ParseInt(args[2], 10, 64)
 				if err != nil {
 					return fmt.Errorf("invalid execution ID %q: %v", args[2], err)
 				}
 			} else {
-				log.Debug("No execution ID provided, prompting user")
+				slog.Debug("No execution ID provided, prompting user")
 				executionID, err = prompt.GetPreheatPolicyExecIDFromUser(projectName, policyName)
 				if err != nil {
 					return fmt.Errorf("failed to get execution id: %v", utils.ParseHarborErrorMsg(err))
 				}
 			}
 
-			log.Debug("Fetching preheat execution details...")
+			slog.Debug("Fetching preheat execution details...")
 			resp, err := api.GetPreheatExecution(projectName, policyName, executionID)
 			if err != nil {
 				if utils.ParseHarborErrorCode(err) == "404" {

--- a/cmd/harbor/root/project/preheat/policy/create.go
+++ b/cmd/harbor/root/project/preheat/policy/create.go
@@ -16,6 +16,7 @@ package policy
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/api"
@@ -23,7 +24,6 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/preheat/policy/create"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -42,14 +42,14 @@ func CreatePolicyCommand() *cobra.Command {
   harbor project preheat policy create -f [CONFIG_FILE]`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			log.Debug("Starting preheat policy create command")
+			slog.Debug("Starting preheat policy create command")
 
 			if configFile != "" {
 				if len(args) > 0 {
 					return fmt.Errorf("arguments are not supported with --policy-config-file")
 				}
 
-				log.Debugf("Loading preheat policy configuration from file: %s", configFile)
+				slog.Debug(fmt.Sprintf("Loading preheat policy configuration from file: %s", configFile))
 				opts, err = config.LoadConfigFromFile(configFile)
 				if err != nil {
 					return fmt.Errorf("failed to load preheat policy configuration: %v", err)
@@ -64,10 +64,10 @@ func CreatePolicyCommand() *cobra.Command {
 				}
 
 				if len(args) > 0 {
-					log.Debugf("Project name provided: %s", args[0])
+					slog.Debug(fmt.Sprintf("Project name provided: %s", args[0]))
 					opts.ProjectName = args[0]
 				} else {
-					log.Debug("No project name provided, prompting user")
+					slog.Debug("No project name provided, prompting user")
 					opts.ProjectName, err = prompt.GetProjectNameFromUser()
 					if err != nil {
 						return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
@@ -94,7 +94,7 @@ func CreatePolicyCommand() *cobra.Command {
 				return fmt.Errorf("failed to verify project: %v", utils.ParseHarborErrorMsg(err))
 			}
 
-			log.Debug("Fetching available providers...")
+			slog.Debug("Fetching available providers...")
 			providers, err := api.ListProvidersUnderProject(opts.ProjectName)
 			if err != nil {
 				return fmt.Errorf("failed to list providers: %v", utils.ParseHarborErrorMsg(err))
@@ -118,7 +118,7 @@ func CreatePolicyCommand() *cobra.Command {
 				return err
 			}
 
-			log.Debug("Creating preheat policy...")
+			slog.Debug("Creating preheat policy...")
 			response, err := api.CreatePreheatPolicy(opts.ProjectName, policy)
 			if err != nil {
 				if utils.ParseHarborErrorCode(err) == "409" {

--- a/cmd/harbor/root/project/preheat/policy/create.go
+++ b/cmd/harbor/root/project/preheat/policy/create.go
@@ -105,7 +105,9 @@ func CreatePolicyCommand() *cobra.Command {
 			}
 
 			if configFile == "" {
-				create.CreatePreheatPolicyView(opts, providers)
+				if err := create.CreatePreheatPolicyView(opts, providers); err != nil {
+					return err
+				}
 			}
 
 			providerID, err := resolveProviderID(providers, opts.ProviderName, opts.ProjectName)

--- a/cmd/harbor/root/project/preheat/policy/delete.go
+++ b/cmd/harbor/root/project/preheat/policy/delete.go
@@ -15,11 +15,11 @@ package policy
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -42,10 +42,10 @@ func DeletePolicyCommand() *cobra.Command {
 			}
 
 			if len(args) >= 1 {
-				log.Debugf("Project name provided: %s", args[0])
+				slog.Debug(fmt.Sprintf("Project name provided: %s", args[0]))
 				projectName = args[0]
 			} else {
-				log.Debug("No project name provided, prompting user")
+				slog.Debug("No project name provided, prompting user")
 				projectName, err = prompt.GetProjectNameFromUser()
 				if err != nil {
 					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
@@ -61,17 +61,17 @@ func DeletePolicyCommand() *cobra.Command {
 			}
 
 			if len(args) >= 2 {
-				log.Debugf("Policy name provided: %s", args[1])
+				slog.Debug(fmt.Sprintf("Policy name provided: %s", args[1]))
 				policyName = args[1]
 			} else {
-				log.Debug("No policy name provided, prompting user")
+				slog.Debug("No policy name provided, prompting user")
 				policyName, err = prompt.GetPreheatPolicyNameFromUser(projectName)
 				if err != nil {
 					return fmt.Errorf("failed to get policy name: %v", utils.ParseHarborErrorMsg(err))
 				}
 			}
 
-			log.Debug("Deleting preheat policy...")
+			slog.Debug("Deleting preheat policy...")
 			err = api.DeletePreheatPolicy(projectName, policyName)
 			if err != nil {
 				if utils.ParseHarborErrorCode(err) == "404" {

--- a/cmd/harbor/root/project/preheat/policy/list.go
+++ b/cmd/harbor/root/project/preheat/policy/list.go
@@ -15,12 +15,12 @@ package policy
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/preheat/policy/list"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -52,17 +52,17 @@ func ListPolicyCommand() *cobra.Command {
 			}
 
 			if len(args) > 0 {
-				log.Debugf("Project name provided: %s", args[0])
+				slog.Debug(fmt.Sprintf("Project name provided: %s", args[0]))
 				projectName = args[0]
 			} else {
-				log.Debug("No project name provided, prompting user")
+				slog.Debug("No project name provided, prompting user")
 				projectName, err = prompt.GetProjectNameFromUser()
 				if err != nil {
 					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
 				}
 			}
 
-			log.Debug("Fetching preheat policies...")
+			slog.Debug("Fetching preheat policies...")
 			resp, err := api.ListPreheatPolicies(projectName, isID, opts)
 			if err != nil {
 				if utils.ParseHarborErrorCode(err) == "404" {

--- a/cmd/harbor/root/project/preheat/policy/start.go
+++ b/cmd/harbor/root/project/preheat/policy/start.go
@@ -15,11 +15,11 @@ package policy
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -42,10 +42,10 @@ func StartPolicyCommand() *cobra.Command {
 			}
 
 			if len(args) >= 1 {
-				log.Debugf("Project name provided: %s", args[0])
+				slog.Debug(fmt.Sprintf("Project name provided: %s", args[0]))
 				projectName = args[0]
 			} else {
-				log.Debug("No project name provided, prompting user")
+				slog.Debug("No project name provided, prompting user")
 				projectName, err = prompt.GetProjectNameFromUser()
 				if err != nil {
 					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
@@ -61,17 +61,17 @@ func StartPolicyCommand() *cobra.Command {
 			}
 
 			if len(args) >= 2 {
-				log.Debugf("Policy name provided: %s", args[1])
+				slog.Debug(fmt.Sprintf("Policy name provided: %s", args[1]))
 				policyName = args[1]
 			} else {
-				log.Debug("No policy name provided, prompting user")
+				slog.Debug("No policy name provided, prompting user")
 				policyName, err = prompt.GetPreheatPolicyNameFromUser(projectName)
 				if err != nil {
 					return fmt.Errorf("failed to get policy name: %v", utils.ParseHarborErrorMsg(err))
 				}
 			}
 
-			log.Debug("Manually triggering preheat policy...")
+			slog.Debug("Manually triggering preheat policy...")
 			location, err := api.StartPreheatPolicy(projectName, policyName)
 			if err != nil {
 				if utils.ParseHarborErrorCode(err) == "404" {

--- a/cmd/harbor/root/project/preheat/policy/update.go
+++ b/cmd/harbor/root/project/preheat/policy/update.go
@@ -98,7 +98,9 @@ func UpdatePolicyCommand() *cobra.Command {
 			}
 
 			opts := policyToCreateView(existingPolicy.Payload, providers)
-			create.CreatePreheatPolicyView(opts, providers)
+			if err := create.CreatePreheatPolicyView(opts, providers); err != nil {
+				return err
+			}
 
 			providerID, err := resolveProviderID(providers, opts.ProviderName, projectName)
 			if err != nil {

--- a/cmd/harbor/root/project/preheat/policy/update.go
+++ b/cmd/harbor/root/project/preheat/policy/update.go
@@ -16,13 +16,13 @@ package policy
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/preheat/policy/create"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -45,10 +45,10 @@ func UpdatePolicyCommand() *cobra.Command {
 			}
 
 			if len(args) >= 1 {
-				log.Debugf("Project name provided: %s", args[0])
+				slog.Debug(fmt.Sprintf("Project name provided: %s", args[0]))
 				projectName = args[0]
 			} else {
-				log.Debug("No project name provided, prompting user")
+				slog.Debug("No project name provided, prompting user")
 				projectName, err = prompt.GetProjectNameFromUser()
 				if err != nil {
 					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
@@ -64,17 +64,17 @@ func UpdatePolicyCommand() *cobra.Command {
 			}
 
 			if len(args) >= 2 {
-				log.Debugf("Policy name provided: %s", args[1])
+				slog.Debug(fmt.Sprintf("Policy name provided: %s", args[1]))
 				policyName = args[1]
 			} else {
-				log.Debug("No policy name provided, prompting user")
+				slog.Debug("No policy name provided, prompting user")
 				policyName, err = prompt.GetPreheatPolicyNameFromUser(projectName)
 				if err != nil {
 					return fmt.Errorf("failed to get policy name: %v", utils.ParseHarborErrorMsg(err))
 				}
 			}
 
-			log.Debug("Fetching preheat policy...")
+			slog.Debug("Fetching preheat policy...")
 			existingPolicy, err := api.GetPreheatPolicy(projectName, policyName)
 			if err != nil {
 				if utils.ParseHarborErrorCode(err) == "404" {
@@ -87,7 +87,7 @@ func UpdatePolicyCommand() *cobra.Command {
 				return fmt.Errorf("preheat policy %s payload is empty", policyName)
 			}
 
-			log.Debug("Fetching available providers...")
+			slog.Debug("Fetching available providers...")
 			providers, err := api.ListProvidersUnderProject(projectName)
 			if err != nil {
 				return fmt.Errorf("failed to list providers: %v", utils.ParseHarborErrorMsg(err))
@@ -114,7 +114,7 @@ func UpdatePolicyCommand() *cobra.Command {
 			policy.CreationTime = existingPolicy.Payload.CreationTime
 			policy.ExtraAttrs = existingPolicy.Payload.ExtraAttrs
 
-			log.Debug("Updating preheat policy...")
+			slog.Debug("Updating preheat policy...")
 			_, err = api.UpdatePreheatPolicy(projectName, policyName, policy)
 			if err != nil {
 				if utils.ParseHarborErrorCode(err) == "409" {

--- a/cmd/harbor/root/project/preheat/policy/view.go
+++ b/cmd/harbor/root/project/preheat/policy/view.go
@@ -15,12 +15,12 @@ package policy
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	view "github.com/goharbor/harbor-cli/pkg/views/preheat/policy/view"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -44,10 +44,10 @@ func ViewPolicyCommand() *cobra.Command {
 			}
 
 			if len(args) >= 1 {
-				log.Debugf("Project name provided: %s", args[0])
+				slog.Debug(fmt.Sprintf("Project name provided: %s", args[0]))
 				projectName = args[0]
 			} else {
-				log.Debug("No project name provided, prompting user")
+				slog.Debug("No project name provided, prompting user")
 				projectName, err = prompt.GetProjectNameFromUser()
 				if err != nil {
 					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
@@ -63,17 +63,17 @@ func ViewPolicyCommand() *cobra.Command {
 			}
 
 			if len(args) >= 2 {
-				log.Debugf("Policy name provided: %s", args[1])
+				slog.Debug(fmt.Sprintf("Policy name provided: %s", args[1]))
 				policyName = args[1]
 			} else {
-				log.Debug("No policy name provided, prompting user")
+				slog.Debug("No policy name provided, prompting user")
 				policyName, err = prompt.GetPreheatPolicyNameFromUser(projectName)
 				if err != nil {
 					return fmt.Errorf("failed to get policy name: %v", utils.ParseHarborErrorMsg(err))
 				}
 			}
 
-			log.Debug("Fetching preheat policy...")
+			slog.Debug("Fetching preheat policy...")
 			resp, err := api.GetPreheatPolicy(projectName, policyName)
 			if err != nil {
 				if utils.ParseHarborErrorCode(err) == "404" {

--- a/cmd/harbor/root/project/robot/create.go
+++ b/cmd/harbor/root/project/robot/create.go
@@ -132,7 +132,9 @@ Examples:
 			if len(args) == 0 {
 				if (opts.Name == "" || opts.Duration == 0) && configFile == "" {
 					fmt.Println("Opening interactive form for robot creation")
-					create.CreateRobotView(&opts)
+					if err := create.CreateRobotView(&opts); err != nil {
+						return err
+					}
 				}
 
 				if opts.Duration == 0 {
@@ -216,7 +218,9 @@ Examples:
 				exportSecretToFile(name, secret, response.Payload.CreationTime.String(), response.Payload.ExpiresAt)
 				return nil
 			} else {
-				create.CreateRobotSecretView(name, secret)
+				if err := create.CreateRobotSecretView(name, secret); err != nil {
+					return err
+				}
 				err = clipboard.WriteAll(response.Payload.Secret)
 				if err != nil {
 					slog.Error("failed to write to clipboard")

--- a/cmd/harbor/root/project/robot/create.go
+++ b/cmd/harbor/root/project/robot/create.go
@@ -16,6 +16,7 @@ package robot
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 
 	"github.com/atotto/clipboard"
@@ -25,7 +26,6 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/robot/create"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -102,7 +102,7 @@ Examples:
 				if loadErr != nil {
 					return fmt.Errorf("failed to load robot config from file: %v", loadErr)
 				}
-				logrus.Debug("Successfully loaded robot configuration")
+				slog.Debug("Successfully loaded robot configuration")
 				opts = *loadedOpts
 				if opts.ProjectName == "" {
 					opts.ProjectName = opts.Permissions[0].Namespace
@@ -219,7 +219,7 @@ Examples:
 				create.CreateRobotSecretView(name, secret)
 				err = clipboard.WriteAll(response.Payload.Secret)
 				if err != nil {
-					logrus.Errorf("failed to write to clipboard")
+					slog.Error("failed to write to clipboard")
 					return nil
 				}
 				fmt.Println("secret copied to clipboard.")
@@ -249,10 +249,10 @@ func exportSecretToFile(name, secret, creationTime string, expiresAt int64) {
 	filename := fmt.Sprintf("%s-secret.json", name)
 	jsonData, err := json.MarshalIndent(secretJson, "", "  ")
 	if err != nil {
-		logrus.Errorf("Failed to marshal secret to JSON: %v", err)
+		slog.Error("Failed to marshal secret to JSON", "error", err)
 	} else {
 		if err := os.WriteFile(filename, jsonData, 0600); err != nil {
-			logrus.Errorf("Failed to write secret to file: %v", err)
+			slog.Error("Failed to write secret to file", "error", err)
 		} else {
 			fmt.Printf("Secret saved to %s\n", filename)
 		}

--- a/cmd/harbor/root/project/robot/delete.go
+++ b/cmd/harbor/root/project/robot/delete.go
@@ -15,12 +15,13 @@ package robot
 
 import (
 	"fmt"
+	"log/slog"
+	"os"
 	"strconv"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/spf13/cobra"
 )
@@ -95,7 +96,8 @@ Examples:
 			} else {
 				projectID, err := prompt.GetProjectIDFromUser()
 				if err != nil {
-					log.Fatalf("failed to get project by id %d: %v", projectID, utils.ParseHarborErrorMsg(err))
+					slog.Error(fmt.Sprintf("failed to get project by id %d: %v", projectID, utils.ParseHarborErrorMsg(err)))
+					os.Exit(1)
 				}
 				robotID, err = prompt.GetRobotIDFromUser(projectID)
 				if err != nil {

--- a/cmd/harbor/root/project/robot/delete.go
+++ b/cmd/harbor/root/project/robot/delete.go
@@ -15,8 +15,6 @@ package robot
 
 import (
 	"fmt"
-	"log/slog"
-	"os"
 	"strconv"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
@@ -96,8 +94,7 @@ Examples:
 			} else {
 				projectID, err := prompt.GetProjectIDFromUser()
 				if err != nil {
-					slog.Error(fmt.Sprintf("failed to get project by id %d: %v", projectID, utils.ParseHarborErrorMsg(err)))
-					os.Exit(1)
+					return fmt.Errorf("failed to get project by id %d: %v", projectID, utils.ParseHarborErrorMsg(err))
 				}
 				robotID, err = prompt.GetRobotIDFromUser(projectID)
 				if err != nil {

--- a/cmd/harbor/root/project/robot/list.go
+++ b/cmd/harbor/root/project/robot/list.go
@@ -15,6 +15,8 @@ package robot
 
 import (
 	"fmt"
+	"log/slog"
+	"os"
 	"strconv"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
@@ -22,7 +24,6 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/robot/list"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -97,7 +98,8 @@ Examples:
 			} else {
 				projectID, err := prompt.GetProjectIDFromUser()
 				if err != nil {
-					log.Fatalf("failed to get project by id %d: %v", projectID, utils.ParseHarborErrorMsg(err))
+					slog.Error(fmt.Sprintf("failed to get project by id %d: %v", projectID, utils.ParseHarborErrorMsg(err)))
+					os.Exit(1)
 				}
 				opts.Q = projectQString + strconv.FormatInt(projectID, 10)
 			}
@@ -109,7 +111,7 @@ Examples:
 
 			formatFlag := viper.GetString("output-format")
 			if formatFlag != "" {
-				log.WithField("output_format", formatFlag).Debug("Output format selected")
+				slog.Debug("Output format selected", "output_format", formatFlag)
 				err = utils.PrintFormat(robots, formatFlag)
 				if err != nil {
 					return err

--- a/cmd/harbor/root/project/robot/list.go
+++ b/cmd/harbor/root/project/robot/list.go
@@ -16,7 +16,6 @@ package robot
 import (
 	"fmt"
 	"log/slog"
-	"os"
 	"strconv"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
@@ -98,8 +97,7 @@ Examples:
 			} else {
 				projectID, err := prompt.GetProjectIDFromUser()
 				if err != nil {
-					slog.Error(fmt.Sprintf("failed to get project by id %d: %v", projectID, utils.ParseHarborErrorMsg(err)))
-					os.Exit(1)
+					return fmt.Errorf("failed to get project by id %d: %v", projectID, utils.ParseHarborErrorMsg(err))
 				}
 				opts.Q = projectQString + strconv.FormatInt(projectID, 10)
 			}

--- a/cmd/harbor/root/project/robot/refresh.go
+++ b/cmd/harbor/root/project/robot/refresh.go
@@ -15,6 +15,8 @@ package robot
 
 import (
 	"fmt"
+	"log/slog"
+	"os"
 	"strconv"
 
 	"github.com/atotto/clipboard"
@@ -22,7 +24,6 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/robot/create"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/spf13/cobra"
 )
@@ -87,7 +88,8 @@ Examples:
 				}
 				robotID, err = prompt.GetRobotIDFromUser(projectID)
 				if err != nil {
-					log.Fatalf("failed to get robot ID from user: %v", utils.ParseHarborErrorMsg(err))
+					slog.Error(fmt.Sprintf("failed to get robot ID from user: %v", utils.ParseHarborErrorMsg(err)))
+					os.Exit(1)
 				}
 			}
 
@@ -133,11 +135,13 @@ Examples:
 func getSecret() string {
 	secret, err := utils.GetSecretStdin("Enter your secret: ")
 	if err != nil {
-		log.Fatalf("Error reading secret: %v\n", err)
+		slog.Error("Error reading secret", "error", err)
+		os.Exit(1)
 	}
 
 	if err := utils.ValidatePassword(secret); err != nil {
-		log.Fatalf("Invalid secret: %v\n", err)
+		slog.Error("Invalid secret", "error", err)
+		os.Exit(1)
 	}
 	return secret
 }

--- a/cmd/harbor/root/project/robot/refresh.go
+++ b/cmd/harbor/root/project/robot/refresh.go
@@ -15,8 +15,6 @@ package robot
 
 import (
 	"fmt"
-	"log/slog"
-	"os"
 	"strconv"
 
 	"github.com/atotto/clipboard"
@@ -88,8 +86,7 @@ Examples:
 				}
 				robotID, err = prompt.GetRobotIDFromUser(projectID)
 				if err != nil {
-					slog.Error(fmt.Sprintf("failed to get robot ID from user: %v", utils.ParseHarborErrorMsg(err)))
-					os.Exit(1)
+					return fmt.Errorf("failed to get robot ID from user: %v", utils.ParseHarborErrorMsg(err))
 				}
 			}
 
@@ -100,7 +97,10 @@ Examples:
 				}
 			}
 			if secretStdin {
-				secret = getSecret()
+				secret, err = getSecret()
+				if err != nil {
+					return err
+				}
 			}
 
 			response, err := api.RefreshSecret(secret, robotID)
@@ -112,7 +112,9 @@ Examples:
 
 			if response.Payload.Secret != "" {
 				secret = response.Payload.Secret
-				create.CreateRobotSecretView("", secret)
+				if err := create.CreateRobotSecretView("", secret); err != nil {
+					return err
+				}
 
 				err = clipboard.WriteAll(response.Payload.Secret)
 				if err != nil {
@@ -132,16 +134,14 @@ Examples:
 }
 
 // getSecret from commandline
-func getSecret() string {
+func getSecret() (string, error) {
 	secret, err := utils.GetSecretStdin("Enter your secret: ")
 	if err != nil {
-		slog.Error("Error reading secret", "error", err)
-		os.Exit(1)
+		return "", fmt.Errorf("Error reading secret: %v", err)
 	}
 
 	if err := utils.ValidatePassword(secret); err != nil {
-		slog.Error("Invalid secret", "error", err)
-		os.Exit(1)
+		return "", fmt.Errorf("Invalid secret: %v", err)
 	}
-	return secret
+	return secret, nil
 }

--- a/cmd/harbor/root/project/robot/update.go
+++ b/cmd/harbor/root/project/robot/update.go
@@ -196,6 +196,8 @@ func updateRobotView(updateView *update.UpdateView) error {
 		updateView = &update.UpdateView{}
 	}
 
-	update.UpdateRobotView(updateView)
+	if err := update.UpdateRobotView(updateView); err != nil {
+		return err
+	}
 	return api.UpdateRobot(updateView)
 }

--- a/cmd/harbor/root/project/search.go
+++ b/cmd/harbor/root/project/search.go
@@ -15,11 +15,11 @@ package project
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/project/list"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -30,12 +30,12 @@ func SearchProjectCommand() *cobra.Command {
 		Short: "search project based on their names",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			log.Debug("Starting project search command")
+			slog.Debug("Starting project search command")
 			projects, err := api.SearchProject(args[0])
 			if err != nil {
 				return fmt.Errorf("failed to get projects: %v", utils.ParseHarborErrorMsg(err))
 			}
-			log.Debugf("Found %d projects", len(projects.Payload.Project))
+			slog.Debug(fmt.Sprintf("Found %d projects", len(projects.Payload.Project)))
 			if len(projects.Payload.Project) == 0 {
 				return fmt.Errorf("No projects found with name similar to : %s", args[0])
 			}

--- a/cmd/harbor/root/project/view.go
+++ b/cmd/harbor/root/project/view.go
@@ -15,13 +15,13 @@ package project
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/project"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/project/view"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -38,17 +38,17 @@ func ViewCommand() *cobra.Command {
 			var project *project.GetProjectOK
 
 			if len(args) > 0 {
-				log.Debugf("Project name provided: %s", args[0])
+				slog.Debug(fmt.Sprintf("Project name provided: %s", args[0]))
 				projectName = args[0]
 			} else {
-				log.Debug("No project name provided, prompting user")
+				slog.Debug("No project name provided, prompting user")
 				projectName, err = prompt.GetProjectNameFromUser()
 				if err != nil {
 					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
 				}
 			}
 
-			log.Debugf("Fetching project: %s", projectName)
+			slog.Debug(fmt.Sprintf("Fetching project: %s", projectName))
 			project, err = api.GetProject(projectName, isID)
 			if err != nil {
 				if utils.ParseHarborErrorCode(err) == "404" {

--- a/cmd/harbor/root/quota/update.go
+++ b/cmd/harbor/root/quota/update.go
@@ -135,7 +135,11 @@ func GetQuotaFromUser(args []string, opts api.ListQuotaFlags) (*models.Quota, er
 			return nil, err
 		}
 	} else {
-		quotaID := prompt.GetQuotaIDFromUser()
+		var quotaID int64
+		quotaID, err = prompt.GetQuotaIDFromUser()
+		if err != nil {
+			return nil, err
+		}
 		if quotaID == 0 {
 			err := fmt.Errorf("failed to get quotaID from user")
 			return nil, err

--- a/cmd/harbor/root/quota/update.go
+++ b/cmd/harbor/root/quota/update.go
@@ -63,7 +63,10 @@ func UpdateQuotaCommand() *cobra.Command {
 					}
 				}
 			} else {
-				storage = update.UpdateQuotaView(quota)
+				storage, err = update.UpdateQuotaView(quota)
+				if err != nil {
+					return err
+				}
 				storageValue, err = utils.StorageStringToBytes(storage)
 				if err != nil {
 					return fmt.Errorf("failed to parse storage: %v", err)

--- a/cmd/harbor/root/registry/create.go
+++ b/cmd/harbor/root/registry/create.go
@@ -106,6 +106,8 @@ func createRegistryView(createView *api.CreateRegView) error {
 		createView = &api.CreateRegView{}
 	}
 
-	create.CreateRegistryView(createView)
+	if err := create.CreateRegistryView(createView); err != nil {
+		return err
+	}
 	return api.CreateRegistry(*createView)
 }

--- a/cmd/harbor/root/registry/list.go
+++ b/cmd/harbor/root/registry/list.go
@@ -15,11 +15,11 @@ package registry
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/registry/list"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -49,7 +49,7 @@ func ListRegistryCommand() *cobra.Command {
 			if formatFlag != "" {
 				err = utils.PrintFormat(registry, formatFlag)
 				if err != nil {
-					log.Error(err)
+					slog.Error(err.Error())
 				}
 			} else {
 				list.ListRegistry(registry.Payload)

--- a/cmd/harbor/root/registry/list.go
+++ b/cmd/harbor/root/registry/list.go
@@ -15,7 +15,6 @@ package registry
 
 import (
 	"fmt"
-	"log/slog"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
@@ -49,7 +48,7 @@ func ListRegistryCommand() *cobra.Command {
 			if formatFlag != "" {
 				err = utils.PrintFormat(registry, formatFlag)
 				if err != nil {
-					slog.Error(err.Error())
+					return err
 				}
 			} else {
 				list.ListRegistry(registry.Payload)

--- a/cmd/harbor/root/registry/update.go
+++ b/cmd/harbor/root/registry/update.go
@@ -97,7 +97,9 @@ func UpdateRegistryCommand() *cobra.Command {
 				updateView.Credential.Type = opts.Credential.Type
 			}
 
-			update.UpdateRegistryView(updateView)
+			if err := update.UpdateRegistryView(updateView); err != nil {
+				return err
+			}
 			err = api.UpdateRegistry(updateView, registryId)
 			if err != nil {
 				return fmt.Errorf("failed to update registry: %v", err)

--- a/cmd/harbor/root/replication/executions/list.go
+++ b/cmd/harbor/root/replication/executions/list.go
@@ -15,13 +15,13 @@ package executions
 
 import (
 	"fmt"
+	"log/slog"
 	"strconv"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/replication/execution/list"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -36,7 +36,7 @@ func ListCommand() *cobra.Command {
   harbor replication executions list`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			log.Debug("Starting replication executions list command")
+			slog.Debug("Starting replication executions list command")
 			if opts.Page < 1 {
 				return fmt.Errorf("page number must be greater than or equal to 1")
 			}
@@ -60,13 +60,13 @@ func ListCommand() *cobra.Command {
 				rpolicyID = prompt.GetReplicationPolicyFromUser()
 			}
 
-			log.Debug("Fetching executions...")
+			slog.Debug("Fetching executions...")
 			executions, err := api.ListReplicationExecutions(rpolicyID, opts)
 			if err != nil {
 				return fmt.Errorf("failed to get projects list: %v", utils.ParseHarborErrorMsg(err))
 			}
 
-			log.WithField("count", len(executions.Payload)).Debug("Number of executions fetched")
+			slog.Debug("Number of executions fetched", "count", len(executions.Payload))
 			if len(executions.Payload) == 0 {
 				fmt.Println("No executions found")
 				return nil
@@ -74,13 +74,13 @@ func ListCommand() *cobra.Command {
 
 			formatFlag := viper.GetString("output-format")
 			if formatFlag != "" {
-				log.WithField("output_format", formatFlag).Debug("Output format selected")
+				slog.Debug("Output format selected", "output_format", formatFlag)
 				err = utils.PrintFormat(executions.Payload, formatFlag)
 				if err != nil {
 					return err
 				}
 			} else {
-				log.Debug("Listing projects using default view")
+				slog.Debug("Listing projects using default view")
 				list.ListExecutions(executions.Payload)
 			}
 			return nil

--- a/cmd/harbor/root/replication/executions/list.go
+++ b/cmd/harbor/root/replication/executions/list.go
@@ -57,7 +57,11 @@ func ListCommand() *cobra.Command {
 					return fmt.Errorf("invalid replication policy ID: %s, %v", args[0], err)
 				}
 			} else {
-				rpolicyID = prompt.GetReplicationPolicyFromUser()
+				var err error
+				rpolicyID, err = prompt.GetReplicationPolicyFromUser()
+				if err != nil {
+					return fmt.Errorf("failed to get replication policy: %v", utils.ParseHarborErrorMsg(err))
+				}
 			}
 
 			slog.Debug("Fetching executions...")

--- a/cmd/harbor/root/replication/executions/view.go
+++ b/cmd/harbor/root/replication/executions/view.go
@@ -65,8 +65,14 @@ func ViewCommand() *cobra.Command {
 					return fmt.Errorf("invalid replication execution ID: %s, %v", args[0], err)
 				}
 			} else {
-				rpolicyID := prompt.GetReplicationPolicyFromUser()
-				execID = prompt.GetReplicationExecutionIDFromUser(rpolicyID)
+				rpolicyID, err := prompt.GetReplicationPolicyFromUser()
+				if err != nil {
+					return fmt.Errorf("failed to get replication policy: %v", utils.ParseHarborErrorMsg(err))
+				}
+				execID, err = prompt.GetReplicationExecutionIDFromUser(rpolicyID)
+				if err != nil {
+					return fmt.Errorf("failed to get replication execution: %v", utils.ParseHarborErrorMsg(err))
+				}
 			}
 
 			execution, err := api.GetReplicationExecution(execID)

--- a/cmd/harbor/root/replication/logs.go
+++ b/cmd/harbor/root/replication/logs.go
@@ -38,11 +38,24 @@ func LogsCommand() *cobra.Command {
 		Args: cobra.MaximumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if execID != 0 && taskID == 0 {
-				taskID = prompt.GetReplicationTaskIDFromUser(execID)
+				var err error
+				taskID, err = prompt.GetReplicationTaskIDFromUser(execID)
+				if err != nil {
+					return fmt.Errorf("failed to get replication task: %v", utils.ParseHarborErrorMsg(err))
+				}
 			} else if execID == 0 && taskID == 0 {
-				rpolicyID := prompt.GetReplicationPolicyFromUser()
-				execID = prompt.GetReplicationExecutionIDFromUser(rpolicyID)
-				taskID = prompt.GetReplicationTaskIDFromUser(execID)
+				rpolicyID, err := prompt.GetReplicationPolicyFromUser()
+				if err != nil {
+					return fmt.Errorf("failed to get replication policy: %v", utils.ParseHarborErrorMsg(err))
+				}
+				execID, err = prompt.GetReplicationExecutionIDFromUser(rpolicyID)
+				if err != nil {
+					return fmt.Errorf("failed to get replication execution: %v", utils.ParseHarborErrorMsg(err))
+				}
+				taskID, err = prompt.GetReplicationTaskIDFromUser(execID)
+				if err != nil {
+					return fmt.Errorf("failed to get replication task: %v", utils.ParseHarborErrorMsg(err))
+				}
 			} else if execID == 0 && taskID != 0 {
 				return fmt.Errorf("execution ID must be provided if task ID is specified")
 			}

--- a/cmd/harbor/root/replication/policies/create.go
+++ b/cmd/harbor/root/replication/policies/create.go
@@ -15,6 +15,7 @@ package policies
 
 import (
 	"fmt"
+	"log/slog"
 	"strconv"
 	"strings"
 
@@ -25,7 +26,6 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/replication/policies/create"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -39,10 +39,10 @@ func CreateCommand() *cobra.Command {
 		Short: "create replication policies",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			log.Debug("Starting replications create command")
+			slog.Debug("Starting replications create command")
 
 			if configFile != "" {
-				log.Debugf("Loading replication policy configuration from file: %s", configFile)
+				slog.Debug(fmt.Sprintf("Loading replication policy configuration from file: %s", configFile))
 				opts, err = config.LoadConfigFromFile(configFile)
 				if err != nil {
 					return fmt.Errorf("failed to load replication policy configuration: %v", err)

--- a/cmd/harbor/root/replication/policies/create.go
+++ b/cmd/harbor/root/replication/policies/create.go
@@ -56,7 +56,9 @@ func CreateCommand() *cobra.Command {
 				}
 			} else {
 				opts = &create.CreateView{}
-				create.CreateRPolicyView(opts, false)
+				if err := create.CreateRPolicyView(opts, false); err != nil {
+					return err
+				}
 				registryID = prompt.GetRegistryNameFromUser()
 			}
 

--- a/cmd/harbor/root/replication/policies/delete.go
+++ b/cmd/harbor/root/replication/policies/delete.go
@@ -39,7 +39,11 @@ func DeleteCommand() *cobra.Command {
 					return fmt.Errorf("invalid replication policy ID: %s, %v", args[0], err)
 				}
 			} else {
-				rpolicyID = prompt.GetReplicationPolicyFromUser()
+				var err error
+				rpolicyID, err = prompt.GetReplicationPolicyFromUser()
+				if err != nil {
+					return fmt.Errorf("failed to get replication policy: %v", utils.ParseHarborErrorMsg(err))
+				}
 			}
 
 			_, err := api.DeleteReplicationPolicy(rpolicyID)

--- a/cmd/harbor/root/replication/policies/list.go
+++ b/cmd/harbor/root/replication/policies/list.go
@@ -15,11 +15,11 @@ package policies
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/replication/policies/list"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -31,7 +31,7 @@ func ListCommand() *cobra.Command {
 		Short: "List replication policies",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			log.Debug("Starting replications list command")
+			slog.Debug("Starting replications list command")
 			if opts.Page < 1 {
 				return fmt.Errorf("page number must be greater than or equal to 1")
 			}
@@ -44,13 +44,13 @@ func ListCommand() *cobra.Command {
 				return fmt.Errorf("page size should be less than or equal to 100")
 			}
 
-			log.Debug("Fetching policies...")
+			slog.Debug("Fetching policies...")
 			allPolicies, err := api.ListReplicationPolicies(opts)
 			if err != nil {
 				return fmt.Errorf("failed to get projects list: %v", utils.ParseHarborErrorMsg(err))
 			}
 
-			log.WithField("count", len(allPolicies.Payload)).Debug("Number of policies fetched")
+			slog.Debug("Number of policies fetched", "count", len(allPolicies.Payload))
 			if len(allPolicies.Payload) == 0 {
 				fmt.Println("No policies found")
 				return nil
@@ -58,13 +58,13 @@ func ListCommand() *cobra.Command {
 
 			formatFlag := viper.GetString("output-format")
 			if formatFlag != "" {
-				log.WithField("output_format", formatFlag).Debug("Output format selected")
+				slog.Debug("Output format selected", "output_format", formatFlag)
 				err = utils.PrintFormat(allPolicies.Payload, formatFlag)
 				if err != nil {
 					return err
 				}
 			} else {
-				log.Debug("Listing projects using default view")
+				slog.Debug("Listing projects using default view")
 				list.ListPolicies(allPolicies.Payload)
 			}
 			return nil

--- a/cmd/harbor/root/replication/policies/update.go
+++ b/cmd/harbor/root/replication/policies/update.go
@@ -15,6 +15,7 @@ package policies
 
 import (
 	"fmt"
+	"log/slog"
 	"strconv"
 	"strings"
 
@@ -22,7 +23,6 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/views/replication/policies/create"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -189,7 +189,7 @@ explicitly provided flags (partial update).`,
 				}
 			}
 
-			log.Debugf("Updating replication policy: %s (ID: %d)", existingPolicy.Payload.Name, policyID)
+			slog.Debug(fmt.Sprintf("Updating replication policy: %s (ID: %d)", existingPolicy.Payload.Name, policyID))
 
 			// Branch: non-interactive if any update flag was explicitly provided.
 			if isNonInteractiveMode {

--- a/cmd/harbor/root/replication/policies/update.go
+++ b/cmd/harbor/root/replication/policies/update.go
@@ -99,7 +99,11 @@ explicitly provided flags (partial update).`,
 				return fmt.Errorf("policy-id is required when update flags are provided. Usage: harbor replication policies update <policy-id> --flag=value")
 			} else {
 				// In interactive mode, prompt for policy ID
-				policyID = prompt.GetReplicationPolicyFromUser()
+				var err error
+				policyID, err = prompt.GetReplicationPolicyFromUser()
+				if err != nil {
+					return fmt.Errorf("failed to get replication policy: %w", err)
+				}
 			}
 
 			existingPolicy, err := api.GetReplicationPolicy(policyID)
@@ -198,7 +202,9 @@ explicitly provided flags (partial update).`,
 				}
 			} else {
 				// Preserve the existing interactive TUI workflow.
-				create.CreateRPolicyView(createView, true)
+				if err := create.CreateRPolicyView(createView, true); err != nil {
+					return err
+				}
 			}
 
 			var updatedPolicy *models.ReplicationPolicy

--- a/cmd/harbor/root/replication/policies/view.go
+++ b/cmd/harbor/root/replication/policies/view.go
@@ -41,7 +41,11 @@ func ViewCommand() *cobra.Command {
 					return fmt.Errorf("invalid replication policy ID: %s, %v", args[0], err)
 				}
 			} else {
-				rpolicyID = prompt.GetReplicationPolicyFromUser()
+				var err error
+				rpolicyID, err = prompt.GetReplicationPolicyFromUser()
+				if err != nil {
+					return fmt.Errorf("failed to get replication policy: %v", utils.ParseHarborErrorMsg(err))
+				}
 			}
 
 			response, err := api.GetReplicationPolicy(rpolicyID)

--- a/cmd/harbor/root/replication/start.go
+++ b/cmd/harbor/root/replication/start.go
@@ -15,12 +15,12 @@ package replication
 
 import (
 	"fmt"
+	"log/slog"
 	"strconv"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -30,7 +30,7 @@ func StartCommand() *cobra.Command {
 		Short: "start replication",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			log.Debug("Starting replication")
+			slog.Debug("Starting replication")
 
 			var rpolicyID int64
 			if len(args) > 0 {

--- a/cmd/harbor/root/replication/start.go
+++ b/cmd/harbor/root/replication/start.go
@@ -41,7 +41,11 @@ func StartCommand() *cobra.Command {
 					return fmt.Errorf("invalid replication policy ID: %s, %v", args[0], err)
 				}
 			} else {
-				rpolicyID = prompt.GetReplicationPolicyFromUser()
+				var err error
+				rpolicyID, err = prompt.GetReplicationPolicyFromUser()
+				if err != nil {
+					return fmt.Errorf("failed to get replication policy: %v", utils.ParseHarborErrorMsg(err))
+				}
 			}
 			response, err := api.StartReplication(rpolicyID)
 			if err != nil {

--- a/cmd/harbor/root/replication/stop.go
+++ b/cmd/harbor/root/replication/stop.go
@@ -15,12 +15,12 @@ package replication
 
 import (
 	"fmt"
+	"log/slog"
 	"strconv"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -30,7 +30,7 @@ func StopCommand() *cobra.Command {
 		Short: "stop replication",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			log.Debug("Stopping replication")
+			slog.Debug("Stopping replication")
 
 			var rpolicyID int64
 			var executionID int64

--- a/cmd/harbor/root/replication/stop.go
+++ b/cmd/harbor/root/replication/stop.go
@@ -41,10 +41,20 @@ func StopCommand() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("invalid replication policy ID: %s, %v", args[0], err)
 				}
-				executionID = prompt.GetReplicationExecutionIDFromUser(rpolicyID)
+				executionID, err = prompt.GetReplicationExecutionIDFromUser(rpolicyID)
+				if err != nil {
+					return fmt.Errorf("failed to get replication execution: %v", utils.ParseHarborErrorMsg(err))
+				}
 			} else {
-				rpolicyID = prompt.GetReplicationPolicyFromUser()
-				executionID = prompt.GetReplicationExecutionIDFromUser(rpolicyID)
+				var err error
+				rpolicyID, err = prompt.GetReplicationPolicyFromUser()
+				if err != nil {
+					return fmt.Errorf("failed to get replication policy: %v", utils.ParseHarborErrorMsg(err))
+				}
+				executionID, err = prompt.GetReplicationExecutionIDFromUser(rpolicyID)
+				if err != nil {
+					return fmt.Errorf("failed to get replication execution: %v", utils.ParseHarborErrorMsg(err))
+				}
 			}
 
 			execution, err := api.GetReplicationExecution(executionID)

--- a/cmd/harbor/root/repository/delete.go
+++ b/cmd/harbor/root/repository/delete.go
@@ -42,7 +42,10 @@ func RepoDeleteCmd() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
 				}
-				repoName = prompt.GetRepoNameFromUser(projectName)
+				repoName, err = prompt.GetRepoNameFromUser(projectName)
+				if err != nil {
+					return fmt.Errorf("failed to get repository name: %v", utils.ParseHarborErrorMsg(err))
+				}
 			}
 			err = api.RepoDelete(projectName, repoName, false)
 			if err != nil {

--- a/cmd/harbor/root/repository/list.go
+++ b/cmd/harbor/root/repository/list.go
@@ -15,7 +15,6 @@ package repository
 
 import (
 	"fmt"
-	"log/slog"
 
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/repository"
 	"github.com/goharbor/harbor-cli/pkg/api"
@@ -72,7 +71,7 @@ func ListRepositoryCommand() *cobra.Command {
 			if FormatFlag != "" {
 				err = utils.PrintFormat(repos, FormatFlag)
 				if err != nil {
-					slog.Error(err.Error())
+					return err
 				}
 			} else {
 				list.ListRepositories(repos.Payload)

--- a/cmd/harbor/root/repository/list.go
+++ b/cmd/harbor/root/repository/list.go
@@ -15,13 +15,13 @@ package repository
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/repository"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/repository/list"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -72,7 +72,7 @@ func ListRepositoryCommand() *cobra.Command {
 			if FormatFlag != "" {
 				err = utils.PrintFormat(repos, FormatFlag)
 				if err != nil {
-					log.Error(err)
+					slog.Error(err.Error())
 				}
 			} else {
 				list.ListRepositories(repos.Payload)

--- a/cmd/harbor/root/repository/update.go
+++ b/cmd/harbor/root/repository/update.go
@@ -52,7 +52,10 @@ Examples:
 				if err != nil {
 					return fmt.Errorf("failed to get project name: %w", err)
 				}
-				repoName = prompt.GetRepoNameFromUser(projectName)
+				repoName, err = prompt.GetRepoNameFromUser(projectName)
+				if err != nil {
+					return fmt.Errorf("failed to get repository name: %w", err)
+				}
 			}
 
 			existingRepo, err := api.RepoView(projectName, repoName)

--- a/cmd/harbor/root/repository/view.go
+++ b/cmd/harbor/root/repository/view.go
@@ -46,7 +46,10 @@ func RepoViewCmd() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("failed to get project name: %v", utils.ParseHarborErrorMsg(err))
 				}
-				repoName = prompt.GetRepoNameFromUser(projectName)
+				repoName, err = prompt.GetRepoNameFromUser(projectName)
+				if err != nil {
+					return fmt.Errorf("failed to get repository name: %v", utils.ParseHarborErrorMsg(err))
+				}
 			}
 
 			repo, err = api.RepoView(projectName, repoName)

--- a/cmd/harbor/root/robot/create.go
+++ b/cmd/harbor/root/robot/create.go
@@ -167,7 +167,9 @@ func loadFromConfigFile(opts *create.CreateView, configFile string, permissions 
 func handleInteractiveInput(opts *create.CreateView, all bool, permissions *[]models.Permission, projectPermissionsMap map[string][]models.Permission) error {
 	// Show interactive form if needed
 	if opts.Name == "" || opts.Duration == 0 {
-		create.CreateRobotView(opts)
+		if err := create.CreateRobotView(opts); err != nil {
+			return err
+		}
 	}
 
 	// Validate duration
@@ -375,7 +377,9 @@ func createRobotAndHandleResponse(opts *create.CreateView, exportToFile bool) er
 		return nil
 	}
 
-	create.CreateRobotSecretView(name, secret)
+	if err := create.CreateRobotSecretView(name, secret); err != nil {
+		return err
+	}
 	if err := clipboard.WriteAll(secret); err != nil {
 		slog.Error("failed to write to clipboard")
 	} else {

--- a/cmd/harbor/root/robot/create.go
+++ b/cmd/harbor/root/robot/create.go
@@ -16,6 +16,7 @@ package robot
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 
 	"github.com/atotto/clipboard"
@@ -26,7 +27,6 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/robot/create"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -129,7 +129,7 @@ func loadFromConfigFile(opts *create.CreateView, configFile string, permissions 
 		return fmt.Errorf("failed to load robot config from file: %v", err)
 	}
 
-	logrus.Debug("Successfully loaded robot configuration")
+	slog.Debug("Successfully loaded robot configuration")
 	*opts = *loadedOpts
 
 	if opts.Level != "system" {
@@ -158,8 +158,8 @@ func loadFromConfigFile(opts *create.CreateView, configFile string, permissions 
 		}
 	}
 
-	logrus.Debugf("Loaded system robot with %d system permissions and %d project-specific permissions",
-		len(*permissions), len(projectPermissionsMap))
+	slog.Debug(fmt.Sprintf("Loaded system robot with %d system permissions and %d project-specific permissions",
+		len(*permissions), len(projectPermissionsMap)))
 
 	return nil
 }
@@ -377,7 +377,7 @@ func createRobotAndHandleResponse(opts *create.CreateView, exportToFile bool) er
 
 	create.CreateRobotSecretView(name, secret)
 	if err := clipboard.WriteAll(secret); err != nil {
-		logrus.Errorf("failed to write to clipboard")
+		slog.Error("failed to write to clipboard")
 	} else {
 		fmt.Println("secret copied to clipboard.")
 	}
@@ -407,12 +407,12 @@ func exportSecretToFile(name, secret, creationTime string, expiresAt int64) {
 	filename := fmt.Sprintf("%s-secret.json", name)
 	jsonData, err := json.MarshalIndent(secretJson, "", "  ")
 	if err != nil {
-		logrus.Errorf("Failed to marshal secret to JSON: %v", err)
+		slog.Error("Failed to marshal secret to JSON", "error", err)
 		return
 	}
 
 	if err := os.WriteFile(filename, jsonData, 0600); err != nil {
-		logrus.Errorf("Failed to write secret to file: %v", err)
+		slog.Error("Failed to write secret to file", "error", err)
 		return
 	}
 

--- a/cmd/harbor/root/robot/refresh.go
+++ b/cmd/harbor/root/robot/refresh.go
@@ -15,6 +15,8 @@ package robot
 
 import (
 	"fmt"
+	"log/slog"
+	"os"
 	"strconv"
 
 	"github.com/atotto/clipboard"
@@ -22,7 +24,6 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/robot/create"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/spf13/cobra"
 )
@@ -83,7 +84,8 @@ Examples:
 			} else {
 				robotID, err = prompt.GetRobotIDFromUser(-1)
 				if err != nil {
-					log.Fatalf("failed to get robot ID from user: %v", utils.ParseHarborErrorMsg(err))
+					slog.Error(fmt.Sprintf("failed to get robot ID from user: %v", utils.ParseHarborErrorMsg(err)))
+					os.Exit(1)
 				}
 			}
 
@@ -101,9 +103,11 @@ Examples:
 			if err != nil {
 				errorCode := utils.ParseHarborErrorCode(err)
 				if errorCode == "403" {
-					log.Fatalf("Permission denied: (Project) Admin privileges are required to execute this command.\n")
+					slog.Error("Permission denied: (Project) Admin privileges are required to execute this command.\n")
+					os.Exit(1)
 				} else {
-					log.Fatalf("failed to refresh robot secret: %v\n", utils.ParseHarborErrorMsg(err))
+					slog.Error(fmt.Sprintf("failed to refresh robot secret: %v\n", utils.ParseHarborErrorMsg(err)))
+					os.Exit(1)
 				}
 			}
 
@@ -134,11 +138,13 @@ Examples:
 func getSecret() string {
 	secret, err := utils.GetSecretStdin("Enter your secret: ")
 	if err != nil {
-		log.Fatalf("Error reading secret: %v\n", err)
+		slog.Error(fmt.Sprintf("Error reading secret: %v\n", err))
+		os.Exit(1)
 	}
 
 	if err := utils.ValidatePassword(secret); err != nil {
-		log.Fatalf("Invalid secret: %v\n", err)
+		slog.Error(fmt.Sprintf("Invalid secret: %v\n", err))
+		os.Exit(1)
 	}
 	return secret
 }

--- a/cmd/harbor/root/robot/refresh.go
+++ b/cmd/harbor/root/robot/refresh.go
@@ -15,8 +15,6 @@ package robot
 
 import (
 	"fmt"
-	"log/slog"
-	"os"
 	"strconv"
 
 	"github.com/atotto/clipboard"
@@ -84,8 +82,7 @@ Examples:
 			} else {
 				robotID, err = prompt.GetRobotIDFromUser(-1)
 				if err != nil {
-					slog.Error(fmt.Sprintf("failed to get robot ID from user: %v", utils.ParseHarborErrorMsg(err)))
-					os.Exit(1)
+					return fmt.Errorf("failed to get robot ID from user: %v", utils.ParseHarborErrorMsg(err))
 				}
 			}
 
@@ -96,26 +93,28 @@ Examples:
 				}
 			}
 			if secretStdin {
-				secret = getSecret()
+				secret, err = getSecret()
+				if err != nil {
+					return err
+				}
 			}
 
 			response, err := api.RefreshSecret(secret, robotID)
 			if err != nil {
 				errorCode := utils.ParseHarborErrorCode(err)
 				if errorCode == "403" {
-					slog.Error("Permission denied: (Project) Admin privileges are required to execute this command.\n")
-					os.Exit(1)
-				} else {
-					slog.Error(fmt.Sprintf("failed to refresh robot secret: %v\n", utils.ParseHarborErrorMsg(err)))
-					os.Exit(1)
+					return fmt.Errorf("Permission denied: (Project) Admin privileges are required to execute this command.\n")
 				}
+				return fmt.Errorf("failed to refresh robot secret: %v\n", utils.ParseHarborErrorMsg(err))
 			}
 
 			fmt.Println("Secret updated successfully.")
 
 			if response.Payload.Secret != "" {
 				secret = response.Payload.Secret
-				create.CreateRobotSecretView("", secret)
+				if err := create.CreateRobotSecretView("", secret); err != nil {
+					return err
+				}
 
 				err = clipboard.WriteAll(response.Payload.Secret)
 				if err != nil {
@@ -135,16 +134,14 @@ Examples:
 }
 
 // getSecret from commandline
-func getSecret() string {
+func getSecret() (string, error) {
 	secret, err := utils.GetSecretStdin("Enter your secret: ")
 	if err != nil {
-		slog.Error(fmt.Sprintf("Error reading secret: %v\n", err))
-		os.Exit(1)
+		return "", fmt.Errorf("Error reading secret: %v\n", err)
 	}
 
 	if err := utils.ValidatePassword(secret); err != nil {
-		slog.Error(fmt.Sprintf("Invalid secret: %v\n", err))
-		os.Exit(1)
+		return "", fmt.Errorf("Invalid secret: %v\n", err)
 	}
-	return secret
+	return secret, nil
 }

--- a/cmd/harbor/root/robot/update.go
+++ b/cmd/harbor/root/robot/update.go
@@ -15,6 +15,7 @@ package robot
 
 import (
 	"fmt"
+	"log/slog"
 	"strconv"
 
 	"github.com/charmbracelet/huh"
@@ -24,7 +25,6 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/robot/update"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -144,8 +144,8 @@ Examples:
 				}
 			}
 
-			logrus.Debugf("Loaded robot with %d system permissions and %d project-specific permissions",
-				len(permissions), len(projectPermissionsMap))
+			slog.Debug(fmt.Sprintf("Loaded robot with %d system permissions and %d project-specific permissions",
+				len(permissions), len(projectPermissionsMap)))
 
 			// Handle configuration from file or interactive input
 			if configFile != "" {
@@ -187,7 +187,7 @@ func loadFromConfigFileForUpdate(opts *update.UpdateView, configFile string, per
 		return fmt.Errorf("failed to load robot config from file: %v", err)
 	}
 
-	logrus.Debug("Successfully loaded robot configuration")
+	slog.Debug("Successfully loaded robot configuration")
 
 	// Only update fields that should be updated from the config file
 	// IMPORTANT: Do not update name or level as the Harbor API doesn't allow this
@@ -230,8 +230,8 @@ func loadFromConfigFileForUpdate(opts *update.UpdateView, configFile string, per
 		}
 	}
 
-	logrus.Debugf("Loaded robot update with %d system permissions and %d project-specific permissions",
-		len(*permissions), len(projectPermissionsMap))
+	slog.Debug(fmt.Sprintf("Loaded robot update with %d system permissions and %d project-specific permissions",
+		len(*permissions), len(projectPermissionsMap)))
 
 	return nil
 }
@@ -264,7 +264,7 @@ func handleInteractiveInputForUpdate(opts *update.UpdateView, all bool, permissi
 	}
 
 	if !updatePerms {
-		logrus.Debug("Keeping existing permissions")
+		slog.Debug("Keeping existing permissions")
 		return nil
 	}
 
@@ -296,7 +296,7 @@ func getSystemPermissionsForUpdate(all bool, permissions *[]models.Permission) e
 	}
 
 	if !updateSystem {
-		logrus.Debug("Keeping existing system permissions")
+		slog.Debug("Keeping existing system permissions")
 		return nil
 	}
 
@@ -328,10 +328,10 @@ func getProjectPermissionsForUpdate(opts *update.UpdateView, projectPermissionsM
 
 	switch permissionMode {
 	case "keep":
-		logrus.Debug("Keeping existing project permissions")
+		slog.Debug("Keeping existing project permissions")
 		return nil
 	case "clear":
-		logrus.Debug("Clearing all project permissions")
+		slog.Debug("Clearing all project permissions")
 		// Clear the map to remove all project permissions
 		for k := range projectPermissionsMap {
 			delete(projectPermissionsMap, k)
@@ -538,7 +538,7 @@ func validateProjectPermissions(permissions []models.Permission) ([]models.Permi
 
 	// Warn about invalid permissions
 	if len(invalidPerms) > 0 {
-		logrus.Warnf("Removed %d invalid project permissions: %v", len(invalidPerms), invalidPerms)
+		slog.Warn(fmt.Sprintf("Removed %d invalid project permissions: %v", len(invalidPerms), invalidPerms))
 	}
 
 	return validPerms, nil

--- a/cmd/harbor/root/robot/update.go
+++ b/cmd/harbor/root/robot/update.go
@@ -238,7 +238,9 @@ func loadFromConfigFileForUpdate(opts *update.UpdateView, configFile string, per
 
 func handleInteractiveInputForUpdate(opts *update.UpdateView, all bool, permissions *[]models.Permission, projectPermissionsMap map[string][]models.Permission) error {
 	// Show interactive form for updating basic details
-	update.UpdateRobotView(opts)
+	if err := update.UpdateRobotView(opts); err != nil {
+		return err
+	}
 
 	// Validate duration
 	if opts.Duration == 0 {

--- a/cmd/harbor/root/scan_all/metrics.go
+++ b/cmd/harbor/root/scan_all/metrics.go
@@ -14,10 +14,12 @@
 package scan_all
 
 import (
+	"fmt"
+	"log/slog"
+
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	view "github.com/goharbor/harbor-cli/pkg/views/scan-all/metrics"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -54,10 +56,10 @@ Examples:
   harbor-cli scan-all metrics --output-format json`,
 		Args: cobra.MaximumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			logrus.Debug("Retrieving scan all metrics")
+			slog.Debug("Retrieving scan all metrics")
 			metrics, err := api.GetScanAllMetrics(scheduled)
 			if err != nil {
-				logrus.Errorf("Failed to retrieve scan all metrics: %v", utils.ParseHarborErrorMsg(err))
+				slog.Error(fmt.Sprintf("Failed to retrieve scan all metrics: %v", utils.ParseHarborErrorMsg(err)))
 				return err
 			}
 

--- a/cmd/harbor/root/scan_all/run.go
+++ b/cmd/harbor/root/scan_all/run.go
@@ -15,12 +15,12 @@ package scan_all
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -54,7 +54,7 @@ The scan progress and results can be monitored through the metrics command
 or through the Harbor web interface.`,
 		Args: cobra.MaximumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			logrus.Debug("Initiating manual scan of all artifacts")
+			slog.Debug("Initiating manual scan of all artifacts")
 			// Random cron expression and random time need to be passed to the API, even though they are not used, otherwise it returns bad request
 			randomCron := "0 * * * * *"
 			randomTime := strfmt.DateTime{}

--- a/cmd/harbor/root/scan_all/stop.go
+++ b/cmd/harbor/root/scan_all/stop.go
@@ -15,10 +15,10 @@ package scan_all
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -39,10 +39,10 @@ Examples:
   harbor-cli scan-all stop && harbor-cli scan-all metrics`,
 		Args: cobra.MaximumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			logrus.Debug("Stopping scan all operation")
+			slog.Debug("Stopping scan all operation")
 			err := api.StopScanAll()
 			if err != nil {
-				logrus.Errorf("Failed to stop scan all operation: %v", utils.ParseHarborErrorMsg(err))
+				slog.Error(fmt.Sprintf("Failed to stop scan all operation: %v", utils.ParseHarborErrorMsg(err)))
 				return err
 			}
 			fmt.Printf("Successfully stopped scan all operation\n")

--- a/cmd/harbor/root/scan_all/update_schedule.go
+++ b/cmd/harbor/root/scan_all/update_schedule.go
@@ -141,7 +141,9 @@ func updatePredefinedSchedule(scheduleType string) error {
 func updateCustomSchedule(cron string) error {
 	if cron == "" {
 		slog.Debug("Opening interactive form for custom schedule configuration")
-		update.UpdateSchedule(&cron)
+		if err := update.UpdateSchedule(&cron); err != nil {
+			return err
+		}
 	}
 
 	if err := validateCron(cron); err != nil {

--- a/cmd/harbor/root/scan_all/update_schedule.go
+++ b/cmd/harbor/root/scan_all/update_schedule.go
@@ -16,6 +16,7 @@ package scan_all
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/go-openapi/strfmt"
@@ -23,7 +24,6 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/scan-all/update"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -84,7 +84,7 @@ Note: For custom schedules, if you provide a 5-field cron expression, the CLI wi
 				return fmt.Errorf("invalid schedule type: %s. Valid types are: none, hourly, daily, weekly, custom", args[0])
 			}
 
-			logrus.Debugf("Updating scan all schedule to type: %s", scheduleType)
+			slog.Debug(fmt.Sprintf("Updating scan all schedule to type: %s", scheduleType))
 
 			switch scheduleType {
 			case "None":
@@ -108,7 +108,7 @@ Note: For custom schedules, if you provide a 5-field cron expression, the CLI wi
 }
 
 func updateScheduleToNone() error {
-	logrus.Debug("Setting scan all schedule to None (disabled)")
+	slog.Debug("Setting scan all schedule to None (disabled)")
 	err := api.UpdateScanAllSchedule(models.ScheduleObj{Type: "None"})
 	if err != nil {
 		return fmt.Errorf("failed to disable scan schedule: %v", utils.ParseHarborErrorMsg(err))
@@ -118,7 +118,7 @@ func updateScheduleToNone() error {
 }
 
 func updatePredefinedSchedule(scheduleType string) error {
-	logrus.Debugf("Setting scan all schedule to %s", scheduleType)
+	slog.Debug(fmt.Sprintf("Setting scan all schedule to %s", scheduleType))
 
 	// Random cron expression and time needed by API
 	randomCron := "0 0 * * * * "
@@ -140,7 +140,7 @@ func updatePredefinedSchedule(scheduleType string) error {
 
 func updateCustomSchedule(cron string) error {
 	if cron == "" {
-		logrus.Debug("Opening interactive form for custom schedule configuration")
+		slog.Debug("Opening interactive form for custom schedule configuration")
 		update.UpdateSchedule(&cron)
 	}
 
@@ -148,7 +148,7 @@ func updateCustomSchedule(cron string) error {
 		return err
 	}
 
-	logrus.Debugf("Setting scan all schedule with custom cron expression: %s", cron)
+	slog.Debug(fmt.Sprintf("Setting scan all schedule with custom cron expression: %s", cron))
 
 	// Random time needed by API
 	randomTime := strfmt.DateTime{}
@@ -177,7 +177,7 @@ func validateCron(cron string) error {
 	fields := strings.Fields(cron)
 	if len(fields) < 6 {
 		if len(fields) == 5 {
-			logrus.Debugf("Converting 5-field cron to 6-field by adding '0' for seconds")
+			slog.Debug("Converting 5-field cron to 6-field by adding '0' for seconds")
 			return fmt.Errorf("harbor requires 6-field cron format (including seconds). Try: '0 %s'", cron)
 		}
 		return fmt.Errorf("harbor requires 6-field cron format (seconds minute hour day month weekday)")

--- a/cmd/harbor/root/scan_all/view_schedule.go
+++ b/cmd/harbor/root/scan_all/view_schedule.go
@@ -14,10 +14,12 @@
 package scan_all
 
 import (
+	"fmt"
+	"log/slog"
+
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/scan-all/view-schedule"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -50,10 +52,10 @@ You can use this command to verify changes after updating the schedule with the 
 		Args:    cobra.MaximumNArgs(0),
 		Aliases: []string{"vs"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			logrus.Debug("Retrieving scan all schedule configuration")
+			slog.Debug("Retrieving scan all schedule configuration")
 			schedule, err := api.GetScanAllSchedule()
 			if err != nil {
-				logrus.Errorf("Failed to retrieve scan all schedule: %v", utils.ParseHarborErrorMsg(err))
+				slog.Error(fmt.Sprintf("Failed to retrieve scan all schedule: %v", utils.ParseHarborErrorMsg(err)))
 				return err
 			}
 

--- a/cmd/harbor/root/scanner/create.go
+++ b/cmd/harbor/root/scanner/create.go
@@ -32,7 +32,9 @@ func CreateScannerCommand() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if opts.Name == "" || opts.Auth == "" || opts.URL == "" {
-				create.CreateScannerView(&opts)
+				if err := create.CreateScannerView(&opts); err != nil {
+					return err
+				}
 			} else {
 				// Validate URL when provided via flags
 				formattedUrl := utils.FormatUrl(opts.URL)

--- a/cmd/harbor/root/scanner/update.go
+++ b/cmd/harbor/root/scanner/update.go
@@ -109,7 +109,9 @@ Only the fields passed through flags will be updated; other fields will retain t
 				updateView.UseInternalAddr = &opts.UseInternalAddr
 			}
 
-			update.UpdateScannerView(updateView)
+			if err := update.UpdateScannerView(updateView); err != nil {
+				return err
+			}
 
 			err = api.UpdateScanner(registrationID, *updateView)
 			if err != nil {

--- a/cmd/harbor/root/tag/immutable/create.go
+++ b/cmd/harbor/root/tag/immutable/create.go
@@ -76,6 +76,8 @@ func createImmutableView(createView *create.CreateView, projectName string) erro
 		createView = &create.CreateView{}
 	}
 
-	create.CreateImmutableView(createView)
+	if err := create.CreateImmutableView(createView); err != nil {
+		return err
+	}
 	return api.CreateImmutable(*createView, projectName)
 }

--- a/cmd/harbor/root/user/create.go
+++ b/cmd/harbor/root/user/create.go
@@ -78,7 +78,9 @@ func UserCreateCmd() *cobra.Command {
 }
 
 func createUserView(createView *create.CreateView) error {
-	create.CreateUserView(createView)
+	if err := create.CreateUserView(createView); err != nil {
+		return err
+	}
 	return api.CreateUser(*createView)
 }
 

--- a/cmd/harbor/root/user/delete.go
+++ b/cmd/harbor/root/user/delete.go
@@ -15,11 +15,11 @@ package user
 
 import (
 	"fmt"
+	"log/slog"
 	"sync"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -38,7 +38,7 @@ func UserDeleteCmd() *cobra.Command {
 					// Retrieve user ID by name.
 					userID, err := api.GetUsersIdByName(arg)
 					if err != nil {
-						log.Errorf("failed to get user id for '%s': %v", arg, err)
+						slog.Error(fmt.Sprintf("failed to get user id for '%s'", arg), "error", err)
 						continue
 					}
 					wg.Add(1)

--- a/cmd/harbor/root/user/elevate.go
+++ b/cmd/harbor/root/user/elevate.go
@@ -16,11 +16,11 @@ package user
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/views"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -38,30 +38,30 @@ func ElevateUser(args []string) error {
 		userId, err = getUsersIDByName(args[0])
 		if err != nil {
 			err = fmt.Errorf("failed to get user id for '%s': %v", args[0], err)
-			log.Error(err.Error())
+			slog.Error(err.Error())
 			return err
 		}
 		if userId == 0 {
 			err = fmt.Errorf("User with name '%s' not found", args[0])
-			log.Error(err.Error())
+			slog.Error(err.Error())
 			return err
 		}
 	} else {
 		userId, err = getUserIDFromUser()
 		if err != nil {
-			log.Errorf("failed to get user id: %v", err)
+			slog.Error("failed to get user id", "error", err)
 			return err
 		}
 	}
 	confirm, err := confirmElevation()
 	if err != nil {
 		err = fmt.Errorf("failed to confirm elevation: %v", err)
-		log.Error(err.Error())
+		slog.Error(err.Error())
 		return err
 	}
 	if !confirm {
 		err = errors.New("User did not confirm elevation. Aborting command.")
-		log.Error(err.Error())
+		slog.Error(err.Error())
 		return err
 	}
 
@@ -72,7 +72,7 @@ func ElevateUser(args []string) error {
 		} else {
 			err = fmt.Errorf("failed to elevate user: %v", err)
 		}
-		log.Error(err.Error())
+		slog.Error(err.Error())
 		return err
 	}
 	return nil

--- a/cmd/harbor/root/user/elevate_test.go
+++ b/cmd/harbor/root/user/elevate_test.go
@@ -16,10 +16,10 @@ package user
 import (
 	"bytes"
 	"fmt"
+	"log/slog"
 	"strings"
 	"testing"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -176,9 +176,9 @@ func TestElevateUser(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			originalLogOutput := log.StandardLogger().Out
-			log.SetOutput(&buf)
-			defer log.SetOutput(originalLogOutput)
+			originalLogger := slog.Default()
+			slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+			defer slog.SetDefault(originalLogger)
 
 			m := tt.setup()
 

--- a/cmd/harbor/root/user/list.go
+++ b/cmd/harbor/root/user/list.go
@@ -15,7 +15,6 @@ package user
 
 import (
 	"fmt"
-	"log/slog"
 
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/api"
@@ -77,7 +76,7 @@ func UserListCmd() *cobra.Command {
 			if formatFlag != "" {
 				err := utils.PrintFormat(allUsers, formatFlag)
 				if err != nil {
-					slog.Error(err.Error())
+					return err
 				}
 			} else {
 				list.ListUsers(allUsers)

--- a/cmd/harbor/root/user/list.go
+++ b/cmd/harbor/root/user/list.go
@@ -15,12 +15,12 @@ package user
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/user/list"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -77,7 +77,7 @@ func UserListCmd() *cobra.Command {
 			if formatFlag != "" {
 				err := utils.PrintFormat(allUsers, formatFlag)
 				if err != nil {
-					log.Error(err)
+					slog.Error(err.Error())
 				}
 			} else {
 				list.ListUsers(allUsers)

--- a/cmd/harbor/root/user/password.go
+++ b/cmd/harbor/root/user/password.go
@@ -79,7 +79,9 @@ func UserPasswordChangeCmd() *cobra.Command {
 				}
 			} else {
 				resetView := &reset.PasswordChangeView{}
-				reset.ChangePasswordView(resetView)
+				if err := reset.ChangePasswordView(resetView); err != nil {
+					return err
+				}
 				opts = *resetView
 			}
 

--- a/cmd/harbor/root/user/password.go
+++ b/cmd/harbor/root/user/password.go
@@ -22,7 +22,6 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/prompt"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/password/reset"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -39,7 +38,6 @@ func UserPasswordChangeCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var userId int64
 			var err error
-			log.SetOutput(cmd.OutOrStderr())
 
 			// Resolve user ID: flag > positional arg > interactive prompt
 			if userID != 0 {

--- a/cmd/harbor/root/vulnerability/list.go
+++ b/cmd/harbor/root/vulnerability/list.go
@@ -15,12 +15,12 @@ package vulnerability
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	vulnlist "github.com/goharbor/harbor-cli/pkg/views/vulnerability/list"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -89,7 +89,7 @@ func fetchVulnerabilities(opts api.ListVulnerabilityOptions) ([]*models.Vulnerab
 	if opts.All {
 		var allVulnerabilities []*models.VulnerabilityItem
 
-		log.Debug("Fetching all vulnerabilities")
+		slog.Debug("Fetching all vulnerabilities")
 		opts.PageSize = 100
 		opts.Page = 1
 

--- a/cmd/harbor/root/webhook/edit.go
+++ b/cmd/harbor/root/webhook/edit.go
@@ -150,6 +150,8 @@ func editWebhookView(view *edit.EditView) error {
 		view.VerifyRemoteCertificate = !selectedWebhook.Targets[0].SkipCertVerify
 		view.NotifyType = selectedWebhook.Targets[0].Type
 	}
-	edit.WebhookEditView(view)
+	if err := edit.WebhookEditView(view); err != nil {
+		return err
+	}
 	return updateWebhook(view)
 }

--- a/doc/doc.go
+++ b/doc/doc.go
@@ -53,9 +53,7 @@ func Doc() error {
 		slog.Info(fmt.Sprintf("Folder %s does not exist", folderName))
 		err = os.Mkdir(folderName, 0755)
 		if err != nil {
-			slog.Info(fmt.Sprintf("Failed to create directory %s : %v", folderName, err))
-			slog.Error(fmt.Sprint("Error creating folder:", err))
-			os.Exit(1)
+			return fmt.Errorf("error creating folder %s: %v", folderName, err)
 		}
 	}
 	docDir := fmt.Sprintf("%s/%s", currentDir, folderName)

--- a/doc/doc.go
+++ b/doc/doc.go
@@ -17,13 +17,13 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"log/slog"
 	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
 
 	cmd "github.com/goharbor/harbor-cli/cmd/harbor/root"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"go.yaml.in/yaml/v4"
 )
@@ -50,11 +50,12 @@ func Doc() error {
 	folderName := "cli-docs"
 	_, err = os.Stat(folderName)
 	if os.IsNotExist(err) {
-		log.Printf("Folder %s does not exist", folderName)
+		slog.Info(fmt.Sprintf("Folder %s does not exist", folderName))
 		err = os.Mkdir(folderName, 0755)
 		if err != nil {
-			log.Printf("Failed to create directory %s : %v", folderName, err)
-			log.Fatal("Error creating folder:", err)
+			slog.Info(fmt.Sprintf("Failed to create directory %s : %v", folderName, err))
+			slog.Error(fmt.Sprint("Error creating folder:", err))
+			os.Exit(1)
 		}
 	}
 	docDir := fmt.Sprintf("%s/%s", currentDir, folderName)
@@ -222,7 +223,7 @@ func getWeight(filename string) int {
 	// Read the entire file
 	data, err := os.ReadFile(filename)
 	if err != nil {
-		log.Warningf("unable to read file: %v", filename)
+		slog.Warn(fmt.Sprintf("unable to read file: %v", filename))
 		return 0
 	}
 
@@ -231,7 +232,7 @@ func getWeight(filename string) int {
 
 	// Check and extract YAML front matter
 	if len(lines) < 3 || lines[0] != "---" {
-		log.Warningf("YAML front matter not found on file: %v", filename)
+		slog.Warn(fmt.Sprintf("YAML front matter not found on file: %v", filename))
 		return 0
 	}
 
@@ -249,7 +250,7 @@ func getWeight(filename string) int {
 	var fm FrontMatter
 	err = yaml.Unmarshal([]byte(yamlContent), &fm)
 	if err != nil {
-		log.Warningf("Failed to parse YAML in file %s", filename)
+		slog.Warn(fmt.Sprintf("Failed to parse YAML in file %s", filename))
 		return 0
 	}
 	return fm.Weight
@@ -258,6 +259,7 @@ func getWeight(filename string) int {
 func main() {
 	err := Doc()
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 }

--- a/doc/doc_test.go
+++ b/doc/doc_test.go
@@ -16,6 +16,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -23,7 +24,6 @@ import (
 
 	"regexp"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"go.yaml.in/yaml/v4"
 )
@@ -227,9 +227,9 @@ weight: [20]
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			buf := new(bytes.Buffer)
-			originalLogOutput := log.StandardLogger().Out
-			log.SetOutput(buf)
-			defer log.SetOutput(originalLogOutput)
+			originalLogger := slog.Default()
+			slog.SetDefault(slog.New(slog.NewTextHandler(buf, nil)))
+			defer slog.SetDefault(originalLogger)
 
 			filename := tt.setup(t)
 			got := getWeight(filename)

--- a/doc/man-docs/man_doc.go
+++ b/doc/man-docs/man_doc.go
@@ -36,8 +36,7 @@ func ManDoc() error {
 	if os.IsNotExist(err) {
 		err = os.Mkdir(folderName, 0755)
 		if err != nil {
-			slog.Error(fmt.Sprint("Error creating folder:", err))
-			os.Exit(1)
+			return fmt.Errorf("error creating folder: %v", err)
 		}
 	}
 	docDir := fmt.Sprintf("%s/%s", currentDir, folderName)
@@ -57,8 +56,7 @@ func ManDoc() error {
 
 	err = cleanManPages(docDir)
 	if err != nil {
-		slog.Error("Error cleaning up documentation", "error", err)
-		os.Exit(1)
+		return fmt.Errorf("error cleaning up documentation: %v", err)
 	}
 
 	fmt.Println("Documentation generated successfully in", docDir)

--- a/doc/man-docs/man_doc.go
+++ b/doc/man-docs/man_doc.go
@@ -16,13 +16,13 @@ package main
 import (
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 
 	cmd "github.com/goharbor/harbor-cli/cmd/harbor/root"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra/doc"
 )
 
@@ -36,7 +36,8 @@ func ManDoc() error {
 	if os.IsNotExist(err) {
 		err = os.Mkdir(folderName, 0755)
 		if err != nil {
-			log.Fatal("Error creating folder:", err)
+			slog.Error(fmt.Sprint("Error creating folder:", err))
+			os.Exit(1)
 		}
 	}
 	docDir := fmt.Sprintf("%s/%s", currentDir, folderName)
@@ -56,7 +57,8 @@ func ManDoc() error {
 
 	err = cleanManPages(docDir)
 	if err != nil {
-		log.Fatalf("Error cleaning up documentation: %v", err)
+		slog.Error("Error cleaning up documentation", "error", err)
+		os.Exit(1)
 	}
 
 	fmt.Println("Documentation generated successfully in", docDir)
@@ -125,6 +127,7 @@ func cleanManPages(docDir string) error {
 func main() {
 	err := ManDoc()
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/gocarina/gocsv v0.0.0-20240520201108-78e41c74b4b1
 	github.com/sahilm/fuzzy v0.1.3
-	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -144,8 +144,6 @@ github.com/sagikazarmark/locafero v0.11.0 h1:1iurJgmM9G3PA/I+wWYIOw/5SyBtxapeHDc
 github.com/sagikazarmark/locafero v0.11.0/go.mod h1:nVIGvgyzw595SUSUE6tvCp3YYTeHs15MvlmU87WwIik=
 github.com/sahilm/fuzzy v0.1.3 h1:juByESSS32nVD81vr6tHmKmA/8zde7gE+x5CLxrzXPU=
 github.com/sahilm/fuzzy v0.1.3/go.mod h1:au6//VbVSqu6DFrkL2CfjlJ5iURpNCPeE+1GwY3XsT8=
-github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
-github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
 github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 h1:+jumHNA0Wrelhe64i8F6HNlS8pkoyMv5sreGx2Ry5Rw=
 github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8/go.mod h1:3n1Cwaq1E1/1lhQhtRK2ts/ZwZEhjcQeJQ1RuC6Q/8U=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=

--- a/pkg/api/artifact_handler.go
+++ b/pkg/api/artifact_handler.go
@@ -15,12 +15,12 @@ package api
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/artifact"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/scan"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 )
 
 // DeleteArtifact handles the deletion of an artifact.
@@ -36,7 +36,7 @@ func DeleteArtifact(projectName, repoName, reference string) error {
 		Reference:      reference,
 	})
 	if err != nil {
-		log.Errorf("Failed to delete artifact: %v", err)
+		slog.Error("Failed to delete artifact", "error", err)
 		return err
 	}
 
@@ -105,7 +105,7 @@ func StartScanArtifact(projectName, repoName, reference string) error {
 		Reference:      reference,
 	})
 	if err != nil {
-		log.Errorf("Failed to start scan: %v", err)
+		slog.Error("Failed to start scan", "error", err)
 		return err
 	}
 
@@ -126,7 +126,7 @@ func StopScanArtifact(projectName, repoName, reference string) error {
 		Reference:      reference,
 	})
 	if err != nil {
-		log.Errorf("Failed to stop scan: %v", err)
+		slog.Error("Failed to stop scan", "error", err)
 		return err
 	}
 
@@ -148,7 +148,7 @@ func DeleteTag(projectName, repoName, reference, tag string) error {
 		TagName:        tag,
 	})
 	if err != nil {
-		log.Errorf("Failed to delete tag: %v", err)
+		slog.Error("Failed to delete tag", "error", err)
 		return err
 	}
 
@@ -170,7 +170,7 @@ func ListTags(projectName, repoName, reference string) (*artifact.ListTagsOK, er
 	})
 
 	if err != nil {
-		log.Errorf("Failed to list tags: %v", err)
+		slog.Error("Failed to list tags", "error", err)
 		return &artifact.ListTagsOK{}, err
 	}
 
@@ -192,7 +192,7 @@ func CreateTag(projectName, repoName, reference, tagName string) error {
 		},
 	})
 	if err != nil {
-		log.Errorf("Failed to create tag: %v", err)
+		slog.Error("Failed to create tag", "error", err)
 		return err
 	}
 	fmt.Printf("Tag created successfully: %s/%s@%s:%s\n", projectName, repoName, reference, tagName)
@@ -215,7 +215,7 @@ func AddLabelArtifact(projectName, repoName, reference string, label *models.Lab
 	})
 
 	if err != nil {
-		log.Errorf("Failed to set label on artifact: %v", err)
+		slog.Error("Failed to set label on artifact", "error", err)
 		return response, err
 	}
 
@@ -238,7 +238,7 @@ func RemoveLabelArtifact(projectName, repoName, reference string, labelID int64)
 	})
 
 	if err != nil {
-		log.Errorf("Failed to remove label on artifact: %v", err)
+		slog.Error("Failed to remove label on artifact", "error", err)
 		return response, err
 	}
 

--- a/pkg/api/ping_handler.go
+++ b/pkg/api/ping_handler.go
@@ -14,21 +14,22 @@
 package api
 
 import (
+	"log/slog"
+
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/ping"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	"github.com/sirupsen/logrus"
 )
 
 func Ping() error {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {
-		logrus.Errorf("failed to get client: %v", err)
+		slog.Error("failed to get client", "error", err)
 		return err
 	}
 
 	_, err = client.Ping.GetPing(ctx, &ping.GetPingParams{})
 	if err != nil {
-		logrus.Errorf("failed to ping the server: %v", err)
+		slog.Error("failed to ping the server", "error", err)
 		return err
 	}
 

--- a/pkg/api/project_handler.go
+++ b/pkg/api/project_handler.go
@@ -15,6 +15,7 @@ package api
 
 import (
 	"fmt"
+	"log/slog"
 	"strconv"
 
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/project"
@@ -23,7 +24,6 @@ import (
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/project/create"
-	log "github.com/sirupsen/logrus"
 )
 
 func CreateProject(opts create.CreateView) error {
@@ -93,39 +93,39 @@ func DeleteProject(projectNameOrID string, forceDelete bool, useProjectID bool) 
 
 		project, err := GetProject(projectNameOrID, useProjectID)
 		if err != nil {
-			log.Errorf("failed to get project name: %v", err)
+			slog.Error("failed to get project name", "error", err)
 			return err
 		}
 		projectName := project.Payload.Name
 
 		immutables, err := ListImmutable(projectName)
 		if err != nil {
-			log.Errorf("failed to list immutables for project: %v", err)
+			slog.Error("failed to list immutables for project", "error", err)
 			return err
 		}
 		for _, rule := range immutables.Payload {
 			err = DeleteImmutable(projectName, rule.ID)
 			if err != nil {
-				log.Errorf("failed to delete tag immutable rule: %v", err)
+				slog.Error("failed to delete tag immutable rule", "error", err)
 				return err
 			}
 		}
 
 		resp, err = ListRepository(projectNameOrID, useProjectID)
 		if err != nil {
-			log.Errorf("failed to list repositories: %v", err)
+			slog.Error("failed to list repositories", "error", err)
 			return err
 		}
 
 		for _, repo := range resp.Payload {
 			_, repoName, err := utils.ParseProjectRepo(repo.Name)
 			if err != nil {
-				log.Errorf("failed to parse project/repo: %v", err)
+				slog.Error("failed to parse project/repo", "error", err)
 				return err
 			}
 			err = RepoDelete(projectNameOrID, repoName, useProjectID)
 			if err != nil {
-				log.Errorf("failed to delete repository: %v", err)
+				slog.Error("failed to delete repository", "error", err)
 				return err
 			}
 		}

--- a/pkg/api/robot_handler.go
+++ b/pkg/api/robot_handler.go
@@ -15,6 +15,7 @@ package api
 
 import (
 	"fmt"
+	"log/slog"
 	"strconv"
 
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/permissions"
@@ -25,7 +26,6 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/robot/create"
 	"github.com/goharbor/harbor-cli/pkg/views/robot/update"
-	log "github.com/sirupsen/logrus"
 )
 
 func ListRobot(opts ListFlags) (*robot.ListRobotOK, error) {
@@ -199,7 +199,7 @@ func CreateRobot(opts create.CreateView) (*robot.CreateRobotCreated, error) {
 func UpdateRobot(opts *update.UpdateView) error {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {
-		log.Errorf("Error: %v", err)
+		slog.Error("Error", "error", err)
 		return err
 	}
 
@@ -233,7 +233,7 @@ func UpdateRobot(opts *update.UpdateView) error {
 		},
 	)
 	if err != nil {
-		log.Errorf("Error in updating Robot: %v", err)
+		slog.Error("Error in updating Robot", "error", err)
 		return err
 	}
 

--- a/pkg/api/webhook_handler.go
+++ b/pkg/api/webhook_handler.go
@@ -15,6 +15,7 @@ package api
 
 import (
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/webhook"
@@ -22,7 +23,6 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/utils"
 	"github.com/goharbor/harbor-cli/pkg/views/webhook/create"
 	"github.com/goharbor/harbor-cli/pkg/views/webhook/edit"
-	log "github.com/sirupsen/logrus"
 )
 
 func ListWebhooks(projectName string) (webhook.ListWebhookPoliciesOfProjectOK, error) {
@@ -80,7 +80,7 @@ func CreateWebhook(opts *create.CreateView) error {
 func DeleteWebhook(projectName string, webhookId int64) error {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {
-		log.Errorf("%s", err)
+		slog.Error(err.Error())
 		return err
 	}
 	response, err := client.Webhook.DeleteWebhookPolicyOfProject(ctx, &webhook.DeleteWebhookPolicyOfProjectParams{
@@ -99,7 +99,7 @@ func DeleteWebhook(projectName string, webhookId int64) error {
 func UpdateWebhook(opts *edit.EditView) error {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {
-		log.Errorf("%s", err)
+		slog.Error(err.Error())
 		return err
 	}
 
@@ -134,7 +134,7 @@ func UpdateWebhook(opts *edit.EditView) error {
 func GetWebhookID(projectName string, WebhookName string) (int64, error) {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {
-		log.Errorf("%s", err)
+		slog.Error(err.Error())
 		return 0, err
 	}
 	response, err := client.Webhook.ListWebhookPoliciesOfProject(ctx, &webhook.ListWebhookPoliciesOfProjectParams{
@@ -157,7 +157,7 @@ func GetWebhookID(projectName string, WebhookName string) (int64, error) {
 func GetWebhook(projectName string, webhookId int64) (models.WebhookPolicy, error) {
 	ctx, client, err := utils.ContextWithClient()
 	if err != nil {
-		log.Errorf("%s", err)
+		slog.Error(err.Error())
 		return models.WebhookPolicy{}, err
 	}
 	IsResourceName := true

--- a/pkg/config/preheat/policies.go
+++ b/pkg/config/preheat/policies.go
@@ -16,12 +16,12 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 
 	policycreate "github.com/goharbor/harbor-cli/pkg/views/preheat/policy/create"
-	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
 
@@ -76,7 +76,7 @@ func LoadConfigFromYAMLorJSON(filename string, fileType string) (*policycreate.C
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file: %v", err)
 	}
-	log.Debug("Preheat policy config file read successfully")
+	slog.Debug("Preheat policy config file read successfully")
 
 	var config PolicyConfig
 	switch fileType {
@@ -84,13 +84,13 @@ func LoadConfigFromYAMLorJSON(filename string, fileType string) (*policycreate.C
 		if err := yaml.Unmarshal(data, &config); err != nil {
 			return nil, fmt.Errorf("failed to parse YAML: %v", err)
 		}
-		log.Debugf("Parsed %s configuration successfully", fileType)
+		slog.Debug(fmt.Sprintf("Parsed %s configuration successfully", fileType))
 
 	case "json":
 		if err := json.Unmarshal(data, &config); err != nil {
 			return nil, fmt.Errorf("failed to parse JSON: %v", err)
 		}
-		log.Debugf("Parsed %s configuration successfully", fileType)
+		slog.Debug(fmt.Sprintf("Parsed %s configuration successfully", fileType))
 	default:
 		return nil, fmt.Errorf("unsupported file type: %s, expected 'yaml' or 'json'", fileType)
 	}
@@ -98,7 +98,7 @@ func LoadConfigFromYAMLorJSON(filename string, fileType string) (*policycreate.C
 	if err := validateConfig(&config); err != nil {
 		return nil, fmt.Errorf("configuration validation failed: %v", err)
 	}
-	log.Debug("Preheat policy configuration validated successfully")
+	slog.Debug("Preheat policy configuration validated successfully")
 
 	triggerType := "manual"
 	cronString := ""

--- a/pkg/config/replication/policies.go
+++ b/pkg/config/replication/policies.go
@@ -16,12 +16,12 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/goharbor/harbor-cli/pkg/views/replication/policies/create"
-	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
 
@@ -72,7 +72,7 @@ func LoadConfigFromYAMLorJSON(filename string, fileType string) (*create.CreateV
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file: %v", err)
 	}
-	log.Debug("Replication policy config file read successfully")
+	slog.Debug("Replication policy config file read successfully")
 
 	var config PolicyConfig
 	switch fileType {
@@ -80,13 +80,13 @@ func LoadConfigFromYAMLorJSON(filename string, fileType string) (*create.CreateV
 		if err := yaml.Unmarshal(data, &config); err != nil {
 			return nil, fmt.Errorf("failed to parse YAML: %v", err)
 		}
-		log.Debugf("Parsed %s configuration successfully", fileType)
+		slog.Debug(fmt.Sprintf("Parsed %s configuration successfully", fileType))
 
 	case "json":
 		if err := json.Unmarshal(data, &config); err != nil {
 			return nil, fmt.Errorf("failed to parse JSON: %v", err)
 		}
-		log.Debugf("Parsed %s configuration successfully", fileType)
+		slog.Debug(fmt.Sprintf("Parsed %s configuration successfully", fileType))
 	default:
 		return nil, fmt.Errorf("unsupported file type: %s, expected 'yaml' or 'json'", fileType)
 	}
@@ -94,7 +94,7 @@ func LoadConfigFromYAMLorJSON(filename string, fileType string) (*create.CreateV
 	if err := validateConfig(&config); err != nil {
 		return nil, fmt.Errorf("configuration validation failed: %v", err)
 	}
-	log.Debug("Replication policy configuration validated successfully")
+	slog.Debug("Replication policy configuration validated successfully")
 
 	opts := &create.CreateView{
 		Name:              config.Name,

--- a/pkg/logger/handler.go
+++ b/pkg/logger/handler.go
@@ -33,7 +33,7 @@ var (
 )
 
 type PrettyHandler struct {
-	mu       sync.Mutex
+	mu       *sync.Mutex // shared across derived handlers writing to the same out
 	out      io.Writer
 	level    slog.Leveler
 	preAttrs []slog.Attr // retained from WithAttrs calls
@@ -42,6 +42,7 @@ type PrettyHandler struct {
 
 func NewPrettyHandler(out io.Writer, level slog.Leveler) *PrettyHandler {
 	return &PrettyHandler{
+		mu:    &sync.Mutex{},
 		out:   out,
 		level: level,
 	}
@@ -114,6 +115,7 @@ func (h *PrettyHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	copy(newPreAttrs[len(h.preAttrs):], attrs)
 
 	return &PrettyHandler{
+		mu:       h.mu,
 		out:      h.out,
 		level:    h.level,
 		preAttrs: newPreAttrs,
@@ -130,6 +132,7 @@ func (h *PrettyHandler) WithGroup(name string) slog.Handler {
 	newGroups[len(h.groups)] = name
 
 	return &PrettyHandler{
+		mu:       h.mu,
 		out:      h.out,
 		level:    h.level,
 		preAttrs: h.preAttrs,

--- a/pkg/logger/handler.go
+++ b/pkg/logger/handler.go
@@ -114,6 +114,8 @@ func (h *PrettyHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	copy(newPreAttrs[len(h.preAttrs):], attrs)
 
 	return &PrettyHandler{
+		out:      h.out,
+		level:    h.level,
 		preAttrs: newPreAttrs,
 		groups:   h.groups,
 	}
@@ -128,6 +130,8 @@ func (h *PrettyHandler) WithGroup(name string) slog.Handler {
 	newGroups[len(h.groups)] = name
 
 	return &PrettyHandler{
+		out:      h.out,
+		level:    h.level,
 		preAttrs: h.preAttrs,
 		groups:   newGroups,
 	}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -22,7 +22,8 @@ import (
 func Setup(verbose bool, format string) {
 	outp := io.Discard
 	if verbose {
-		outp = os.Stdout
+		// Logs go to stderr so command payloads on stdout stay parsable
+		outp = os.Stderr
 	}
 
 	var handler slog.Handler

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -17,7 +17,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"os"
 	"strconv"
 
 	"github.com/goharbor/harbor-cli/pkg/utils"
@@ -144,19 +143,18 @@ func GetRoleNameFromUser() int64 {
 	return <-roleChan
 }
 
-func GetRepoNameFromUser(projectName string) string {
-	repositoryName := make(chan string)
+func GetRepoNameFromUser(projectName string) (string, error) {
+	response, err := api.ListRepository(projectName, false)
+	if err != nil {
+		return "", err
+	}
 
+	repositoryName := make(chan string)
 	go func() {
-		response, err := api.ListRepository(projectName, false)
-		if err != nil {
-			slog.Error(err.Error())
-			os.Exit(1)
-		}
 		repoView.RepositoryList(response.Payload, repositoryName)
 	}()
 
-	return <-repositoryName
+	return <-repositoryName, nil
 }
 
 // complete the function
@@ -386,57 +384,52 @@ func GetRobotIDFromUser(projectID int64) (int64, error) {
 	return id, nil
 }
 
-func GetReplicationPolicyFromUser() int64 {
-	replicationPolicyID := make(chan int64)
+func GetReplicationPolicyFromUser() (int64, error) {
+	response, err := api.ListReplicationPolicies()
+	if err != nil {
+		return 0, err
+	}
 
+	replicationPolicyID := make(chan int64)
 	go func() {
-		response, err := api.ListReplicationPolicies()
-		if err != nil {
-			slog.Error(err.Error())
-			os.Exit(1)
-		}
 		rpolicies.ReplicationPoliciesList(response.Payload, replicationPolicyID)
 	}()
 
-	return <-replicationPolicyID
+	return <-replicationPolicyID, nil
 }
 
-func GetReplicationExecutionIDFromUser(rpolicyID int64) int64 {
-	executionID := make(chan int64)
+func GetReplicationExecutionIDFromUser(rpolicyID int64) (int64, error) {
+	response, err := api.ListReplicationExecutions(rpolicyID)
+	if err != nil {
+		return 0, err
+	}
+	if len(response.Payload) == 0 {
+		return 0, errors.New("no replication executions found")
+	}
 
+	executionID := make(chan int64)
 	go func() {
-		response, err := api.ListReplicationExecutions(rpolicyID)
-		if err != nil {
-			slog.Error(err.Error())
-			os.Exit(1)
-		}
-		if len(response.Payload) == 0 {
-			slog.Error("no replication executions found")
-			os.Exit(1)
-		}
 		rexecutions.ReplicationExecutionList(response.Payload, executionID)
 	}()
 
-	return <-executionID
+	return <-executionID, nil
 }
 
-func GetReplicationTaskIDFromUser(execID int64) int64 {
-	executionID := make(chan int64)
+func GetReplicationTaskIDFromUser(execID int64) (int64, error) {
+	response, err := api.ListReplicationTasks(execID)
+	if err != nil {
+		return 0, err
+	}
+	if len(response.Payload) == 0 {
+		return 0, errors.New("no replication tasks found")
+	}
 
+	executionID := make(chan int64)
 	go func() {
-		response, err := api.ListReplicationTasks(execID)
-		if err != nil {
-			slog.Error(err.Error())
-			os.Exit(1)
-		}
-		if len(response.Payload) == 0 {
-			slog.Error("no replication tasks found")
-			os.Exit(1)
-		}
 		rtasks.ReplicationTasksList(response.Payload, executionID)
 	}()
 
-	return <-executionID
+	return <-executionID, nil
 }
 
 // Get GetMemberIDFromUser choosing from list of members

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -16,6 +16,8 @@ package prompt
 import (
 	"errors"
 	"fmt"
+	"log/slog"
+	"os"
 	"strconv"
 
 	"github.com/goharbor/harbor-cli/pkg/utils"
@@ -46,7 +48,6 @@ import (
 	sview "github.com/goharbor/harbor-cli/pkg/views/scanner/select"
 	uview "github.com/goharbor/harbor-cli/pkg/views/user/select"
 	wview "github.com/goharbor/harbor-cli/pkg/views/webhook/select"
-	log "github.com/sirupsen/logrus"
 )
 
 func GetRegistryNameFromUser() int64 {
@@ -149,7 +150,8 @@ func GetRepoNameFromUser(projectName string) string {
 	go func() {
 		response, err := api.ListRepository(projectName, false)
 		if err != nil {
-			log.Fatal(err)
+			slog.Error(err.Error())
+			os.Exit(1)
 		}
 		repoView.RepositoryList(response.Payload, repositoryName)
 	}()
@@ -311,7 +313,7 @@ func GetQuotaIDFromUser() int64 {
 	go func() {
 		response, err := api.ListQuota(*&api.ListQuotaFlags{})
 		if err != nil {
-			log.Errorf("failed to list quota: %v", err)
+			slog.Error("failed to list quota", "error", err)
 		}
 		qview.QuotaList(response.Payload, QuotaID)
 	}()
@@ -390,7 +392,8 @@ func GetReplicationPolicyFromUser() int64 {
 	go func() {
 		response, err := api.ListReplicationPolicies()
 		if err != nil {
-			log.Fatal(err)
+			slog.Error(err.Error())
+			os.Exit(1)
 		}
 		rpolicies.ReplicationPoliciesList(response.Payload, replicationPolicyID)
 	}()
@@ -404,10 +407,12 @@ func GetReplicationExecutionIDFromUser(rpolicyID int64) int64 {
 	go func() {
 		response, err := api.ListReplicationExecutions(rpolicyID)
 		if err != nil {
-			log.Fatal(err)
+			slog.Error(err.Error())
+			os.Exit(1)
 		}
 		if len(response.Payload) == 0 {
-			log.Fatal("no replication executions found")
+			slog.Error("no replication executions found")
+			os.Exit(1)
 		}
 		rexecutions.ReplicationExecutionList(response.Payload, executionID)
 	}()
@@ -421,10 +426,12 @@ func GetReplicationTaskIDFromUser(execID int64) int64 {
 	go func() {
 		response, err := api.ListReplicationTasks(execID)
 		if err != nil {
-			log.Fatal(err)
+			slog.Error(err.Error())
+			os.Exit(1)
 		}
 		if len(response.Payload) == 0 {
-			log.Fatal("no replication tasks found")
+			slog.Error("no replication tasks found")
+			os.Exit(1)
 		}
 		rtasks.ReplicationTasksList(response.Payload, executionID)
 	}()

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -16,7 +16,6 @@ package prompt
 import (
 	"errors"
 	"fmt"
-	"log/slog"
 	"strconv"
 
 	"github.com/goharbor/harbor-cli/pkg/utils"
@@ -305,18 +304,18 @@ func GetInstanceNameFromUser() (string, error) {
 	return res.name, res.err
 }
 
-func GetQuotaIDFromUser() int64 {
-	QuotaID := make(chan int64)
+func GetQuotaIDFromUser() (int64, error) {
+	response, err := api.ListQuota(api.ListQuotaFlags{})
+	if err != nil {
+		return 0, fmt.Errorf("failed to list quota: %v", err)
+	}
 
+	QuotaID := make(chan int64)
 	go func() {
-		response, err := api.ListQuota(*&api.ListQuotaFlags{})
-		if err != nil {
-			slog.Error("failed to list quota", "error", err)
-		}
 		qview.QuotaList(response.Payload, QuotaID)
 	}()
 
-	return <-QuotaID
+	return <-QuotaID, nil
 }
 
 func GetActiveContextFromUser() (string, error) {

--- a/pkg/utils/client.go
+++ b/pkg/utils/client.go
@@ -16,11 +16,11 @@ package utils
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"sync"
 
 	"github.com/goharbor/go-client/pkg/harbor"
 	v2client "github.com/goharbor/go-client/pkg/sdk/v2.0/client"
-	log "github.com/sirupsen/logrus"
 )
 
 var (
@@ -44,7 +44,7 @@ func GetClient() (*v2client.HarborAPI, error) {
 
 		ClientInstance, ClientErr = GetClientByCredentialName(credentialName)
 		if ClientErr != nil {
-			log.Errorf("failed to initialize client: %v", ClientErr)
+			slog.Error("failed to initialize client", "error", ClientErr)
 			return
 		}
 	})

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -64,50 +64,48 @@ var (
 
 var ConfigInitialization = &Once{}
 
-func InitConfig(cfgFile string, userSpecifiedConfig bool) {
+func InitConfig(cfgFile string, userSpecifiedConfig bool) error {
 	ConfigInitialization.Do(func() {
-		harborDataPath, harborDataDir := GetDataPaths()
+		harborDataPath, harborDataDir, err := GetDataPaths()
+		if err != nil {
+			configInitError = err
+			return
+		}
 		harborConfigPath, err := DetermineConfigPath(cfgFile, userSpecifiedConfig)
 		if err != nil {
 			configInitError = err
-			slog.Error(err.Error())
-			os.Exit(1)
+			return
 		}
 
 		// Ensure data directory exists
 		if err := os.MkdirAll(harborDataDir, os.ModePerm); err != nil {
 			configInitError = fmt.Errorf("failed to create data directory: %w", err)
-			slog.Error(configInitError.Error())
-			os.Exit(1)
+			return
 		}
 
 		// Update or create data file
 		if err := ApplyDataFile(harborDataPath, harborConfigPath); err != nil {
 			configInitError = err
-			slog.Error(err.Error())
-			os.Exit(1)
+			return
 		}
 
 		// Ensure config file exists
 		if err := EnsureConfigFileExists(harborConfigPath); err != nil {
 			configInitError = err
-			slog.Error(err.Error())
-			os.Exit(1)
+			return
 		}
 
 		// Read and unmarshal the config file
 		err = ReadConfig(harborConfigPath)
 		if err != nil {
 			configInitError = err
-			slog.Error(err.Error())
-			os.Exit(1)
+			return
 		}
 
 		var harborConfig HarborConfig
 		if err := viper.Unmarshal(&harborConfig); err != nil {
 			configInitError = fmt.Errorf("failed to unmarshal config file: %w", err)
-			slog.Error(configInitError.Error())
-			os.Exit(1)
+			return
 		}
 
 		configMutex.Lock()
@@ -115,22 +113,22 @@ func InitConfig(cfgFile string, userSpecifiedConfig bool) {
 		CurrentHarborConfig = &harborConfig
 		CurrentHarborData = &HarborData{ConfigPath: harborConfigPath}
 	})
+	return configInitError
 }
 
 // Helper function to get data paths
-func GetDataPaths() (harborDataPath string, harborDataDir string) {
+func GetDataPaths() (harborDataPath string, harborDataDir string, err error) {
 	xdgDataHome := os.Getenv("XDG_DATA_HOME")
 	if xdgDataHome == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			slog.Error("Unable to determine user home directory", "error", err)
-			os.Exit(1)
+			return "", "", fmt.Errorf("unable to determine user home directory: %v", err)
 		}
 		xdgDataHome = filepath.Join(home, ".local", "share")
 	}
 	harborDataDir = filepath.Join(xdgDataHome, "harbor-cli")
 	harborDataPath = filepath.Join(harborDataDir, "data.yaml")
-	return
+	return harborDataPath, harborDataDir, nil
 }
 
 // Helper function to determine the config path
@@ -291,14 +289,12 @@ func CreateDataFile(dataFilePath string, initialConfigPath string) error {
 	if _, err := os.Stat(dataFilePath); os.IsNotExist(err) {
 		dataDir := filepath.Dir(dataFilePath)
 		if err := os.MkdirAll(dataDir, os.ModePerm); err != nil {
-			slog.Error("Failed to create data directory", "error", err)
-			os.Exit(1)
+			return fmt.Errorf("failed to create data directory: %v", err)
 		}
 
 		absConfigPath, err := filepath.Abs(initialConfigPath)
 		if err != nil {
-			slog.Error("Failed to resolve absolute path for config file", "error", err)
-			os.Exit(1)
+			return fmt.Errorf("failed to resolve absolute path for config file: %v", err)
 		}
 
 		dataFile := HarborData{
@@ -310,14 +306,12 @@ func CreateDataFile(dataFilePath string, initialConfigPath string) error {
 		v.Set("configPath", dataFile.ConfigPath)
 
 		if err := v.WriteConfigAs(dataFilePath); err != nil {
-			slog.Error("Failed to write data file", "error", err)
-			os.Exit(1)
+			return fmt.Errorf("failed to write data file: %v", err)
 		}
 
 		fmt.Printf("Data file created at %s with configPath: %s\n", dataFilePath, dataFile.ConfigPath)
 	} else if err != nil {
-		slog.Error("Error checking data file", "error", err)
-		os.Exit(1)
+		return fmt.Errorf("error checking data file: %v", err)
 	}
 
 	return nil
@@ -365,17 +359,14 @@ func ApplyDataFile(harborDataPath, harborConfigPath string) error {
 
 func UpdateDataFile(dataFilePath string, newConfigPath string) error {
 	if _, err := os.Stat(dataFilePath); os.IsNotExist(err) {
-		slog.Error(fmt.Sprintf("data file does not exist at %s", dataFilePath))
-		os.Exit(1)
+		return fmt.Errorf("data file does not exist at %s", dataFilePath)
 	} else if err != nil {
-		slog.Error("error checking data file", "error", err)
-		os.Exit(1)
+		return fmt.Errorf("error checking data file: %v", err)
 	}
 
 	absConfigPath, err := filepath.Abs(newConfigPath)
 	if err != nil {
-		slog.Error("failed to resolve absolute path for new config file", "error", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to resolve absolute path for new config file: %v", err)
 	}
 
 	v := viper.New()
@@ -383,15 +374,13 @@ func UpdateDataFile(dataFilePath string, newConfigPath string) error {
 	v.SetConfigFile(dataFilePath)
 
 	if err := v.ReadInConfig(); err != nil {
-		slog.Error("failed to read existing data file", "error", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to read existing data file: %v", err)
 	}
 
 	v.Set("configPath", absConfigPath)
 
 	if err := v.WriteConfig(); err != nil {
-		slog.Error("failed to write updated data file", "error", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to write updated data file: %v", err)
 	}
 
 	fmt.Printf("Data file at %s updated with new configPath: %s\n", dataFilePath, absConfigPath)
@@ -402,8 +391,7 @@ func CreateConfigFile(configPath string) error {
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
 		configDir := filepath.Dir(configPath)
 		if err := os.MkdirAll(configDir, os.ModePerm); err != nil {
-			slog.Error("failed to create config directory", "error", err)
-			os.Exit(1)
+			return fmt.Errorf("failed to create config directory: %v", err)
 		}
 
 		v := viper.New()
@@ -419,14 +407,12 @@ func CreateConfigFile(configPath string) error {
 		v.Set("credentials", defaultConfig.Credentials)
 
 		if err := v.WriteConfigAs(configPath); err != nil {
-			slog.Error("failed to write config file", "error", err)
-			os.Exit(1)
+			return fmt.Errorf("failed to write config file: %v", err)
 		}
 
 		fmt.Printf("Config file created at %s", configPath)
 	} else if err != nil {
-		slog.Error("error checking config file", "error", err)
-		os.Exit(1)
+		return fmt.Errorf("error checking config file: %v", err)
 	}
 
 	return nil

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -66,6 +66,7 @@ var ConfigInitialization = &Once{}
 
 func InitConfig(cfgFile string, userSpecifiedConfig bool) error {
 	ConfigInitialization.Do(func() {
+		configInitError = nil
 		harborDataPath, harborDataDir, err := GetDataPaths()
 		if err != nil {
 			configInitError = err

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -16,12 +16,12 @@ package utils
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
 
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/spf13/viper"
 )
@@ -70,38 +70,44 @@ func InitConfig(cfgFile string, userSpecifiedConfig bool) {
 		harborConfigPath, err := DetermineConfigPath(cfgFile, userSpecifiedConfig)
 		if err != nil {
 			configInitError = err
-			log.Fatalf("%v", err)
+			slog.Error(err.Error())
+			os.Exit(1)
 		}
 
 		// Ensure data directory exists
 		if err := os.MkdirAll(harborDataDir, os.ModePerm); err != nil {
 			configInitError = fmt.Errorf("failed to create data directory: %w", err)
-			log.Fatalf("%v", configInitError)
+			slog.Error(configInitError.Error())
+			os.Exit(1)
 		}
 
 		// Update or create data file
 		if err := ApplyDataFile(harborDataPath, harborConfigPath); err != nil {
 			configInitError = err
-			log.Fatalf("%v", err)
+			slog.Error(err.Error())
+			os.Exit(1)
 		}
 
 		// Ensure config file exists
 		if err := EnsureConfigFileExists(harborConfigPath); err != nil {
 			configInitError = err
-			log.Fatalf("%v", err)
+			slog.Error(err.Error())
+			os.Exit(1)
 		}
 
 		// Read and unmarshal the config file
 		err = ReadConfig(harborConfigPath)
 		if err != nil {
 			configInitError = err
-			log.Fatalf("%v", err)
+			slog.Error(err.Error())
+			os.Exit(1)
 		}
 
 		var harborConfig HarborConfig
 		if err := viper.Unmarshal(&harborConfig); err != nil {
 			configInitError = fmt.Errorf("failed to unmarshal config file: %w", err)
-			log.Fatalf("%v", configInitError)
+			slog.Error(configInitError.Error())
+			os.Exit(1)
 		}
 
 		configMutex.Lock()
@@ -117,7 +123,8 @@ func GetDataPaths() (harborDataPath string, harborDataDir string) {
 	if xdgDataHome == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			log.Fatalf("Unable to determine user home directory: %v", err)
+			slog.Error("Unable to determine user home directory", "error", err)
+			os.Exit(1)
 		}
 		xdgDataHome = filepath.Join(home, ".local", "share")
 	}
@@ -284,12 +291,14 @@ func CreateDataFile(dataFilePath string, initialConfigPath string) error {
 	if _, err := os.Stat(dataFilePath); os.IsNotExist(err) {
 		dataDir := filepath.Dir(dataFilePath)
 		if err := os.MkdirAll(dataDir, os.ModePerm); err != nil {
-			log.Fatalf("Failed to create data directory: %v", err)
+			slog.Error("Failed to create data directory", "error", err)
+			os.Exit(1)
 		}
 
 		absConfigPath, err := filepath.Abs(initialConfigPath)
 		if err != nil {
-			log.Fatalf("Failed to resolve absolute path for config file: %v", err)
+			slog.Error("Failed to resolve absolute path for config file", "error", err)
+			os.Exit(1)
 		}
 
 		dataFile := HarborData{
@@ -301,12 +310,14 @@ func CreateDataFile(dataFilePath string, initialConfigPath string) error {
 		v.Set("configPath", dataFile.ConfigPath)
 
 		if err := v.WriteConfigAs(dataFilePath); err != nil {
-			log.Fatalf("Failed to write data file: %v", err)
+			slog.Error("Failed to write data file", "error", err)
+			os.Exit(1)
 		}
 
 		fmt.Printf("Data file created at %s with configPath: %s\n", dataFilePath, dataFile.ConfigPath)
 	} else if err != nil {
-		log.Fatalf("Error checking data file: %v", err)
+		slog.Error("Error checking data file", "error", err)
+		os.Exit(1)
 	}
 
 	return nil
@@ -341,7 +352,7 @@ func ApplyDataFile(harborDataPath, harborConfigPath string) error {
 				return fmt.Errorf("failed to create data file: %w", err)
 			}
 		} else {
-			log.Debugf("Data file already exists with the same config path: %s", harborConfigPath)
+			slog.Debug(fmt.Sprintf("Data file already exists with the same config path: %s", harborConfigPath))
 		}
 	} else {
 		// Data file does not exist, create it
@@ -354,14 +365,17 @@ func ApplyDataFile(harborDataPath, harborConfigPath string) error {
 
 func UpdateDataFile(dataFilePath string, newConfigPath string) error {
 	if _, err := os.Stat(dataFilePath); os.IsNotExist(err) {
-		log.Fatalf("data file does not exist at %s", dataFilePath)
+		slog.Error(fmt.Sprintf("data file does not exist at %s", dataFilePath))
+		os.Exit(1)
 	} else if err != nil {
-		log.Fatalf("error checking data file: %v", err)
+		slog.Error("error checking data file", "error", err)
+		os.Exit(1)
 	}
 
 	absConfigPath, err := filepath.Abs(newConfigPath)
 	if err != nil {
-		log.Fatalf("failed to resolve absolute path for new config file: %v", err)
+		slog.Error("failed to resolve absolute path for new config file", "error", err)
+		os.Exit(1)
 	}
 
 	v := viper.New()
@@ -369,13 +383,15 @@ func UpdateDataFile(dataFilePath string, newConfigPath string) error {
 	v.SetConfigFile(dataFilePath)
 
 	if err := v.ReadInConfig(); err != nil {
-		log.Fatalf("failed to read existing data file: %v", err)
+		slog.Error("failed to read existing data file", "error", err)
+		os.Exit(1)
 	}
 
 	v.Set("configPath", absConfigPath)
 
 	if err := v.WriteConfig(); err != nil {
-		log.Fatalf("failed to write updated data file: %v", err)
+		slog.Error("failed to write updated data file", "error", err)
+		os.Exit(1)
 	}
 
 	fmt.Printf("Data file at %s updated with new configPath: %s\n", dataFilePath, absConfigPath)
@@ -386,7 +402,8 @@ func CreateConfigFile(configPath string) error {
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
 		configDir := filepath.Dir(configPath)
 		if err := os.MkdirAll(configDir, os.ModePerm); err != nil {
-			log.Fatalf("failed to create config directory: %v", err)
+			slog.Error("failed to create config directory", "error", err)
+			os.Exit(1)
 		}
 
 		v := viper.New()
@@ -402,12 +419,14 @@ func CreateConfigFile(configPath string) error {
 		v.Set("credentials", defaultConfig.Credentials)
 
 		if err := v.WriteConfigAs(configPath); err != nil {
-			log.Fatalf("failed to write config file: %v", err)
+			slog.Error("failed to write config file", "error", err)
+			os.Exit(1)
 		}
 
 		fmt.Printf("Config file created at %s", configPath)
 	} else if err != nil {
-		log.Fatalf("error checking config file: %v", err)
+		slog.Error("error checking config file", "error", err)
+		os.Exit(1)
 	}
 
 	return nil

--- a/pkg/utils/config_test.go
+++ b/pkg/utils/config_test.go
@@ -30,9 +30,10 @@ func Test_Config_EnvVar(t *testing.T) {
 	tempDir := t.TempDir()
 	helpers.SafeSetEnv("HARBOR_CLI_CONFIG", filepath.Join(tempDir, "config.yaml"))
 	helpers.SafeSetEnv("XDG_DATA_HOME", filepath.Join(tempDir, ".data"))
-	utils.InitConfig("", false)
+	err := utils.InitConfig("", false)
+	assert.NoError(t, err, "Expected no error for config initialization")
 	cds := root.RootCmd()
-	err := cds.Execute()
+	err = cds.Execute()
 	assert.NoError(t, err, "Expected no error for Root command")
 	assert.NoError(t, err, "Expected no error for Root command execution")
 
@@ -51,9 +52,10 @@ func Test_Config_EnvVar(t *testing.T) {
 func Test_Config_Vanilla(t *testing.T) {
 	utils.ConfigInitialization.Reset() // Reset sync.Once for the test
 	helpers.SetMockKeyring(t)
-	utils.InitConfig("", false)
+	err := utils.InitConfig("", false)
+	assert.NoError(t, err, "Expected no error for config initialization")
 	cds := root.RootCmd()
-	err := cds.Execute()
+	err = cds.Execute()
 	assert.NoError(t, err, "Expected no error for Root command")
 	assert.NoError(t, err, "Expected no error for Root command execution")
 	currentData, err := utils.GetCurrentHarborData()
@@ -75,9 +77,10 @@ func Test_Config_Xdg(t *testing.T) {
 	helpers.SafeSetEnv("HARBOR_CLI_CONFIG", filepath.Join(tempDir, "config.yaml"))
 	helpers.SafeSetEnv("XDG_CONFIG_HOME", filepath.Join(tempDir, ".config"))
 	helpers.SafeSetEnv("XDG_DATA_HOME", filepath.Join(tempDir, ".data"))
-	utils.InitConfig("", false)
+	err := utils.InitConfig("", false)
+	assert.NoError(t, err, "Expected no error for config initialization")
 	cds := root.RootCmd()
-	err := cds.Execute()
+	err = cds.Execute()
 	assert.NoError(t, err, "Expected no error for Root command")
 	assert.NoError(t, err, "Expected no error for Root command execution")
 
@@ -99,7 +102,8 @@ func Test_Config_Flag(t *testing.T) {
 	defer helpers.ConfigCleanup(t, data)
 
 	testConfigFile := filepath.Join(tempDir, "config.yaml")
-	utils.InitConfig(testConfigFile, true)
+	err := utils.InitConfig(testConfigFile, true)
+	assert.NoError(t, err, "Expected no error for config initialization")
 	currentConfig, err := utils.GetCurrentHarborConfig()
 	assert.NoError(t, err, "Expected no error when fetching HarborConfig")
 	assert.NotNil(t, currentConfig, "Configuration should not be nil")

--- a/pkg/utils/encryption.go
+++ b/pkg/utils/encryption.go
@@ -20,12 +20,12 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 
-	"github.com/sirupsen/logrus"
 	"github.com/zalando/go-keyring"
 )
 
@@ -127,7 +127,7 @@ func GetKeyringProvider() KeyringProvider {
 	// Priority 1: Check for environment variable configuration
 	envKeyName := "HARBOR_ENCRYPTION_KEY"
 	if envKey := os.Getenv(envKeyName); envKey != "" {
-		logrus.Debug("Using environment-based encryption key")
+		slog.Debug("Using environment-based encryption key")
 		return &EnvironmentKeyring{
 			EnvVarName: envKeyName,
 		}
@@ -138,9 +138,9 @@ func GetKeyringProvider() KeyringProvider {
 		// Clean up the test entry
 		err = keyring.Delete("harbor-cli-test", "test-user")
 		if err != nil {
-			logrus.Warnf("Failed to delete test entry from system keyring: %v", err)
+			slog.Warn("Failed to delete test entry from system keyring", "error", err)
 		}
-		logrus.Debug("Using system keyring")
+		slog.Debug("Using system keyring")
 		return &SystemKeyring{}
 	}
 
@@ -153,7 +153,7 @@ func GetKeyringProvider() KeyringProvider {
 		BaseDir: filepath.Join(homeDir, ".harbor", "keyring"),
 	}
 
-	logrus.Warn("System keyring not available, using file-based keyring")
+	slog.Warn("System keyring not available, using file-based keyring")
 	return fileKeyring
 }
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"regexp"
 	"strconv"
@@ -28,7 +29,6 @@ import (
 	"github.com/gocarina/gocsv"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/user"
 	uview "github.com/goharbor/harbor-cli/pkg/views/user/select"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"go.yaml.in/yaml/v4"
 	"golang.org/x/term"
@@ -84,7 +84,7 @@ func ParseProjectRepo(projectRepo string) (project, repo string, err error) {
 }
 
 func ParseProjectRepoReference(projectRepoReference string) (project, repo, reference string, err error) {
-	log.Debugf("Parsing input: %s", projectRepoReference)
+	slog.Debug(fmt.Sprintf("Parsing input: %s", projectRepoReference))
 
 	var ref string
 	var repoPath string
@@ -213,16 +213,19 @@ func GetUserIdFromUser() int64 {
 	credentialName := viper.GetString("current-credential-name")
 	client, err := GetClientByCredentialName(credentialName)
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 	ctx := context.Background()
 	response, err := client.User.ListUsers(ctx, &user.ListUsersParams{})
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 	userId, err := uview.UserList(response.Payload)
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 	return userId
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -209,25 +209,22 @@ func FromKebabCase(s string) string {
 }
 
 // GetUserIdFromUser retrieves the user ID from the current user context using viper and the Harbor client.
-func GetUserIdFromUser() int64 {
+func GetUserIdFromUser() (int64, error) {
 	credentialName := viper.GetString("current-credential-name")
 	client, err := GetClientByCredentialName(credentialName)
 	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return 0, err
 	}
 	ctx := context.Background()
 	response, err := client.User.ListUsers(ctx, &user.ListUsersParams{})
 	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return 0, err
 	}
 	userId, err := uview.UserList(response.Payload)
 	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return 0, err
 	}
-	return userId
+	return userId, nil
 }
 
 // RemoveColumns removes columns with specified titles from the given columns array.

--- a/pkg/views/artifact/tags/create/view.go
+++ b/pkg/views/artifact/tags/create/view.go
@@ -15,11 +15,12 @@ package create
 
 import (
 	"errors"
+	"log/slog"
+	"os"
 	"strings"
 
 	"github.com/charmbracelet/huh"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 )
 
 func CreateTagView(tagName *string) {
@@ -43,6 +44,7 @@ func CreateTagView(tagName *string) {
 	).WithTheme(theme).Run()
 
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 }

--- a/pkg/views/artifact/tags/create/view.go
+++ b/pkg/views/artifact/tags/create/view.go
@@ -15,15 +15,13 @@ package create
 
 import (
 	"errors"
-	"log/slog"
-	"os"
 	"strings"
 
 	"github.com/charmbracelet/huh"
 	"github.com/goharbor/harbor-cli/pkg/utils"
 )
 
-func CreateTagView(tagName *string) {
+func CreateTagView(tagName *string) error {
 	theme := huh.ThemeCharm()
 
 	err := huh.NewForm(
@@ -44,7 +42,8 @@ func CreateTagView(tagName *string) {
 	).WithTheme(theme).Run()
 
 	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return err
 	}
+
+	return nil
 }

--- a/pkg/views/confirmation.go
+++ b/pkg/views/confirmation.go
@@ -14,8 +14,10 @@
 package views
 
 import (
+	"log/slog"
+	"os"
+
 	"github.com/charmbracelet/huh"
-	log "github.com/sirupsen/logrus"
 )
 
 func ConfirmElevation() (bool, error) {
@@ -27,7 +29,8 @@ func ConfirmElevation() (bool, error) {
 		Negative("No").
 		Value(&confirm).Run()
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 
 	return confirm, nil

--- a/pkg/views/confirmation.go
+++ b/pkg/views/confirmation.go
@@ -14,9 +14,6 @@
 package views
 
 import (
-	"log/slog"
-	"os"
-
 	"github.com/charmbracelet/huh"
 )
 
@@ -29,8 +26,7 @@ func ConfirmElevation() (bool, error) {
 		Negative("No").
 		Value(&confirm).Run()
 	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return false, err
 	}
 
 	return confirm, nil

--- a/pkg/views/cveallowlist/update/view.go
+++ b/pkg/views/cveallowlist/update/view.go
@@ -15,9 +15,10 @@ package update
 
 import (
 	"errors"
+	"log/slog"
+	"os"
 
 	"github.com/charmbracelet/huh"
-	log "github.com/sirupsen/logrus"
 )
 
 type UpdateView struct {
@@ -63,6 +64,7 @@ func UpdateCveView(updateView *UpdateView) {
 	).WithTheme(theme).Run()
 
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 }

--- a/pkg/views/cveallowlist/update/view.go
+++ b/pkg/views/cveallowlist/update/view.go
@@ -15,8 +15,6 @@ package update
 
 import (
 	"errors"
-	"log/slog"
-	"os"
 
 	"github.com/charmbracelet/huh"
 )
@@ -27,7 +25,7 @@ type UpdateView struct {
 	ExpireDate string
 }
 
-func UpdateCveView(updateView *UpdateView) {
+func UpdateCveView(updateView *UpdateView) error {
 	theme := huh.ThemeCharm()
 	err := huh.NewForm(
 		huh.NewGroup(
@@ -64,7 +62,8 @@ func UpdateCveView(updateView *UpdateView) {
 	).WithTheme(theme).Run()
 
 	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return err
 	}
+
+	return nil
 }

--- a/pkg/views/immutable/create/view.go
+++ b/pkg/views/immutable/create/view.go
@@ -15,8 +15,6 @@ package create
 
 import (
 	"errors"
-	"log/slog"
-	"os"
 
 	"github.com/charmbracelet/huh"
 )
@@ -31,7 +29,7 @@ type ImmutableSelector struct {
 	Pattern    string `json:"pattern,omitempty"`
 }
 
-func CreateImmutableView(createView *CreateView) {
+func CreateImmutableView(createView *CreateView) error {
 	theme := huh.ThemeCharm()
 	err := huh.NewForm(
 		huh.NewGroup(
@@ -83,7 +81,8 @@ func CreateImmutableView(createView *CreateView) {
 	).WithTheme(theme).Run()
 
 	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return err
 	}
+
+	return nil
 }

--- a/pkg/views/immutable/create/view.go
+++ b/pkg/views/immutable/create/view.go
@@ -15,9 +15,10 @@ package create
 
 import (
 	"errors"
+	"log/slog"
+	"os"
 
 	"github.com/charmbracelet/huh"
-	log "github.com/sirupsen/logrus"
 )
 
 type CreateView struct {
@@ -82,6 +83,7 @@ func CreateImmutableView(createView *CreateView) {
 	).WithTheme(theme).Run()
 
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 }

--- a/pkg/views/label/create/view.go
+++ b/pkg/views/label/create/view.go
@@ -15,8 +15,6 @@ package create
 
 import (
 	"errors"
-	"log/slog"
-	"os"
 
 	"github.com/charmbracelet/huh"
 )
@@ -29,7 +27,7 @@ type CreateView struct {
 	ProjectID   int64
 }
 
-func CreateLabelView(createView *CreateView) {
+func CreateLabelView(createView *CreateView) error {
 	theme := huh.ThemeCharm()
 	err := huh.NewForm(
 		huh.NewGroup(
@@ -104,7 +102,8 @@ func CreateLabelView(createView *CreateView) {
 	).WithTheme(theme).Run()
 
 	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return err
 	}
+
+	return nil
 }

--- a/pkg/views/label/create/view.go
+++ b/pkg/views/label/create/view.go
@@ -15,9 +15,10 @@ package create
 
 import (
 	"errors"
+	"log/slog"
+	"os"
 
 	"github.com/charmbracelet/huh"
-	log "github.com/sirupsen/logrus"
 )
 
 type CreateView struct {
@@ -103,6 +104,7 @@ func CreateLabelView(createView *CreateView) {
 	).WithTheme(theme).Run()
 
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 }

--- a/pkg/views/label/update/view.go
+++ b/pkg/views/label/update/view.go
@@ -15,14 +15,12 @@ package update
 
 import (
 	"errors"
-	"log/slog"
-	"os"
 
 	"github.com/charmbracelet/huh"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 )
 
-func UpdateLabelView(updateView *models.Label) {
+func UpdateLabelView(updateView *models.Label) error {
 	theme := huh.ThemeCharm()
 	err := huh.NewForm(
 		huh.NewGroup(
@@ -85,7 +83,8 @@ func UpdateLabelView(updateView *models.Label) {
 	).WithTheme(theme).Run()
 
 	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return err
 	}
+
+	return nil
 }

--- a/pkg/views/label/update/view.go
+++ b/pkg/views/label/update/view.go
@@ -15,10 +15,11 @@ package update
 
 import (
 	"errors"
+	"log/slog"
+	"os"
 
 	"github.com/charmbracelet/huh"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
-	log "github.com/sirupsen/logrus"
 )
 
 func UpdateLabelView(updateView *models.Label) {
@@ -84,6 +85,7 @@ func UpdateLabelView(updateView *models.Label) {
 	).WithTheme(theme).Run()
 
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 }

--- a/pkg/views/login/create.go
+++ b/pkg/views/login/create.go
@@ -15,8 +15,6 @@ package login
 
 import (
 	"errors"
-	"log/slog"
-	"os"
 	"strings"
 
 	"github.com/charmbracelet/huh"
@@ -31,7 +29,7 @@ type LoginView struct {
 	Config   string
 }
 
-func CreateView(loginView *LoginView) {
+func CreateView(loginView *LoginView) error {
 	theme := huh.ThemeCharm()
 
 	err := huh.NewForm(
@@ -96,7 +94,8 @@ func CreateView(loginView *LoginView) {
 	).WithTheme(theme).
 		Run()
 	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return err
 	}
+
+	return nil
 }

--- a/pkg/views/login/create.go
+++ b/pkg/views/login/create.go
@@ -15,11 +15,12 @@ package login
 
 import (
 	"errors"
+	"log/slog"
+	"os"
 	"strings"
 
 	"github.com/charmbracelet/huh"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 )
 
 type LoginView struct {
@@ -95,6 +96,7 @@ func CreateView(loginView *LoginView) {
 	).WithTheme(theme).
 		Run()
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 }

--- a/pkg/views/password/change/view.go
+++ b/pkg/views/password/change/view.go
@@ -15,11 +15,12 @@ package change
 
 import (
 	"errors"
+	"log/slog"
+	"os"
 	"strings"
 
 	"github.com/charmbracelet/huh"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 )
 
 type PasswordChangeView struct {
@@ -73,6 +74,7 @@ func ChangePasswordView(view *PasswordChangeView) {
 	).WithTheme(theme).Run()
 
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 }

--- a/pkg/views/password/change/view.go
+++ b/pkg/views/password/change/view.go
@@ -15,8 +15,6 @@ package change
 
 import (
 	"errors"
-	"log/slog"
-	"os"
 	"strings"
 
 	"github.com/charmbracelet/huh"
@@ -29,7 +27,7 @@ type PasswordChangeView struct {
 	ConfirmPassword string
 }
 
-func ChangePasswordView(view *PasswordChangeView) {
+func ChangePasswordView(view *PasswordChangeView) error {
 	theme := huh.ThemeCharm()
 
 	err := huh.NewForm(
@@ -74,7 +72,8 @@ func ChangePasswordView(view *PasswordChangeView) {
 	).WithTheme(theme).Run()
 
 	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return err
 	}
+
+	return nil
 }

--- a/pkg/views/password/reset/view.go
+++ b/pkg/views/password/reset/view.go
@@ -15,8 +15,6 @@ package reset
 
 import (
 	"errors"
-	"log/slog"
-	"os"
 	"strings"
 
 	"github.com/charmbracelet/huh"
@@ -28,7 +26,7 @@ type PasswordChangeView struct {
 	ConfirmPassword string
 }
 
-func ChangePasswordView(view *PasswordChangeView) {
+func ChangePasswordView(view *PasswordChangeView) error {
 	theme := huh.ThemeCharm()
 
 	err := huh.NewForm(
@@ -63,7 +61,8 @@ func ChangePasswordView(view *PasswordChangeView) {
 	).WithTheme(theme).Run()
 
 	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return err
 	}
+
+	return nil
 }

--- a/pkg/views/password/reset/view.go
+++ b/pkg/views/password/reset/view.go
@@ -15,11 +15,12 @@ package reset
 
 import (
 	"errors"
+	"log/slog"
+	"os"
 	"strings"
 
 	"github.com/charmbracelet/huh"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 )
 
 type PasswordChangeView struct {
@@ -62,6 +63,7 @@ func ChangePasswordView(view *PasswordChangeView) {
 	).WithTheme(theme).Run()
 
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 }

--- a/pkg/views/preheat/policy/create/view.go
+++ b/pkg/views/preheat/policy/create/view.go
@@ -16,12 +16,13 @@ package create
 import (
 	"errors"
 	"fmt"
+	"log/slog"
+	"os"
 	"strings"
 
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
-	log "github.com/sirupsen/logrus"
 )
 
 type CreateView struct {
@@ -51,7 +52,8 @@ func CreatePreheatPolicyView(createView *CreateView, providers []*models.Provide
 	theme := huh.ThemeCharm()
 
 	if len(providers) == 0 {
-		log.Fatal("No P2P provider instances available for this project. Please create a provider instance first.")
+		slog.Error("No P2P provider instances available for this project. Please create a provider instance first.")
+		os.Exit(1)
 	}
 
 	providerOptions := make([]huh.Option[string], 0, len(providers))
@@ -64,7 +66,8 @@ func CreatePreheatPolicyView(createView *CreateView, providers []*models.Provide
 	}
 
 	if len(providerOptions) == 0 {
-		log.Fatal("No enabled P2P provider instances available for this project.")
+		slog.Error("No enabled P2P provider instances available for this project.")
+		os.Exit(1)
 	}
 
 	basicGroup := huh.NewGroup(
@@ -92,7 +95,8 @@ func CreatePreheatPolicyView(createView *CreateView, providers []*models.Provide
 
 	basicForm := huh.NewForm(basicGroup).WithTheme(theme)
 	if err := basicForm.Run(); err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 
 	filterGroup := huh.NewGroup(
@@ -135,7 +139,8 @@ func CreatePreheatPolicyView(createView *CreateView, providers []*models.Provide
 
 	restForm := huh.NewForm(filterGroup, triggerGroup).WithTheme(theme)
 	if err := restForm.Run(); err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 
 	if createView.TriggerType == "scheduled" {
@@ -157,7 +162,8 @@ func CreatePreheatPolicyView(createView *CreateView, providers []*models.Provide
 		).WithTheme(theme)
 
 		if err := presetForm.Run(); err != nil {
-			log.Fatal(err)
+			slog.Error(err.Error())
+			os.Exit(1)
 		}
 
 		if schedulePreset == "custom" {
@@ -184,7 +190,8 @@ func CreatePreheatPolicyView(createView *CreateView, providers []*models.Provide
 			).WithTheme(theme)
 
 			if err := cronForm.Run(); err != nil {
-				log.Fatal(err)
+				slog.Error(err.Error())
+				os.Exit(1)
 			}
 			createView.CronString = ResolveSchedulePreset(schedulePreset, createView.CronString)
 		} else {

--- a/pkg/views/preheat/policy/create/view.go
+++ b/pkg/views/preheat/policy/create/view.go
@@ -16,8 +16,6 @@ package create
 import (
 	"errors"
 	"fmt"
-	"log/slog"
-	"os"
 	"strings"
 
 	"github.com/charmbracelet/huh"
@@ -44,7 +42,7 @@ type CreateView struct {
 	CronString  string `json:"cron_string,omitempty"`
 }
 
-func CreatePreheatPolicyView(createView *CreateView, providers []*models.ProviderUnderProject) {
+func CreatePreheatPolicyView(createView *CreateView, providers []*models.ProviderUnderProject) error {
 	if createView.TriggerType == "" {
 		createView.TriggerType = "manual"
 	}
@@ -52,8 +50,7 @@ func CreatePreheatPolicyView(createView *CreateView, providers []*models.Provide
 	theme := huh.ThemeCharm()
 
 	if len(providers) == 0 {
-		slog.Error("No P2P provider instances available for this project. Please create a provider instance first.")
-		os.Exit(1)
+		return errors.New("No P2P provider instances available for this project. Please create a provider instance first.")
 	}
 
 	providerOptions := make([]huh.Option[string], 0, len(providers))
@@ -66,8 +63,7 @@ func CreatePreheatPolicyView(createView *CreateView, providers []*models.Provide
 	}
 
 	if len(providerOptions) == 0 {
-		slog.Error("No enabled P2P provider instances available for this project.")
-		os.Exit(1)
+		return errors.New("No enabled P2P provider instances available for this project.")
 	}
 
 	basicGroup := huh.NewGroup(
@@ -95,8 +91,7 @@ func CreatePreheatPolicyView(createView *CreateView, providers []*models.Provide
 
 	basicForm := huh.NewForm(basicGroup).WithTheme(theme)
 	if err := basicForm.Run(); err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return err
 	}
 
 	filterGroup := huh.NewGroup(
@@ -139,8 +134,7 @@ func CreatePreheatPolicyView(createView *CreateView, providers []*models.Provide
 
 	restForm := huh.NewForm(filterGroup, triggerGroup).WithTheme(theme)
 	if err := restForm.Run(); err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return err
 	}
 
 	if createView.TriggerType == "scheduled" {
@@ -162,8 +156,7 @@ func CreatePreheatPolicyView(createView *CreateView, providers []*models.Provide
 		).WithTheme(theme)
 
 		if err := presetForm.Run(); err != nil {
-			slog.Error(err.Error())
-			os.Exit(1)
+			return err
 		}
 
 		if schedulePreset == "custom" {
@@ -190,14 +183,14 @@ func CreatePreheatPolicyView(createView *CreateView, providers []*models.Provide
 			).WithTheme(theme)
 
 			if err := cronForm.Run(); err != nil {
-				slog.Error(err.Error())
-				os.Exit(1)
+				return err
 			}
 			createView.CronString = ResolveSchedulePreset(schedulePreset, createView.CronString)
 		} else {
 			createView.CronString = ResolveSchedulePreset(schedulePreset, "")
 		}
 	}
+	return nil
 }
 
 func schedulePresetForCron(cron string) string {

--- a/pkg/views/project/config/update/view.go
+++ b/pkg/views/project/config/update/view.go
@@ -14,9 +14,6 @@
 package update
 
 import (
-	"log/slog"
-	"os"
-
 	"github.com/charmbracelet/huh"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 )
@@ -29,7 +26,7 @@ func validateValue(value *string) *string {
 	return value
 }
 
-func UpdateProjectMetadataView(config *models.ProjectMetadata) {
+func UpdateProjectMetadataView(config *models.ProjectMetadata) error {
 	theme := huh.ThemeCharm()
 	err := huh.NewForm(
 		huh.NewGroup(
@@ -76,7 +73,8 @@ func UpdateProjectMetadataView(config *models.ProjectMetadata) {
 	).WithTheme(theme).Run()
 
 	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return err
 	}
+
+	return nil
 }

--- a/pkg/views/project/config/update/view.go
+++ b/pkg/views/project/config/update/view.go
@@ -14,9 +14,11 @@
 package update
 
 import (
+	"log/slog"
+	"os"
+
 	"github.com/charmbracelet/huh"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
-	log "github.com/sirupsen/logrus"
 )
 
 func validateValue(value *string) *string {
@@ -74,6 +76,7 @@ func UpdateProjectMetadataView(config *models.ProjectMetadata) {
 	).WithTheme(theme).Run()
 
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 }

--- a/pkg/views/project/create/view.go
+++ b/pkg/views/project/create/view.go
@@ -17,12 +17,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/charmbracelet/huh"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/registry"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
@@ -38,7 +38,7 @@ func getRegistryList() (*registry.ListRegistriesOK, error) {
 	credentialName := viper.GetString("current-credential-name")
 	client, err := utils.GetClientByCredentialName(credentialName)
 	if err != nil {
-		log.Errorf("failed to initialize client: %v", err)
+		slog.Error("failed to initialize client", "error", err)
 		return nil, err
 	}
 	ctx := context.Background()

--- a/pkg/views/quota/update/view.go
+++ b/pkg/views/quota/update/view.go
@@ -16,6 +16,8 @@ package update
 import (
 	"errors"
 	"fmt"
+	"log/slog"
+	"os"
 	"slices"
 	"strconv"
 	"strings"
@@ -23,7 +25,6 @@ import (
 	"github.com/charmbracelet/huh"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/views/quota/list"
-	log "github.com/sirupsen/logrus"
 )
 
 type CreateView struct {
@@ -91,7 +92,8 @@ func UpdateQuotaView(quta *models.Quota) string {
 		),
 	).WithTheme(theme).Run()
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 
 	return fmt.Sprintf("%v%v", createView.Value, createView.StorageUnit)

--- a/pkg/views/quota/update/view.go
+++ b/pkg/views/quota/update/view.go
@@ -16,8 +16,6 @@ package update
 import (
 	"errors"
 	"fmt"
-	"log/slog"
-	"os"
 	"slices"
 	"strconv"
 	"strings"
@@ -32,7 +30,7 @@ type CreateView struct {
 	Value       int64
 }
 
-func UpdateQuotaView(quta *models.Quota) string {
+func UpdateQuotaView(quta *models.Quota) (string, error) {
 	var (
 		value      string
 		createView CreateView
@@ -92,9 +90,8 @@ func UpdateQuotaView(quta *models.Quota) string {
 		),
 	).WithTheme(theme).Run()
 	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return "", err
 	}
 
-	return fmt.Sprintf("%v%v", createView.Value, createView.StorageUnit)
+	return fmt.Sprintf("%v%v", createView.Value, createView.StorageUnit), nil
 }

--- a/pkg/views/registry/create/view.go
+++ b/pkg/views/registry/create/view.go
@@ -30,7 +30,10 @@ type RegistryOption struct {
 }
 
 func CreateRegistryView(createView *api.CreateRegView) error {
-	registries, _ := api.GetRegistryProviders()
+	registries, err := api.GetRegistryProviders()
+	if err != nil {
+		return err
+	}
 
 	// Initialize a slice to hold registry options
 	var registryOptions []RegistryOption
@@ -55,7 +58,7 @@ func CreateRegistryView(createView *api.CreateRegView) error {
 	}
 
 	theme := huh.ThemeCharm()
-	err := huh.NewForm(
+	err = huh.NewForm(
 		huh.NewGroup(
 			huh.NewSelect[string]().
 				Title("Select a Registry Provider").

--- a/pkg/views/registry/create/view.go
+++ b/pkg/views/registry/create/view.go
@@ -15,8 +15,6 @@ package create
 
 import (
 	"errors"
-	"log/slog"
-	"os"
 	"strconv"
 	"strings"
 
@@ -31,7 +29,7 @@ type RegistryOption struct {
 	Name string
 }
 
-func CreateRegistryView(createView *api.CreateRegView) {
+func CreateRegistryView(createView *api.CreateRegView) error {
 	registries, _ := api.GetRegistryProviders()
 
 	// Initialize a slice to hold registry options
@@ -114,7 +112,7 @@ func CreateRegistryView(createView *api.CreateRegView) {
 		),
 	).WithTheme(theme).Run()
 	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return err
 	}
+	return nil
 }

--- a/pkg/views/registry/create/view.go
+++ b/pkg/views/registry/create/view.go
@@ -15,13 +15,14 @@ package create
 
 import (
 	"errors"
+	"log/slog"
+	"os"
 	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/huh"
 	"github.com/goharbor/harbor-cli/pkg/api"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 )
 
 // struct to hold registry options
@@ -113,6 +114,7 @@ func CreateRegistryView(createView *api.CreateRegView) {
 		),
 	).WithTheme(theme).Run()
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 }

--- a/pkg/views/registry/update/view.go
+++ b/pkg/views/registry/update/view.go
@@ -15,8 +15,6 @@ package update
 
 import (
 	"errors"
-	"log/slog"
-	"os"
 	"strings"
 
 	"github.com/charmbracelet/huh"
@@ -24,7 +22,7 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/utils"
 )
 
-func UpdateRegistryView(updateView *models.Registry) {
+func UpdateRegistryView(updateView *models.Registry) error {
 	theme := huh.ThemeCharm()
 	err := huh.NewForm(
 		huh.NewGroup(
@@ -80,7 +78,7 @@ func UpdateRegistryView(updateView *models.Registry) {
 	).WithTheme(theme).Run()
 
 	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return err
 	}
+	return nil
 }

--- a/pkg/views/registry/update/view.go
+++ b/pkg/views/registry/update/view.go
@@ -15,12 +15,13 @@ package update
 
 import (
 	"errors"
+	"log/slog"
+	"os"
 	"strings"
 
 	"github.com/charmbracelet/huh"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 )
 
 func UpdateRegistryView(updateView *models.Registry) {
@@ -79,6 +80,7 @@ func UpdateRegistryView(updateView *models.Registry) {
 	).WithTheme(theme).Run()
 
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 }

--- a/pkg/views/replication/policies/create/view.go
+++ b/pkg/views/replication/policies/create/view.go
@@ -16,8 +16,6 @@ package create
 import (
 	"errors"
 	"fmt"
-	"log/slog"
-	"os"
 	"strconv"
 	"strings"
 
@@ -49,7 +47,7 @@ type CreateView struct {
 	LabelPattern   string `json:"label_pattern,omitempty"` // label key=value pairs
 }
 
-func CreateRPolicyView(createView *CreateView, update bool) {
+func CreateRPolicyView(createView *CreateView, update bool) error {
 	if createView.TriggerType == "" {
 		createView.TriggerType = "manual"
 	}
@@ -103,8 +101,7 @@ func CreateRPolicyView(createView *CreateView, update bool) {
 	basicForm := huh.NewForm(basicGroup).WithTheme(theme)
 	err := basicForm.Run()
 	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return err
 	}
 
 	// Step 2: Create filter group based on selected mode
@@ -250,8 +247,7 @@ func CreateRPolicyView(createView *CreateView, update bool) {
 	restForm := huh.NewForm(filterGroup, triggerGroup, advancedGroup).WithTheme(theme)
 	err = restForm.Run()
 	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return err
 	}
 
 	// Handle trigger-specific additional forms
@@ -267,8 +263,7 @@ func CreateRPolicyView(createView *CreateView, update bool) {
 		).WithTheme(theme)
 
 		if err := eventForm.Run(); err != nil {
-			slog.Error(err.Error())
-			os.Exit(1)
+			return err
 		}
 	} else if createView.TriggerType == "scheduled" {
 		cronForm := huh.NewForm(
@@ -295,8 +290,8 @@ func CreateRPolicyView(createView *CreateView, update bool) {
 		).WithTheme(theme)
 
 		if err := cronForm.Run(); err != nil {
-			slog.Error(err.Error())
-			os.Exit(1)
+			return err
 		}
 	}
+	return nil
 }

--- a/pkg/views/replication/policies/create/view.go
+++ b/pkg/views/replication/policies/create/view.go
@@ -16,12 +16,13 @@ package create
 import (
 	"errors"
 	"fmt"
+	"log/slog"
+	"os"
 	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
-	log "github.com/sirupsen/logrus"
 )
 
 type CreateView struct {
@@ -102,7 +103,8 @@ func CreateRPolicyView(createView *CreateView, update bool) {
 	basicForm := huh.NewForm(basicGroup).WithTheme(theme)
 	err := basicForm.Run()
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 
 	// Step 2: Create filter group based on selected mode
@@ -248,7 +250,8 @@ func CreateRPolicyView(createView *CreateView, update bool) {
 	restForm := huh.NewForm(filterGroup, triggerGroup, advancedGroup).WithTheme(theme)
 	err = restForm.Run()
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 
 	// Handle trigger-specific additional forms
@@ -264,7 +267,8 @@ func CreateRPolicyView(createView *CreateView, update bool) {
 		).WithTheme(theme)
 
 		if err := eventForm.Run(); err != nil {
-			log.Fatal(err)
+			slog.Error(err.Error())
+			os.Exit(1)
 		}
 	} else if createView.TriggerType == "scheduled" {
 		cronForm := huh.NewForm(
@@ -291,7 +295,8 @@ func CreateRPolicyView(createView *CreateView, update bool) {
 		).WithTheme(theme)
 
 		if err := cronForm.Run(); err != nil {
-			log.Fatal(err)
+			slog.Error(err.Error())
+			os.Exit(1)
 		}
 	}
 }

--- a/pkg/views/robot/create/view.go
+++ b/pkg/views/robot/create/view.go
@@ -15,12 +15,13 @@ package create
 
 import (
 	"errors"
+	"log/slog"
+	"os"
 	"strconv"
 	"unicode"
 
 	"github.com/charmbracelet/huh"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
-	log "github.com/sirupsen/logrus"
 )
 
 type CreateView struct {
@@ -88,7 +89,8 @@ func CreateRobotView(createView *CreateView) {
 		),
 	).WithTheme(theme).Run()
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 }
 
@@ -106,7 +108,8 @@ func CreateRobotSecretView(name string, secret string) {
 		),
 	).WithTheme(theme).Run()
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 }
 

--- a/pkg/views/robot/create/view.go
+++ b/pkg/views/robot/create/view.go
@@ -15,8 +15,6 @@ package create
 
 import (
 	"errors"
-	"log/slog"
-	"os"
 	"strconv"
 	"unicode"
 
@@ -47,7 +45,7 @@ type Access struct {
 	Resource string `json:"resource,omitempty"`
 }
 
-func CreateRobotView(createView *CreateView) {
+func CreateRobotView(createView *CreateView) error {
 	duration := strconv.FormatInt(createView.Duration, 10)
 	if createView.Duration == 0 {
 		duration = "-1"
@@ -89,12 +87,12 @@ func CreateRobotView(createView *CreateView) {
 		),
 	).WithTheme(theme).Run()
 	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return err
 	}
+	return nil
 }
 
-func CreateRobotSecretView(name string, secret string) {
+func CreateRobotSecretView(name string, secret string) error {
 	theme := huh.ThemeCharm()
 	err := huh.NewForm(
 		huh.NewGroup(
@@ -108,9 +106,9 @@ func CreateRobotSecretView(name string, secret string) {
 		),
 	).WithTheme(theme).Run()
 	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return err
 	}
+	return nil
 }
 
 func isValidName(s string) bool {

--- a/pkg/views/robot/update/view.go
+++ b/pkg/views/robot/update/view.go
@@ -15,12 +15,13 @@ package update
 
 import (
 	"errors"
+	"log/slog"
+	"os"
 	"strconv"
 
 	"github.com/charmbracelet/huh"
 	"github.com/go-openapi/strfmt"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
-	log "github.com/sirupsen/logrus"
 )
 
 type UpdateView struct {
@@ -81,6 +82,7 @@ func UpdateRobotView(updateView *UpdateView) {
 		),
 	).WithTheme(theme).Run()
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 }

--- a/pkg/views/robot/update/view.go
+++ b/pkg/views/robot/update/view.go
@@ -15,8 +15,6 @@ package update
 
 import (
 	"errors"
-	"log/slog"
-	"os"
 	"strconv"
 
 	"github.com/charmbracelet/huh"
@@ -51,7 +49,7 @@ type Access struct {
 	Resource string `json:"resource,omitempty"`
 }
 
-func UpdateRobotView(updateView *UpdateView) {
+func UpdateRobotView(updateView *UpdateView) error {
 	duration := strconv.FormatInt(updateView.Duration, 10)
 
 	theme := huh.ThemeCharm()
@@ -82,7 +80,7 @@ func UpdateRobotView(updateView *UpdateView) {
 		),
 	).WithTheme(theme).Run()
 	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return err
 	}
+	return nil
 }

--- a/pkg/views/scan-all/update/view.go
+++ b/pkg/views/scan-all/update/view.go
@@ -16,15 +16,13 @@ package update
 import (
 	"errors"
 	"fmt"
-	"log/slog"
-	"os"
 	"regexp"
 	"strings"
 
 	"github.com/charmbracelet/huh"
 )
 
-func UpdateSchedule(cron *string) {
+func UpdateSchedule(cron *string) error {
 	theme := huh.ThemeCharm()
 	err := huh.NewForm(
 		huh.NewGroup(
@@ -38,9 +36,9 @@ func UpdateSchedule(cron *string) {
 	).WithTheme(theme).Run()
 
 	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return err
 	}
+	return nil
 }
 
 func validateCronExpression(cron string) error {

--- a/pkg/views/scan-all/update/view.go
+++ b/pkg/views/scan-all/update/view.go
@@ -16,11 +16,12 @@ package update
 import (
 	"errors"
 	"fmt"
+	"log/slog"
+	"os"
 	"regexp"
 	"strings"
 
 	"github.com/charmbracelet/huh"
-	log "github.com/sirupsen/logrus"
 )
 
 func UpdateSchedule(cron *string) {
@@ -37,7 +38,8 @@ func UpdateSchedule(cron *string) {
 	).WithTheme(theme).Run()
 
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 }
 

--- a/pkg/views/scanner/create/view.go
+++ b/pkg/views/scanner/create/view.go
@@ -15,11 +15,12 @@ package create
 
 import (
 	"errors"
+	"log/slog"
+	"os"
 	"strings"
 
 	"github.com/charmbracelet/huh"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 )
 
 type CreateView struct {
@@ -57,7 +58,8 @@ func CreateScannerView(createView *CreateView) {
 	).WithTheme(theme).Run()
 
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 
 	if createView.Auth == "Basic" {
@@ -86,7 +88,8 @@ func CreateScannerView(createView *CreateView) {
 			),
 		).WithTheme(theme).Run()
 		if err != nil {
-			log.Fatal(err)
+			slog.Error(err.Error())
+			os.Exit(1)
 		}
 		createView.AccessCredential = username + ":" + password
 	} else if createView.Auth == "Bearer" || createView.Auth == "X-ScannerAdapter-API-Key" {
@@ -99,7 +102,8 @@ func CreateScannerView(createView *CreateView) {
 			),
 		).WithTheme(theme).Run()
 		if err != nil {
-			log.Fatal(err)
+			slog.Error(err.Error())
+			os.Exit(1)
 		}
 		if createView.Auth == "Bearer" {
 			createView.AccessCredential = "Bearer: " + createView.AccessCredential
@@ -148,7 +152,8 @@ func CreateScannerView(createView *CreateView) {
 		),
 	).WithTheme(theme).Run()
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 	createView.URL = utils.FormatUrl(createView.URL)
 }

--- a/pkg/views/scanner/create/view.go
+++ b/pkg/views/scanner/create/view.go
@@ -15,8 +15,6 @@ package create
 
 import (
 	"errors"
-	"log/slog"
-	"os"
 	"strings"
 
 	"github.com/charmbracelet/huh"
@@ -34,7 +32,7 @@ type CreateView struct {
 	UseInternalAddr  bool
 }
 
-func CreateScannerView(createView *CreateView) {
+func CreateScannerView(createView *CreateView) error {
 	theme := huh.ThemeCharm()
 	err := huh.NewForm(
 		huh.NewGroup(
@@ -58,8 +56,7 @@ func CreateScannerView(createView *CreateView) {
 	).WithTheme(theme).Run()
 
 	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return err
 	}
 
 	if createView.Auth == "Basic" {
@@ -88,8 +85,7 @@ func CreateScannerView(createView *CreateView) {
 			),
 		).WithTheme(theme).Run()
 		if err != nil {
-			slog.Error(err.Error())
-			os.Exit(1)
+			return err
 		}
 		createView.AccessCredential = username + ":" + password
 	} else if createView.Auth == "Bearer" || createView.Auth == "X-ScannerAdapter-API-Key" {
@@ -102,8 +98,7 @@ func CreateScannerView(createView *CreateView) {
 			),
 		).WithTheme(theme).Run()
 		if err != nil {
-			slog.Error(err.Error())
-			os.Exit(1)
+			return err
 		}
 		if createView.Auth == "Bearer" {
 			createView.AccessCredential = "Bearer: " + createView.AccessCredential
@@ -152,8 +147,8 @@ func CreateScannerView(createView *CreateView) {
 		),
 	).WithTheme(theme).Run()
 	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return err
 	}
 	createView.URL = utils.FormatUrl(createView.URL)
+	return nil
 }

--- a/pkg/views/scanner/update/view.go
+++ b/pkg/views/scanner/update/view.go
@@ -15,8 +15,6 @@ package update
 
 import (
 	"errors"
-	"log/slog"
-	"os"
 	"strings"
 
 	"github.com/charmbracelet/huh"
@@ -25,7 +23,7 @@ import (
 	"github.com/goharbor/harbor-cli/pkg/utils"
 )
 
-func UpdateScannerView(scanner *models.ScannerRegistration) {
+func UpdateScannerView(scanner *models.ScannerRegistration) error {
 	theme := huh.ThemeCharm()
 	err := huh.NewForm(
 		huh.NewGroup(
@@ -49,8 +47,7 @@ func UpdateScannerView(scanner *models.ScannerRegistration) {
 	).WithTheme(theme).Run()
 
 	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return err
 	}
 
 	switch scanner.Auth {
@@ -80,8 +77,7 @@ func UpdateScannerView(scanner *models.ScannerRegistration) {
 			),
 		).WithTheme(theme).Run()
 		if err != nil {
-			slog.Error(err.Error())
-			os.Exit(1)
+			return err
 		}
 		scanner.AccessCredential = username + ":" + password
 	case "Bearer", "X-ScannerAdapter-API-Key":
@@ -94,8 +90,7 @@ func UpdateScannerView(scanner *models.ScannerRegistration) {
 			),
 		).WithTheme(theme).Run()
 		if err != nil {
-			slog.Error(err.Error())
-			os.Exit(1)
+			return err
 		}
 		if scanner.Auth == "Bearer" {
 			scanner.AccessCredential = "Bearer: " + scanner.AccessCredential
@@ -144,8 +139,8 @@ func UpdateScannerView(scanner *models.ScannerRegistration) {
 		),
 	).WithTheme(theme).Run()
 	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return err
 	}
 	scanner.URL = strfmt.URI(utils.FormatUrl(url))
+	return nil
 }

--- a/pkg/views/scanner/update/view.go
+++ b/pkg/views/scanner/update/view.go
@@ -15,13 +15,14 @@ package update
 
 import (
 	"errors"
+	"log/slog"
+	"os"
 	"strings"
 
 	"github.com/charmbracelet/huh"
 	"github.com/go-openapi/strfmt"
 	"github.com/goharbor/go-client/pkg/sdk/v2.0/models"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 )
 
 func UpdateScannerView(scanner *models.ScannerRegistration) {
@@ -48,7 +49,8 @@ func UpdateScannerView(scanner *models.ScannerRegistration) {
 	).WithTheme(theme).Run()
 
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 
 	switch scanner.Auth {
@@ -78,7 +80,8 @@ func UpdateScannerView(scanner *models.ScannerRegistration) {
 			),
 		).WithTheme(theme).Run()
 		if err != nil {
-			log.Fatal(err)
+			slog.Error(err.Error())
+			os.Exit(1)
 		}
 		scanner.AccessCredential = username + ":" + password
 	case "Bearer", "X-ScannerAdapter-API-Key":
@@ -91,7 +94,8 @@ func UpdateScannerView(scanner *models.ScannerRegistration) {
 			),
 		).WithTheme(theme).Run()
 		if err != nil {
-			log.Fatal(err)
+			slog.Error(err.Error())
+			os.Exit(1)
 		}
 		if scanner.Auth == "Bearer" {
 			scanner.AccessCredential = "Bearer: " + scanner.AccessCredential
@@ -140,7 +144,8 @@ func UpdateScannerView(scanner *models.ScannerRegistration) {
 		),
 	).WithTheme(theme).Run()
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 	scanner.URL = strfmt.URI(utils.FormatUrl(url))
 }

--- a/pkg/views/user/create/view.go
+++ b/pkg/views/user/create/view.go
@@ -15,8 +15,6 @@ package create
 
 import (
 	"errors"
-	"log/slog"
-	"os"
 	"strings"
 
 	"github.com/charmbracelet/huh"
@@ -32,7 +30,7 @@ type CreateView struct {
 	ConfirmPassword string
 }
 
-func CreateUserView(createView *CreateView) {
+func CreateUserView(createView *CreateView) error {
 	theme := huh.ThemeCharm()
 	err := huh.NewForm(
 		huh.NewGroup(
@@ -106,7 +104,8 @@ func CreateUserView(createView *CreateView) {
 	).WithTheme(theme).Run()
 
 	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return err
 	}
+
+	return nil
 }

--- a/pkg/views/user/create/view.go
+++ b/pkg/views/user/create/view.go
@@ -15,11 +15,12 @@ package create
 
 import (
 	"errors"
+	"log/slog"
+	"os"
 	"strings"
 
 	"github.com/charmbracelet/huh"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 )
 
 type CreateView struct {
@@ -105,6 +106,7 @@ func CreateUserView(createView *CreateView) {
 	).WithTheme(theme).Run()
 
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 }

--- a/pkg/views/webhook/edit/view.go
+++ b/pkg/views/webhook/edit/view.go
@@ -15,11 +15,12 @@ package edit
 
 import (
 	"errors"
+	"log/slog"
+	"os"
 	"strings"
 
 	"github.com/charmbracelet/huh"
 	"github.com/goharbor/harbor-cli/pkg/utils"
-	log "github.com/sirupsen/logrus"
 )
 
 type EditView struct {
@@ -79,7 +80,8 @@ func WebhookEditView(editView *EditView) {
 	).WithTheme(theme).Run()
 
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 
 	if editView.NotifyType == "http" {
@@ -96,7 +98,8 @@ func WebhookEditView(editView *EditView) {
 		).WithTheme(theme).Run()
 
 		if err != nil {
-			log.Fatal(err)
+			slog.Error(err.Error())
+			os.Exit(1)
 		}
 	}
 
@@ -170,6 +173,7 @@ func WebhookEditView(editView *EditView) {
 	}
 
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 }

--- a/pkg/views/webhook/edit/view.go
+++ b/pkg/views/webhook/edit/view.go
@@ -15,8 +15,6 @@ package edit
 
 import (
 	"errors"
-	"log/slog"
-	"os"
 	"strings"
 
 	"github.com/charmbracelet/huh"
@@ -46,7 +44,7 @@ func isSelected(selected []string, option string) bool {
 	return false
 }
 
-func WebhookEditView(editView *EditView) {
+func WebhookEditView(editView *EditView) error {
 	theme := huh.ThemeCharm()
 	var verifyCert string
 	var enable string
@@ -80,8 +78,7 @@ func WebhookEditView(editView *EditView) {
 	).WithTheme(theme).Run()
 
 	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return err
 	}
 
 	if editView.NotifyType == "http" {
@@ -98,8 +95,7 @@ func WebhookEditView(editView *EditView) {
 		).WithTheme(theme).Run()
 
 		if err != nil {
-			slog.Error(err.Error())
-			os.Exit(1)
+			return err
 		}
 	}
 
@@ -173,7 +169,7 @@ func WebhookEditView(editView *EditView) {
 	}
 
 	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
+		return err
 	}
+	return nil
 }

--- a/test/helper/helpers.go
+++ b/test/helper/helpers.go
@@ -66,9 +66,10 @@ func Initialize(t *testing.T, tempDir string) *utils.HarborData {
 
 	// this will create both the data.yaml and the empty config.yaml underneath
 	// and return you a *utils.HarborData with the path to config.yaml
-	utils.InitConfig(filepath.Join(cfgDir, "config.yaml"), true)
+	err := utils.InitConfig(filepath.Join(cfgDir, "config.yaml"), true)
+	assert.NoError(t, err, "Expected no error for config initialization")
 	cds := root.RootCmd()
-	err := cds.Execute()
+	err = cds.Execute()
 	assert.NoError(t, err, "Expected no error for Root command")
 	assert.NoError(t, err, "Expected no error for Root command execution")
 


### PR DESCRIPTION
## Description
### What this PR does
Migrates all logging from github.com/sirupsen/logrus to the standard library's log/slog and removes the logrus dependency entirely (~290 call sites across 90+ files).

### Why

The slog infrastructure already existed (pkg/logger with a custom pretty handler and JSON support, wired up in the root command), but only a single call site actually used it — everything else still logged through logrus. This completes the migration so the CLI has one logging system, drops a third-party dependency in favor of the stdlib, and enables structured logging output.

- Fixes #881
- Fixes #882 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation update
- [ ] Chore / maintenance

## Changes
- All log.Fatal/Fatalf sites become slog.Error + os.Exit(1), preserving exit behavior.
- Formatted calls with a trailing error verb ("...: %v", err) are converted to structured form (slog.Error("...", "error", err)); the rest keep their message text via fmt.Sprintf.
- WithField/WithFields/WithError chains are flattened to slog key-value attributes.
- harbor logs uses a dedicated slog TextHandler; the audit entry timestamp is now a time attribute because slog records can't override the record timestamp.
- Logger setup now runs before config initialization so early logs go through the configured handler.
- Fixes a latent PrettyHandler bug where WithAttrs/WithGroup dropped the writer and level.
- Log-capture tests (elevate_test.go, doc_test.go) adapted to slog.
- go mod tidy: logrus removed from go.mod/go.sum.

